### PR TITLE
Fix: Enforce 2FA for Google OAuth login

### DIFF
--- a/app/Http/Controllers/Auth/GoogleAuthController.php
+++ b/app/Http/Controllers/Auth/GoogleAuthController.php
@@ -50,7 +50,15 @@ class GoogleAuthController extends Controller
                 ]);
             }
 
-            // Log the user in
+            // Check if user has two-factor authentication enabled
+            if ($user->two_factor_secret && $user->two_factor_confirmed_at) {
+                // Store user ID in session for two-factor challenge
+                session(['login.id' => $user->id]);
+
+                return redirect()->route('two-factor.login');
+            }
+
+            // Log the user in directly if no 2FA
             Auth::login($user);
 
             return redirect()->intended('/dashboard');

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:2fl3unkN7fDQnNXz4PqRUhGDh+M5PGE7sk9oG8AfiWg="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/tests/Feature/Auth/GoogleAuthTest.php
+++ b/tests/Feature/Auth/GoogleAuthTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Fortify\Features;
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\User as SocialiteUser;
+
+beforeEach(function () {
+    // Mock the Socialite Google driver
+    $this->mockSocialiteUser = (new SocialiteUser)
+        ->map([
+            'id' => '1234567890',
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'avatar' => 'https://example.com/avatar.jpg',
+        ])
+        ->setToken('mock-token');
+});
+
+test('google oauth login works for users without two factor authentication', function () {
+    Socialite::shouldReceive('driver->user')
+        ->once()
+        ->andReturn($this->mockSocialiteUser);
+
+    $response = $this->get(route('google.callback'));
+
+    $this->assertAuthenticated();
+    $response->assertRedirect('/dashboard');
+
+    // Verify user was created
+    $user = User::where('email', 'john@example.com')->first();
+    expect($user)->not->toBeNull()
+        ->and($user->google_id)->toBe('1234567890')
+        ->and($user->name)->toBe('John Doe');
+});
+
+test('google oauth login redirects to two factor challenge when user has 2fa enabled', function () {
+    if (! Features::canManageTwoFactorAuthentication()) {
+        $this->markTestSkipped('Two-factor authentication is not enabled.');
+    }
+
+    Features::twoFactorAuthentication([
+        'confirm' => true,
+        'confirmPassword' => true,
+    ]);
+
+    // Create a user with 2FA enabled
+    $user = User::factory()->create([
+        'email' => 'john@example.com',
+        'google_id' => '1234567890',
+    ]);
+
+    $user->forceFill([
+        'two_factor_secret' => encrypt('test-secret'),
+        'two_factor_recovery_codes' => encrypt(json_encode(['code1', 'code2'])),
+        'two_factor_confirmed_at' => now(),
+    ])->save();
+
+    Socialite::shouldReceive('driver->user')
+        ->once()
+        ->andReturn($this->mockSocialiteUser);
+
+    $response = $this->get(route('google.callback'));
+
+    // Should NOT be authenticated yet
+    $this->assertGuest();
+
+    // Should be redirected to two-factor challenge
+    $response->assertRedirect(route('two-factor.login'));
+
+    // Session should have the login.id
+    $response->assertSessionHas('login.id', $user->id);
+});
+
+test('google oauth login updates existing user with google credentials', function () {
+    // Create existing user without Google ID
+    $user = User::factory()->withoutTwoFactor()->create([
+        'email' => 'john@example.com',
+        'google_id' => null,
+    ]);
+
+    Socialite::shouldReceive('driver->user')
+        ->once()
+        ->andReturn($this->mockSocialiteUser);
+
+    $response = $this->get(route('google.callback'));
+
+    $this->assertAuthenticated();
+    $response->assertRedirect('/dashboard');
+
+    // Verify user was updated with Google credentials
+    $user->refresh();
+    expect($user->google_id)->toBe('1234567890')
+        ->and($user->google_avatar_url)->toBe('https://example.com/avatar.jpg');
+});
+
+test('google oauth login finds user by google_id', function () {
+    // Create user with Google ID
+    $user = User::factory()->withoutTwoFactor()->create([
+        'email' => 'different@example.com',
+        'google_id' => '1234567890',
+    ]);
+
+    Socialite::shouldReceive('driver->user')
+        ->once()
+        ->andReturn($this->mockSocialiteUser);
+
+    $response = $this->get(route('google.callback'));
+
+    $this->assertAuthenticated();
+
+    // Should authenticate as the existing user (matched by google_id)
+    expect(Auth::user()->id)->toBe($user->id)
+        ->and(Auth::user()->email)->toBe('different@example.com');
+});


### PR DESCRIPTION
## Summary
- Fix security inconsistency where Google OAuth login bypassed 2FA challenge
- Ensure consistent authentication behavior between OAuth and email/password login

## Problem
Users with 2FA enabled could bypass the two-factor authentication challenge when logging in via Google OAuth, while email/password login correctly enforced 2FA. This created a security gap.

## Changes
- **GoogleAuthController**: Added check for 2FA before login
  - If user has `two_factor_secret` and `two_factor_confirmed_at`, redirect to two-factor challenge
  - Store `login.id` in session for 2FA flow consistency
  - Only log in directly if user has no 2FA enabled
- **Tests**: Added comprehensive test suite (`GoogleAuthTest.php`) covering:
  - OAuth login without 2FA (direct login)
  - OAuth login with 2FA enabled (redirect to challenge)
  - Updating existing user with Google credentials
  - Finding user by google_id
- **phpunit.xml**: Added APP_KEY for test encryption support

## Test Results
All OAuth authentication tests passing (4/4):
- ✓ OAuth login works for users without 2FA
- ✓ OAuth login redirects to 2FA challenge when enabled
- ✓ Updates existing user with Google credentials
- ✓ Finds user by google_id

## Security Impact
This fix ensures that 2FA protection is consistently applied across all authentication methods, closing a potential security bypass.