### PR TITLE
fix: cast max_teams to int in TournamentService

### DIFF
--- a/app/Services/TournamentService.php
+++ b/app/Services/TournamentService.php
@@ -20,7 +20,7 @@ final class TournamentService
     public function createTournament(User $user, array $data): Tournament
     {
         // Validate max_teams is power of 2
-        $maxTeams = $data['max_teams'] ?? 8;
+        $maxTeams = (int) ($data['max_teams'] ?? 8);
         if (! $this->isPowerOfTwo($maxTeams)) {
             throw new \InvalidArgumentException('Max teams must be a power of 2 (4, 8, 16, 32, 64)');
         }
@@ -54,7 +54,7 @@ final class TournamentService
 
         // Validate max_teams is power of 2 if being changed
         if (isset($data['max_teams'])) {
-            if (! $this->isPowerOfTwo($data['max_teams'])) {
+            if (! $this->isPowerOfTwo((int) $data['max_teams'])) {
                 throw new \InvalidArgumentException('Max teams must be a power of 2 (4, 8, 16, 32, 64)');
             }
 


### PR DESCRIPTION
## Summary
- `POST /tournaments` was throwing `TypeError: TournamentService::isPowerOfTwo(): Argument #1 ($number) must be of type int, string given` because multipart form data sends `max_teams` as a string and Laravel's `integer` validation rule type-checks without casting.
- Cast `max_teams` to `int` at the boundary in both `createTournament` and `updateTournament` so the strict-typed `isPowerOfTwo(int)` call works.

## Test plan
- [ ] Create a tournament via the UI and confirm it succeeds without a 500
- [ ] Update an existing tournament's `max_teams` and confirm the validation still rejects non-powers-of-two

🤖 Generated with [Claude Code](https://claude.com/claude-code)