### PR TITLE
feat: Improve match page UI with consolidated availability panel

### DIFF
--- a/resources/js/components/availability-panel.tsx
+++ b/resources/js/components/availability-panel.tsx
@@ -1,0 +1,351 @@
+import {
+    AlertCircle,
+    Check,
+    ChevronDown,
+    HelpCircle,
+    Loader2,
+    Users,
+    X,
+} from 'lucide-react';
+import { useState } from 'react';
+
+import { TeamAvatar } from '@/components/team-avatar';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+    Collapsible,
+    CollapsibleContent,
+    CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { Progress } from '@/components/ui/progress';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { UserAvatar } from '@/components/user-avatar';
+import { UserNameLink } from '@/components/user-name-link';
+
+import type {
+    AvailabilityStats,
+    AvailabilityStatus,
+    MatchAvailability,
+} from '@/types';
+
+interface TeamData {
+    id: number;
+    name: string;
+    logo_url?: string;
+}
+
+interface TeamAvailabilityData {
+    team: TeamData;
+    stats: AvailabilityStats;
+    availability: MatchAvailability[];
+    isLeader: boolean;
+}
+
+interface AvailabilityPanelProps {
+    homeTeam: TeamAvailabilityData;
+    awayTeam?: TeamAvailabilityData;
+}
+
+const statusConfig = {
+    available: {
+        icon: Check,
+        label: 'Disponibles',
+        color: 'text-green-600 dark:text-green-400',
+        bgColor: 'bg-green-100 dark:bg-green-900',
+        borderColor: 'border-green-200 dark:border-green-900',
+        lightBg: 'bg-green-50 dark:bg-green-950',
+    },
+    maybe: {
+        icon: HelpCircle,
+        label: 'Tal vez',
+        color: 'text-yellow-600 dark:text-yellow-400',
+        bgColor: 'bg-yellow-100 dark:bg-yellow-900',
+        borderColor: 'border-yellow-200 dark:border-yellow-900',
+        lightBg: 'bg-yellow-50 dark:bg-yellow-950',
+    },
+    unavailable: {
+        icon: X,
+        label: 'No Disponibles',
+        color: 'text-red-600 dark:text-red-400',
+        bgColor: 'bg-red-100 dark:bg-red-900',
+        borderColor: 'border-red-200 dark:border-red-900',
+        lightBg: 'bg-red-50 dark:bg-red-950',
+    },
+    pending: {
+        icon: Loader2,
+        label: 'Pendientes',
+        color: 'text-gray-600 dark:text-gray-400',
+        bgColor: 'bg-gray-100 dark:bg-gray-900',
+        borderColor: 'border-gray-200 dark:border-gray-800',
+        lightBg: 'bg-gray-50 dark:bg-gray-900',
+    },
+};
+
+function CompactStats({
+    stats,
+    isLeader,
+}: {
+    stats: AvailabilityStats;
+    isLeader: boolean;
+}) {
+    const hasEnoughPlayers = stats.available >= stats.minimum;
+
+    return (
+        <div className="space-y-3">
+            {!hasEnoughPlayers && isLeader && (
+                <Alert variant="destructive" className="py-2">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertTitle className="text-sm">
+                        Jugadores Insuficientes
+                    </AlertTitle>
+                    <AlertDescription className="text-xs">
+                        Necesitas {stats.minimum - stats.available} jugador(es)
+                        más.
+                    </AlertDescription>
+                </Alert>
+            )}
+
+            <div className="space-y-1.5">
+                <div className="flex justify-between text-xs">
+                    <span className="text-muted-foreground">Confirmados</span>
+                    <span className="font-medium">
+                        {stats.available} / {stats.minimum} requeridos
+                    </span>
+                </div>
+                <Progress
+                    value={Math.min(
+                        (stats.available / stats.minimum) * 100,
+                        100,
+                    )}
+                    className="h-1.5"
+                />
+            </div>
+
+            <div className="grid grid-cols-4 gap-2">
+                {(
+                    ['available', 'maybe', 'unavailable', 'pending'] as const
+                ).map((status) => {
+                    const config = statusConfig[status];
+                    const Icon = config.icon;
+                    const count = stats[status];
+                    return (
+                        <div
+                            key={status}
+                            className={`rounded-md border ${config.borderColor} ${config.lightBg} p-2 text-center`}
+                        >
+                            <div
+                                className={`flex items-center justify-center gap-1 ${config.color}`}
+                            >
+                                <Icon className="h-3 w-3" />
+                            </div>
+                            <p className="mt-0.5 text-lg font-bold">{count}</p>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+function PlayerStatusGroup({
+    availability,
+    status,
+    defaultOpen = false,
+}: {
+    availability: MatchAvailability[];
+    status: AvailabilityStatus;
+    defaultOpen?: boolean;
+}) {
+    const [isOpen, setIsOpen] = useState(defaultOpen);
+    const config = statusConfig[status];
+    const Icon = config.icon;
+
+    const filteredPlayers = availability.filter(
+        (item) => item.status === status,
+    );
+
+    if (filteredPlayers.length === 0) return null;
+
+    return (
+        <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+            <CollapsibleTrigger className="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm hover:bg-muted/50">
+                <div className="flex items-center gap-2">
+                    <Icon className={`h-4 w-4 ${config.color}`} />
+                    <span className="font-medium">{config.label}</span>
+                    <Badge variant="secondary" className="h-5 px-1.5 text-xs">
+                        {filteredPlayers.length}
+                    </Badge>
+                </div>
+                <ChevronDown
+                    className={`h-4 w-4 text-muted-foreground transition-transform ${isOpen ? 'rotate-180' : ''}`}
+                />
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+                <div className="mt-1 space-y-1 pl-6">
+                    {filteredPlayers.map((item) => (
+                        <div
+                            key={item.id}
+                            className={`flex items-center gap-2 rounded-md ${config.bgColor} px-2 py-1.5`}
+                        >
+                            {item.user && (
+                                <>
+                                    <UserAvatar
+                                        name={item.user.name}
+                                        avatarUrl={item.user.avatar_url}
+                                        size="sm"
+                                        className="h-5 w-5"
+                                    />
+                                    <span className="text-sm">
+                                        <UserNameLink user={item.user} />
+                                    </span>
+                                </>
+                            )}
+                            {!item.user && (
+                                <span className="text-sm text-muted-foreground">
+                                    Jugador Desconocido
+                                </span>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            </CollapsibleContent>
+        </Collapsible>
+    );
+}
+
+function TeamContent({
+    stats,
+    availability,
+    isLeader,
+}: Omit<TeamAvailabilityData, 'team'>) {
+    return (
+        <div className="space-y-4">
+            <CompactStats stats={stats} isLeader={isLeader} />
+
+            {isLeader && availability.length > 0 && (
+                <div className="space-y-1 border-t pt-3">
+                    <PlayerStatusGroup
+                        availability={availability}
+                        status="available"
+                        defaultOpen={true}
+                    />
+                    <PlayerStatusGroup
+                        availability={availability}
+                        status="maybe"
+                    />
+                    <PlayerStatusGroup
+                        availability={availability}
+                        status="unavailable"
+                    />
+                    <PlayerStatusGroup
+                        availability={availability}
+                        status="pending"
+                    />
+                </div>
+            )}
+
+            <p className="text-center text-xs text-muted-foreground">
+                {stats.total} miembros del equipo
+            </p>
+        </div>
+    );
+}
+
+export function AvailabilityPanel({
+    homeTeam,
+    awayTeam,
+}: AvailabilityPanelProps) {
+    // If no away team, render without tabs
+    if (!awayTeam) {
+        return (
+            <Card>
+                <CardHeader className="pb-3">
+                    <CardTitle className="flex items-center gap-2 text-base">
+                        <Users className="h-4 w-4" />
+                        Disponibilidad - {homeTeam.team.name}
+                    </CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <TeamContent {...homeTeam} />
+                </CardContent>
+            </Card>
+        );
+    }
+
+    // With away team, use tabs
+    return (
+        <Card>
+            <CardHeader className="pb-3">
+                <CardTitle className="flex items-center gap-2 text-base">
+                    <Users className="h-4 w-4" />
+                    Disponibilidad
+                </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+                <Tabs defaultValue="home">
+                    <TabsList className="grid w-full grid-cols-2">
+                        <TabsTrigger
+                            value="home"
+                            className="flex items-center gap-2"
+                        >
+                            <TeamAvatar
+                                name={homeTeam.team.name}
+                                logoUrl={homeTeam.team.logo_url}
+                                size="sm"
+                                className="h-5 w-5 text-[10px]"
+                            />
+                            <span className="hidden truncate sm:inline">
+                                {homeTeam.team.name}
+                            </span>
+                            <Badge
+                                variant={
+                                    homeTeam.stats.available >=
+                                    homeTeam.stats.minimum
+                                        ? 'default'
+                                        : 'destructive'
+                                }
+                                className="ml-auto h-5 px-1.5 text-xs"
+                            >
+                                {homeTeam.stats.available}/
+                                {homeTeam.stats.minimum}
+                            </Badge>
+                        </TabsTrigger>
+                        <TabsTrigger
+                            value="away"
+                            className="flex items-center gap-2"
+                        >
+                            <TeamAvatar
+                                name={awayTeam.team.name}
+                                logoUrl={awayTeam.team.logo_url}
+                                size="sm"
+                                className="h-5 w-5 text-[10px]"
+                            />
+                            <span className="hidden truncate sm:inline">
+                                {awayTeam.team.name}
+                            </span>
+                            <Badge
+                                variant={
+                                    awayTeam.stats.available >=
+                                    awayTeam.stats.minimum
+                                        ? 'default'
+                                        : 'destructive'
+                                }
+                                className="ml-auto h-5 px-1.5 text-xs"
+                            >
+                                {awayTeam.stats.available}/
+                                {awayTeam.stats.minimum}
+                            </Badge>
+                        </TabsTrigger>
+                    </TabsList>
+                    <TabsContent value="home" className="mt-3">
+                        <TeamContent {...homeTeam} />
+                    </TabsContent>
+                    <TabsContent value="away" className="mt-3">
+                        <TeamContent {...awayTeam} />
+                    </TabsContent>
+                </Tabs>
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/availability-selector.tsx
+++ b/resources/js/components/availability-selector.tsx
@@ -1,17 +1,10 @@
 import { router } from '@inertiajs/react';
-import { Check, HelpCircle, X } from 'lucide-react';
+import { Check, HelpCircle, Loader2, X } from 'lucide-react';
 import { useState } from 'react';
+import { toast } from 'sonner';
 
-import { Button } from '@/components/ui/button';
-import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-} from '@/components/ui/card';
-import { Label } from '@/components/ui/label';
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 
 import type { AvailabilityStatus, MatchAvailability } from '@/types';
 
@@ -20,6 +13,25 @@ interface AvailabilitySelectorProps {
     teamId: number;
     currentStatus?: MatchAvailability;
     onUpdate?: () => void;
+}
+
+function formatRelativeTime(dateString: string): string {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMins / 60);
+    const diffDays = Math.floor(diffHours / 24);
+
+    if (diffMins < 1) return 'hace un momento';
+    if (diffMins < 60) return `hace ${diffMins}m`;
+    if (diffHours < 24) return `hace ${diffHours}h`;
+    if (diffDays < 7) return `hace ${diffDays}d`;
+
+    return date.toLocaleDateString('es-ES', {
+        day: 'numeric',
+        month: 'short',
+    });
 }
 
 export function AvailabilitySelector({
@@ -33,19 +45,28 @@ export function AvailabilitySelector({
     );
     const [isSubmitting, setIsSubmitting] = useState(false);
 
-    const handleSubmit = () => {
+    const handleStatusChange = (newStatus: string) => {
+        if (!newStatus || newStatus === status) return;
+
+        const previousStatus = status;
+        setStatus(newStatus as AvailabilityStatus);
         setIsSubmitting(true);
 
         router.post(
             `/matches/${matchId}/availability`,
             {
-                status,
+                status: newStatus,
                 team_id: teamId,
             },
             {
                 preserveScroll: true,
                 onSuccess: () => {
+                    toast.success('Disponibilidad actualizada');
                     onUpdate?.();
+                },
+                onError: () => {
+                    setStatus(previousStatus);
+                    toast.error('Error al actualizar disponibilidad');
                 },
                 onFinish: () => {
                     setIsSubmitting(false);
@@ -54,88 +75,63 @@ export function AvailabilitySelector({
         );
     };
 
-    const hasChanged = status !== (currentStatus?.status ?? 'pending');
-
     return (
         <Card>
-            <CardHeader>
-                <CardTitle>Confirma tu Disponibilidad</CardTitle>
-                <CardDescription>
-                    Informa a tu equipo si podrás asistir al partido
-                </CardDescription>
+            <CardHeader className="pb-2">
+                <CardTitle className="text-base">Tu Disponibilidad</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-4">
-                <RadioGroup
-                    value={status}
-                    onValueChange={(value) =>
-                        setStatus(value as AvailabilityStatus)
-                    }
-                >
-                    <div className="flex items-center space-x-3 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-900 dark:bg-green-950">
-                        <RadioGroupItem value="available" id="available" />
-                        <Label
-                            htmlFor="available"
-                            className="flex flex-1 cursor-pointer items-center gap-2"
-                        >
-                            <Check className="h-5 w-5 text-green-600 dark:text-green-400" />
-                            <div>
-                                <div className="font-medium">Disponible</div>
-                                <div className="text-sm text-muted-foreground">
-                                    Estaré presente
-                                </div>
-                            </div>
-                        </Label>
-                    </div>
-
-                    <div className="flex items-center space-x-3 rounded-lg border border-yellow-200 bg-yellow-50 p-4 dark:border-yellow-900 dark:bg-yellow-950">
-                        <RadioGroupItem value="maybe" id="maybe" />
-                        <Label
-                            htmlFor="maybe"
-                            className="flex flex-1 cursor-pointer items-center gap-2"
-                        >
-                            <HelpCircle className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
-                            <div>
-                                <div className="font-medium">Tal vez</div>
-                                <div className="text-sm text-muted-foreground">
-                                    No estoy seguro aún
-                                </div>
-                            </div>
-                        </Label>
-                    </div>
-
-                    <div className="flex items-center space-x-3 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900 dark:bg-red-950">
-                        <RadioGroupItem value="unavailable" id="unavailable" />
-                        <Label
-                            htmlFor="unavailable"
-                            className="flex flex-1 cursor-pointer items-center gap-2"
-                        >
-                            <X className="h-5 w-5 text-red-600 dark:text-red-400" />
-                            <div>
-                                <div className="font-medium">No Disponible</div>
-                                <div className="text-sm text-muted-foreground">
-                                    No podré asistir
-                                </div>
-                            </div>
-                        </Label>
-                    </div>
-                </RadioGroup>
-
-                <Button
-                    onClick={handleSubmit}
-                    disabled={!hasChanged || isSubmitting}
+            <CardContent className="space-y-3">
+                <ToggleGroup
+                    type="single"
+                    value={status === 'pending' ? '' : status}
+                    onValueChange={handleStatusChange}
+                    disabled={isSubmitting}
                     className="w-full"
+                    variant="outline"
                 >
-                    {isSubmitting
-                        ? 'Actualizando...'
-                        : 'Actualizar Disponibilidad'}
-                </Button>
+                    <ToggleGroupItem
+                        value="available"
+                        className="flex-1 gap-1.5 data-[state=on]:border-green-500 data-[state=on]:bg-green-100 data-[state=on]:text-green-700 dark:data-[state=on]:border-green-600 dark:data-[state=on]:bg-green-950 dark:data-[state=on]:text-green-400"
+                        aria-label="Disponible"
+                    >
+                        <Check className="h-4 w-4" />
+                        <span className="hidden sm:inline">Voy</span>
+                    </ToggleGroupItem>
+                    <ToggleGroupItem
+                        value="maybe"
+                        className="flex-1 gap-1.5 data-[state=on]:border-yellow-500 data-[state=on]:bg-yellow-100 data-[state=on]:text-yellow-700 dark:data-[state=on]:border-yellow-600 dark:data-[state=on]:bg-yellow-950 dark:data-[state=on]:text-yellow-400"
+                        aria-label="Tal vez"
+                    >
+                        <HelpCircle className="h-4 w-4" />
+                        <span className="hidden sm:inline">Quizás</span>
+                    </ToggleGroupItem>
+                    <ToggleGroupItem
+                        value="unavailable"
+                        className="flex-1 gap-1.5 data-[state=on]:border-red-500 data-[state=on]:bg-red-100 data-[state=on]:text-red-700 dark:data-[state=on]:border-red-600 dark:data-[state=on]:bg-red-950 dark:data-[state=on]:text-red-400"
+                        aria-label="No disponible"
+                    >
+                        <X className="h-4 w-4" />
+                        <span className="hidden sm:inline">No voy</span>
+                    </ToggleGroupItem>
+                </ToggleGroup>
 
-                {currentStatus?.confirmed_at && (
-                    <p className="text-center text-sm text-muted-foreground">
-                        Última actualización:{' '}
-                        {new Date(
-                            currentStatus.confirmed_at,
-                        ).toLocaleDateString('es-ES')}
+                {isSubmitting && (
+                    <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                        <span>Actualizando...</span>
+                    </div>
+                )}
+
+                {!isSubmitting && currentStatus?.confirmed_at && (
+                    <p className="text-center text-xs text-muted-foreground">
+                        Actualizado{' '}
+                        {formatRelativeTime(currentStatus.confirmed_at)}
+                    </p>
+                )}
+
+                {!isSubmitting && status === 'pending' && (
+                    <p className="text-center text-xs text-muted-foreground">
+                        Selecciona tu disponibilidad
                     </p>
                 )}
             </CardContent>

--- a/resources/js/components/edit-team-modal.tsx
+++ b/resources/js/components/edit-team-modal.tsx
@@ -1,341 +1,365 @@
-import { router } from "@inertiajs/react";
-import { Edit, Upload, X } from "lucide-react";
-import type { FormEventHandler, ReactNode } from "react";
-import { useEffect, useRef, useState } from "react";
-import { toast } from "sonner";
-import { TeamAvatar } from "@/components/team-avatar";
-import { Button } from "@/components/ui/button";
+import { TeamAvatar } from '@/components/team-avatar';
+import { Button } from '@/components/ui/button';
 import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogHeader,
-	DialogTitle,
-	DialogTrigger,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
-import teams from "@/routes/teams";
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import teams from '@/routes/teams';
+import { router } from '@inertiajs/react';
+import { Edit, Upload, X } from 'lucide-react';
+import type { FormEventHandler, ReactNode } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
 
 interface TeamData {
-	id: number;
-	name: string;
-	variant: string;
-	description?: string;
-	logo_url?: string;
-	logo_path?: string;
+    id: number;
+    name: string;
+    variant: string;
+    description?: string;
+    logo_url?: string;
+    logo_path?: string;
 }
 
 interface Props {
-	team: TeamData;
-	trigger?: ReactNode;
+    team: TeamData;
+    trigger?: ReactNode;
 }
 
 export function EditTeamModal({ team, trigger }: Props) {
-	const [open, setOpen] = useState(false);
-	const [processing, setProcessing] = useState(false);
-	const [errors, setErrors] = useState<Record<string, string>>({});
-	const [formData, setFormData] = useState({
-		name: team.name || "",
-		variant: team.variant || "football_11",
-		description: team.description || "",
-	});
-	const [selectedLogo, setSelectedLogo] = useState<File | null>(null);
-	const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-	const [removeLogo, setRemoveLogo] = useState(false);
-	const fileInputRef = useRef<HTMLInputElement>(null);
+    const [open, setOpen] = useState(false);
+    const [processing, setProcessing] = useState(false);
+    const [errors, setErrors] = useState<Record<string, string>>({});
+    const [formData, setFormData] = useState({
+        name: team.name || '',
+        variant: team.variant || 'football_11',
+        description: team.description || '',
+    });
+    const [selectedLogo, setSelectedLogo] = useState<File | null>(null);
+    const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+    const [removeLogo, setRemoveLogo] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
 
-	// Cleanup preview URL when component unmounts or preview changes
-	useEffect(() => {
-		return () => {
-			if (previewUrl) {
-				URL.revokeObjectURL(previewUrl);
-			}
-		};
-	}, [previewUrl]);
+    // Cleanup preview URL when component unmounts or preview changes
+    useEffect(() => {
+        return () => {
+            if (previewUrl) {
+                URL.revokeObjectURL(previewUrl);
+            }
+        };
+    }, [previewUrl]);
 
-	const handleLogoSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const file = e.target.files?.[0];
-		if (!file) return;
+    const handleLogoSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
 
-		// Validate file type
-		if (
-			!["image/jpeg", "image/jpg", "image/png", "image/webp"].includes(
-				file.type,
-			)
-		) {
-			toast.error("Por favor selecciona una imagen válida (JPG, PNG o WEBP)");
-			return;
-		}
+        // Validate file type
+        if (
+            !['image/jpeg', 'image/jpg', 'image/png', 'image/webp'].includes(
+                file.type,
+            )
+        ) {
+            toast.error(
+                'Por favor selecciona una imagen válida (JPG, PNG o WEBP)',
+            );
+            return;
+        }
 
-		// Validate file size (2MB)
-		if (file.size > 2048 * 1024) {
-			toast.error("La imagen no debe superar los 2MB");
-			return;
-		}
+        // Validate file size (2MB)
+        if (file.size > 2048 * 1024) {
+            toast.error('La imagen no debe superar los 2MB');
+            return;
+        }
 
-		// Revoke old preview URL
-		if (previewUrl) {
-			URL.revokeObjectURL(previewUrl);
-		}
+        // Revoke old preview URL
+        if (previewUrl) {
+            URL.revokeObjectURL(previewUrl);
+        }
 
-		setSelectedLogo(file);
-		setPreviewUrl(URL.createObjectURL(file));
-		setRemoveLogo(false);
-	};
+        setSelectedLogo(file);
+        setPreviewUrl(URL.createObjectURL(file));
+        setRemoveLogo(false);
+    };
 
-	const handleRemoveLogo = () => {
-		if (selectedLogo && previewUrl) {
-			URL.revokeObjectURL(previewUrl);
-			setPreviewUrl(null);
-			setSelectedLogo(null);
-		}
-		setRemoveLogo(true);
-		if (fileInputRef.current) {
-			fileInputRef.current.value = "";
-		}
-	};
+    const handleRemoveLogo = () => {
+        if (selectedLogo && previewUrl) {
+            URL.revokeObjectURL(previewUrl);
+            setPreviewUrl(null);
+            setSelectedLogo(null);
+        }
+        setRemoveLogo(true);
+        if (fileInputRef.current) {
+            fileInputRef.current.value = '';
+        }
+    };
 
-	const handleReset = () => {
-		setFormData({
-			name: team.name || "",
-			variant: team.variant || "football_11",
-			description: team.description || "",
-		});
-		setSelectedLogo(null);
-		setRemoveLogo(false);
-		if (previewUrl) {
-			URL.revokeObjectURL(previewUrl);
-			setPreviewUrl(null);
-		}
-		if (fileInputRef.current) {
-			fileInputRef.current.value = "";
-		}
-		setErrors({});
-	};
+    const handleReset = () => {
+        setFormData({
+            name: team.name || '',
+            variant: team.variant || 'football_11',
+            description: team.description || '',
+        });
+        setSelectedLogo(null);
+        setRemoveLogo(false);
+        if (previewUrl) {
+            URL.revokeObjectURL(previewUrl);
+            setPreviewUrl(null);
+        }
+        if (fileInputRef.current) {
+            fileInputRef.current.value = '';
+        }
+        setErrors({});
+    };
 
-	const submit: FormEventHandler = (e) => {
-		e.preventDefault();
-		setProcessing(true);
-		setErrors({});
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        setProcessing(true);
+        setErrors({});
 
-		const data = new FormData();
-		data.append("name", formData.name);
-		data.append("variant", formData.variant);
-		data.append("description", formData.description || "");
-		data.append("_method", "PUT");
+        const data = new FormData();
+        data.append('name', formData.name);
+        data.append('variant', formData.variant);
+        data.append('description', formData.description || '');
+        data.append('_method', 'PUT');
 
-		if (selectedLogo) {
-			data.append("logo", selectedLogo);
-		} else if (removeLogo) {
-			data.append("remove_logo", "1");
-		}
+        if (selectedLogo) {
+            data.append('logo', selectedLogo);
+        } else if (removeLogo) {
+            data.append('remove_logo', '1');
+        }
 
-		router.post(teams.update(team.id).url, data, {
-			onSuccess: () => {
-				setProcessing(false);
-				setOpen(false);
-				handleReset();
-				toast.success("¡Equipo actualizado exitosamente!");
-			},
-			onError: (errors) => {
-				setProcessing(false);
-				setErrors(errors as Record<string, string>);
-				const errorMessage =
-					(errors as Record<string, string>).logo ||
-					(errors as Record<string, string>).name ||
-					"Error al actualizar el equipo";
-				toast.error(errorMessage);
-			},
-		});
-	};
+        router.post(teams.update(team.id).url, data, {
+            onSuccess: () => {
+                setProcessing(false);
+                setOpen(false);
+                handleReset();
+                toast.success('¡Equipo actualizado exitosamente!');
+            },
+            onError: (errors) => {
+                setProcessing(false);
+                setErrors(errors as Record<string, string>);
+                const errorMessage =
+                    (errors as Record<string, string>).logo ||
+                    (errors as Record<string, string>).name ||
+                    'Error al actualizar el equipo';
+                toast.error(errorMessage);
+            },
+        });
+    };
 
-	const getCurrentLogoUrl = () => {
-		if (previewUrl) return previewUrl;
-		if (removeLogo) return undefined;
-		return team.logo_url;
-	};
+    const getCurrentLogoUrl = () => {
+        if (previewUrl) return previewUrl;
+        if (removeLogo) return undefined;
+        return team.logo_url;
+    };
 
-	return (
-		<Dialog
-			open={open}
-			onOpenChange={(newOpen) => {
-				setOpen(newOpen);
-				if (!newOpen) {
-					handleReset();
-				}
-			}}
-		>
-			<DialogTrigger asChild>
-				{trigger || (
-					<Button>
-						<Edit className="mr-2 h-4 w-4" />
-						Editar Equipo
-					</Button>
-				)}
-			</DialogTrigger>
-			<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[600px]">
-				<DialogHeader>
-					<DialogTitle>Editar Equipo</DialogTitle>
-					<DialogDescription>
-						Actualiza la información de tu equipo
-					</DialogDescription>
-				</DialogHeader>
-				<form onSubmit={submit} className="space-y-6">
-					{/* Logo Upload */}
-					<div className="space-y-3">
-						<Label className="text-base font-semibold">Logo del Equipo</Label>
-						<div className="flex flex-col items-center gap-4 rounded-lg border border-border bg-muted/20 p-6">
-							<TeamAvatar
-								name={formData.name}
-								logoUrl={getCurrentLogoUrl()}
-								size="2xl"
-							/>
-							<div className="flex w-full flex-col gap-2">
-								<div className="flex w-full gap-2">
-									<Button
-										type="button"
-										variant="outline"
-										size="default"
-										className="flex-1"
-										onClick={() => fileInputRef.current?.click()}
-									>
-										<Upload className="mr-2 h-4 w-4" />
-										{selectedLogo || team.logo_path
-											? "Cambiar Logo"
-											: "Subir Logo"}
-									</Button>
-									{(selectedLogo || (team.logo_path && !removeLogo)) && (
-										<Button
-											type="button"
-											variant="outline"
-											size="default"
-											onClick={handleRemoveLogo}
-										>
-											<X className="mr-2 h-4 w-4" />
-											Eliminar
-										</Button>
-									)}
-								</div>
-								<div className="text-center">
-									<p className="text-xs text-muted-foreground">
-										Formatos: JPG, PNG o WEBP · Tamaño máximo: 2MB
-									</p>
-									{selectedLogo && (
-										<p className="mt-2 text-sm font-medium text-green-600">
-											✓ Nueva imagen seleccionada
-										</p>
-									)}
-									{removeLogo && (
-										<p className="mt-2 text-sm font-medium text-orange-600">
-											⚠ Logo será eliminado al guardar
-										</p>
-									)}
-								</div>
-							</div>
-						</div>
-						<input
-							ref={fileInputRef}
-							type="file"
-							accept="image/jpeg,image/jpg,image/png,image/webp"
-							className="hidden"
-							onChange={handleLogoSelect}
-						/>
-						{errors.logo && (
-							<p className="text-sm text-destructive">{errors.logo}</p>
-						)}
-					</div>
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={(newOpen) => {
+                setOpen(newOpen);
+                if (!newOpen) {
+                    handleReset();
+                }
+            }}
+        >
+            <DialogTrigger asChild>
+                {trigger || (
+                    <Button>
+                        <Edit className="mr-2 h-4 w-4" />
+                        Editar Equipo
+                    </Button>
+                )}
+            </DialogTrigger>
+            <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[600px]">
+                <DialogHeader>
+                    <DialogTitle>Editar Equipo</DialogTitle>
+                    <DialogDescription>
+                        Actualiza la información de tu equipo
+                    </DialogDescription>
+                </DialogHeader>
+                <form onSubmit={submit} className="space-y-6">
+                    {/* Logo Upload */}
+                    <div className="space-y-3">
+                        <Label className="text-base font-semibold">
+                            Logo del Equipo
+                        </Label>
+                        <div className="flex flex-col items-center gap-4 rounded-lg border border-border bg-muted/20 p-6">
+                            <TeamAvatar
+                                name={formData.name}
+                                logoUrl={getCurrentLogoUrl()}
+                                size="2xl"
+                            />
+                            <div className="flex w-full flex-col gap-2">
+                                <div className="flex w-full gap-2">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="default"
+                                        className="flex-1"
+                                        onClick={() =>
+                                            fileInputRef.current?.click()
+                                        }
+                                    >
+                                        <Upload className="mr-2 h-4 w-4" />
+                                        {selectedLogo || team.logo_path
+                                            ? 'Cambiar Logo'
+                                            : 'Subir Logo'}
+                                    </Button>
+                                    {(selectedLogo ||
+                                        (team.logo_path && !removeLogo)) && (
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            size="default"
+                                            onClick={handleRemoveLogo}
+                                        >
+                                            <X className="mr-2 h-4 w-4" />
+                                            Eliminar
+                                        </Button>
+                                    )}
+                                </div>
+                                <div className="text-center">
+                                    <p className="text-xs text-muted-foreground">
+                                        Formatos: JPG, PNG o WEBP · Tamaño
+                                        máximo: 2MB
+                                    </p>
+                                    {selectedLogo && (
+                                        <p className="mt-2 text-sm font-medium text-green-600">
+                                            ✓ Nueva imagen seleccionada
+                                        </p>
+                                    )}
+                                    {removeLogo && (
+                                        <p className="mt-2 text-sm font-medium text-orange-600">
+                                            ⚠ Logo será eliminado al guardar
+                                        </p>
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                        <input
+                            ref={fileInputRef}
+                            type="file"
+                            accept="image/jpeg,image/jpg,image/png,image/webp"
+                            className="hidden"
+                            onChange={handleLogoSelect}
+                        />
+                        {errors.logo && (
+                            <p className="text-sm text-destructive">
+                                {errors.logo}
+                            </p>
+                        )}
+                    </div>
 
-					{/* Team Name */}
-					<div className="space-y-2">
-						<Label htmlFor="name">
-							Nombre del Equipo <span className="text-destructive">*</span>
-						</Label>
-						<Input
-							id="name"
-							value={formData.name}
-							onChange={(e) =>
-								setFormData({
-									...formData,
-									name: e.target.value,
-								})
-							}
-							placeholder="Ingresa el nombre del equipo"
-							required
-						/>
-						{errors.name && (
-							<p className="text-sm text-destructive">{errors.name}</p>
-						)}
-					</div>
+                    {/* Team Name */}
+                    <div className="space-y-2">
+                        <Label htmlFor="name">
+                            Nombre del Equipo{' '}
+                            <span className="text-destructive">*</span>
+                        </Label>
+                        <Input
+                            id="name"
+                            value={formData.name}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    name: e.target.value,
+                                })
+                            }
+                            placeholder="Ingresa el nombre del equipo"
+                            required
+                        />
+                        {errors.name && (
+                            <p className="text-sm text-destructive">
+                                {errors.name}
+                            </p>
+                        )}
+                    </div>
 
-					{/* Variant */}
-					<div className="space-y-2">
-						<Label htmlFor="variant">
-							Variante de Fútbol <span className="text-destructive">*</span>
-						</Label>
-						<Select
-							value={formData.variant}
-							onValueChange={(value) =>
-								setFormData({ ...formData, variant: value })
-							}
-						>
-							<SelectTrigger>
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								<SelectItem value="football_11">Fútbol 11</SelectItem>
-								<SelectItem value="football_7">Fútbol 7</SelectItem>
-								<SelectItem value="football_5">Fútbol 5</SelectItem>
-								<SelectItem value="futsal">Futsal</SelectItem>
-							</SelectContent>
-						</Select>
-						{errors.variant && (
-							<p className="text-sm text-destructive">{errors.variant}</p>
-						)}
-					</div>
+                    {/* Variant */}
+                    <div className="space-y-2">
+                        <Label htmlFor="variant">
+                            Variante de Fútbol{' '}
+                            <span className="text-destructive">*</span>
+                        </Label>
+                        <Select
+                            value={formData.variant}
+                            onValueChange={(value) =>
+                                setFormData({ ...formData, variant: value })
+                            }
+                        >
+                            <SelectTrigger>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="football_11">
+                                    Fútbol 11
+                                </SelectItem>
+                                <SelectItem value="football_7">
+                                    Fútbol 7
+                                </SelectItem>
+                                <SelectItem value="football_5">
+                                    Fútbol 5
+                                </SelectItem>
+                                <SelectItem value="futsal">Futsal</SelectItem>
+                            </SelectContent>
+                        </Select>
+                        {errors.variant && (
+                            <p className="text-sm text-destructive">
+                                {errors.variant}
+                            </p>
+                        )}
+                    </div>
 
-					{/* Description */}
-					<div className="space-y-2">
-						<Label htmlFor="description">Descripción</Label>
-						<Textarea
-							id="description"
-							value={formData.description}
-							onChange={(e) =>
-								setFormData({
-									...formData,
-									description: e.target.value,
-								})
-							}
-							placeholder="Cuéntanos sobre tu equipo..."
-							rows={3}
-						/>
-						{errors.description && (
-							<p className="text-sm text-destructive">{errors.description}</p>
-						)}
-					</div>
+                    {/* Description */}
+                    <div className="space-y-2">
+                        <Label htmlFor="description">Descripción</Label>
+                        <Textarea
+                            id="description"
+                            value={formData.description}
+                            onChange={(e) =>
+                                setFormData({
+                                    ...formData,
+                                    description: e.target.value,
+                                })
+                            }
+                            placeholder="Cuéntanos sobre tu equipo..."
+                            rows={3}
+                        />
+                        {errors.description && (
+                            <p className="text-sm text-destructive">
+                                {errors.description}
+                            </p>
+                        )}
+                    </div>
 
-					<div className="flex justify-end gap-3 pt-4">
-						<Button
-							type="button"
-							variant="outline"
-							onClick={() => setOpen(false)}
-						>
-							Cancelar
-						</Button>
-						<Button type="submit" disabled={processing}>
-							{processing ? "Guardando..." : "Guardar Cambios"}
-						</Button>
-					</div>
-				</form>
-			</DialogContent>
-		</Dialog>
-	);
+                    <div className="flex justify-end gap-3 pt-4">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => setOpen(false)}
+                        >
+                            Cancelar
+                        </Button>
+                        <Button type="submit" disabled={processing}>
+                            {processing ? 'Guardando...' : 'Guardar Cambios'}
+                        </Button>
+                    </div>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
 }

--- a/resources/js/components/match-card.tsx
+++ b/resources/js/components/match-card.tsx
@@ -125,20 +125,45 @@ export function MatchCard({ match }: MatchCardProps) {
             </CardHeader>
 
             <CardContent className="space-y-3">
-                {/* Countdown Section */}
-                {!hasStarted &&
-                    countdown &&
-                    match.status !== 'completed' &&
-                    match.status !== 'cancelled' && (
-                        <div className="flex items-center justify-center gap-2 rounded-lg border bg-primary/5 p-2">
+                {/* Status Section - Always visible for consistent layout */}
+                <div className="flex items-center justify-center gap-2 rounded-lg border p-2">
+                    {match.status === 'completed' ? (
+                        <>
+                            <Trophy className="h-4 w-4 text-muted-foreground" />
+                            <p className="text-xs font-semibold text-muted-foreground">
+                                Partido finalizado
+                            </p>
+                        </>
+                    ) : match.status === 'cancelled' ? (
+                        <>
+                            <Clock className="h-4 w-4 text-destructive" />
+                            <p className="text-xs font-semibold text-destructive">
+                                Partido cancelado
+                            </p>
+                        </>
+                    ) : hasStarted ? (
+                        <>
+                            <Clock className="h-4 w-4 text-orange-500" />
+                            <p className="text-xs font-semibold text-orange-500">
+                                En juego
+                            </p>
+                        </>
+                    ) : countdown ? (
+                        <>
                             <Clock className="h-4 w-4 text-primary" />
-                            <div className="text-center">
-                                <p className="text-xs font-semibold text-primary">
-                                    Comienza en {countdown}
-                                </p>
-                            </div>
-                        </div>
+                            <p className="text-xs font-semibold text-primary">
+                                Comienza en {countdown}
+                            </p>
+                        </>
+                    ) : (
+                        <>
+                            <CalendarDays className="h-4 w-4 text-muted-foreground" />
+                            <p className="text-xs font-semibold text-muted-foreground">
+                                Programado
+                            </p>
+                        </>
                     )}
+                </div>
 
                 {/* Match Details Section */}
                 <div className="flex items-center justify-between text-sm text-muted-foreground">

--- a/resources/js/pages/matches/show.tsx
+++ b/resources/js/pages/matches/show.tsx
@@ -1,6 +1,5 @@
-import { AvailabilityList } from '@/components/availability-list';
+import { AvailabilityPanel } from '@/components/availability-panel';
 import { AvailabilitySelector } from '@/components/availability-selector';
-import { AvailabilityStatsComponent } from '@/components/availability-stats';
 import { CreateMatchRequestDialog } from '@/components/create-match-request-dialog';
 import { MatchEventsManager } from '@/components/match-events-manager';
 import { TeamAvatar } from '@/components/team-avatar';
@@ -976,49 +975,28 @@ export default function Show({
                                 />
                             )}
 
-                        {/* Estadísticas de Disponibilidad - Equipo Local */}
+                        {/* Panel de Disponibilidad Consolidado */}
                         {(match.status === 'confirmed' ||
                             match.status === 'available') &&
                             homeAvailabilityStats && (
-                                <AvailabilityStatsComponent
-                                    stats={homeAvailabilityStats}
-                                    teamName={match.home_team.name}
-                                    isLeader={isHomeLeader}
-                                />
-                            )}
-
-                        {/* Estadísticas de Disponibilidad - Equipo Visitante */}
-                        {match.away_team &&
-                            awayAvailabilityStats &&
-                            (match.status === 'confirmed' ||
-                                match.status === 'available') && (
-                                <AvailabilityStatsComponent
-                                    stats={awayAvailabilityStats}
-                                    teamName={match.away_team.name}
-                                    isLeader={isAwayLeader}
-                                />
-                            )}
-
-                        {/* Lista de Disponibilidad - Equipo Local */}
-                        {isHomeLeader &&
-                            homeAvailability.length > 0 &&
-                            (match.status === 'confirmed' ||
-                                match.status === 'available') && (
-                                <AvailabilityList
-                                    availability={homeAvailability}
-                                    teamName={match.home_team.name}
-                                />
-                            )}
-
-                        {/* Lista de Disponibilidad - Equipo Visitante */}
-                        {isAwayLeader &&
-                            awayAvailability.length > 0 &&
-                            match.away_team &&
-                            (match.status === 'confirmed' ||
-                                match.status === 'available') && (
-                                <AvailabilityList
-                                    availability={awayAvailability}
-                                    teamName={match.away_team.name}
+                                <AvailabilityPanel
+                                    homeTeam={{
+                                        team: match.home_team,
+                                        stats: homeAvailabilityStats,
+                                        availability: homeAvailability,
+                                        isLeader: isHomeLeader,
+                                    }}
+                                    awayTeam={
+                                        match.away_team && awayAvailabilityStats
+                                            ? {
+                                                  team: match.away_team,
+                                                  stats: awayAvailabilityStats,
+                                                  availability:
+                                                      awayAvailability,
+                                                  isLeader: isAwayLeader,
+                                              }
+                                            : undefined
+                                    }
                                 />
                             )}
 


### PR DESCRIPTION
## Summary

- **New AvailabilityPanel component**: Consolidates availability stats and player lists into a single tabbed card (Home/Away tabs), reducing sidebar from 6 cards to 3
- **Redesigned AvailabilitySelector**: Converted from stacked radio cards to compact horizontal toggle group with auto-submit on selection
- **Matches index page improvements**: Added "Próximos" (upcoming) and "Historial" (past) tabs to organize matches, placed alongside main navigation for consistency

## Changes

### New Component
- `resources/js/components/availability-panel.tsx` - Tabbed panel with collapsible player lists by status

### Modified Components
- `resources/js/components/availability-selector.tsx` - Compact toggle group design (~80px vs ~200px height)
- `resources/js/pages/matches/show.tsx` - Uses new consolidated components
- `resources/js/pages/matches/index.tsx` - Added upcoming/history tabs

## Test plan

- [ ] View match as regular player → see compact selector + stats panel (no player list)
- [ ] View match as team leader → see selector + panel with player list in tabs
- [ ] View match with away team → tabs appear for home/away
- [ ] View match without away team → no tabs, just home team info
- [ ] Click availability button → auto-submits, shows toast
- [ ] Switch tabs in availability panel → content updates correctly
- [ ] Navigate to matches page → see Próximos/Historial tabs
- [ ] Switch between upcoming and history → correct matches displayed
- [ ] Test on mobile → layout stacks properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)