### PR TITLE
fix: resolve type errors and replace native confirm dialogs

### DIFF
--- a/resources/js/components/commendation-dialog.tsx
+++ b/resources/js/components/commendation-dialog.tsx
@@ -114,7 +114,7 @@ export function CommendationDialog({
     useEffect(() => {
         if (isOpen) {
             // If we have initial data, use it; otherwise fetch
-            if (initialExistingCommendations !== null) {
+            if (initialExistingCommendations != null) {
                 setExistingCommendations(initialExistingCommendations);
             } else {
                 fetchExistingCommendations();

--- a/resources/js/components/profile-comments.tsx
+++ b/resources/js/components/profile-comments.tsx
@@ -1,3 +1,13 @@
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { UserAvatar } from '@/components/user-avatar';
@@ -34,6 +44,7 @@ export function ProfileComments({
     const [currentPage, setCurrentPage] = useState(1);
     const [lastPage, setLastPage] = useState(1);
     const [deletingId, setDeletingId] = useState<number | null>(null);
+    const [commentToDelete, setCommentToDelete] = useState<number | null>(null);
 
     const fetchComments = useCallback(
         async (page: number = 1, append: boolean = false) => {
@@ -76,12 +87,7 @@ export function ProfileComments({
     }, [fetchComments]);
 
     const handleDelete = async (commentId: number) => {
-        if (
-            !confirm('¿Estás seguro de que quieres eliminar este comentario?')
-        ) {
-            return;
-        }
-
+        setCommentToDelete(null);
         setDeletingId(commentId);
 
         try {
@@ -184,7 +190,9 @@ export function ProfileComments({
                                     <Button
                                         variant="ghost"
                                         size="sm"
-                                        onClick={() => handleDelete(comment.id)}
+                                        onClick={() =>
+                                            setCommentToDelete(comment.id)
+                                        }
                                         disabled={deletingId === comment.id}
                                         className="h-auto p-1"
                                     >
@@ -221,6 +229,33 @@ export function ProfileComments({
                     )}
                 </Button>
             )}
+
+            <AlertDialog
+                open={commentToDelete !== null}
+                onOpenChange={(open) => !open && setCommentToDelete(null)}
+            >
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Eliminar comentario</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            ¿Estás seguro de que quieres eliminar este
+                            comentario? Esta acción no se puede deshacer.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                        <AlertDialogAction
+                            onClick={() =>
+                                commentToDelete !== null &&
+                                handleDelete(commentToDelete)
+                            }
+                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                        >
+                            Eliminar
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/resources/js/components/user-avatar.tsx
+++ b/resources/js/components/user-avatar.tsx
@@ -5,13 +5,15 @@ interface UserAvatarProps {
     name: string;
     avatarUrl?: string;
     className?: string;
-    size?: 'sm' | 'md' | 'lg';
+    size?: 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 }
 
 const sizeClasses = {
     sm: 'h-8 w-8 text-xs',
     md: 'h-10 w-10 text-sm',
     lg: 'h-12 w-12 text-base',
+    xl: 'h-16 w-16 text-xl',
+    '2xl': 'h-20 w-20 text-xl',
 };
 
 export function UserAvatar({

--- a/resources/js/components/variant-badge.tsx
+++ b/resources/js/components/variant-badge.tsx
@@ -1,8 +1,10 @@
 import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
 import { Trophy } from 'lucide-react';
 
 interface VariantBadgeProps {
     variant: string;
+    className?: string;
 }
 
 const variantConfig = {
@@ -24,14 +26,14 @@ const variantConfig = {
     },
 };
 
-export function VariantBadge({ variant }: VariantBadgeProps) {
+export function VariantBadge({ variant, className }: VariantBadgeProps) {
     const config = variantConfig[variant as keyof typeof variantConfig] || {
         label: variant,
         color: 'bg-gray-100 text-gray-700 hover:bg-gray-100',
     };
 
     return (
-        <Badge variant="secondary" className={config.color}>
+        <Badge variant="secondary" className={cn(config.color, className)}>
             <Trophy className="mr-1 h-3 w-3" />
             {config.label}
         </Badge>

--- a/resources/js/pages/settings/profile.tsx
+++ b/resources/js/pages/settings/profile.tsx
@@ -2,6 +2,16 @@ import ProfileController from '@/actions/App/Http/Controllers/Settings/ProfileCo
 import DeleteUser from '@/components/delete-user';
 import HeadingSmall from '@/components/heading-small';
 import InputError from '@/components/input-error';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -38,6 +48,7 @@ export default function Profile({
     const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
     const [bioLength, setBioLength] = useState(auth.user.bio?.length || 0);
+    const [showDeleteAvatarDialog, setShowDeleteAvatarDialog] = useState(false);
 
     const handleAvatarUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
@@ -68,9 +79,7 @@ export default function Profile({
     };
 
     const handleDeleteAvatar = () => {
-        if (!confirm('¿Estás seguro de que deseas eliminar tu foto de perfil?'))
-            return;
-
+        setShowDeleteAvatarDialog(false);
         router.delete('/settings/avatar', {
             preserveScroll: true,
             onSuccess: () => {
@@ -133,7 +142,9 @@ export default function Profile({
                                             type="button"
                                             variant="outline"
                                             size="sm"
-                                            onClick={handleDeleteAvatar}
+                                            onClick={() =>
+                                                setShowDeleteAvatarDialog(true)
+                                            }
                                             disabled={isUploadingAvatar}
                                         >
                                             <X className="mr-2 h-4 w-4" />
@@ -374,6 +385,32 @@ export default function Profile({
 
                 <DeleteUser hasPassword={hasPassword} />
             </SettingsLayout>
+
+            <AlertDialog
+                open={showDeleteAvatarDialog}
+                onOpenChange={setShowDeleteAvatarDialog}
+            >
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>
+                            Eliminar foto de perfil
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                            ¿Estás seguro de que deseas eliminar tu foto de
+                            perfil? Esta acción no se puede deshacer.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                        <AlertDialogAction
+                            onClick={handleDeleteAvatar}
+                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                        >
+                            Eliminar
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </AppLayout>
     );
 }


### PR DESCRIPTION
## Summary
- Clear three pre-existing TypeScript errors so `bun run types` is green and can be enforced in CI:
  - `commendation-dialog.tsx` — narrow `!== null` to `!= null` so an omitted `initialExistingCommendations` prop falls through to `fetchExistingCommendations()` instead of being passed to `setState` as `undefined`
  - `user-avatar.tsx` — extend size union with `xl` / `2xl` to mirror `TeamAvatar` (the user profile hero already passes `size=\"xl\"`)
  - `variant-badge.tsx` — accept an optional `className` and merge with `cn()`, matching the rest of the design-system primitives
- Replace the last two `window.confirm()` calls with `AlertDialog`, bringing destructive actions in line with the pattern landed in #79:
  - `settings/profile.tsx` — delete avatar
  - `profile-comments.tsx` — delete comment (single shared dialog driven by `commentToDelete` id)

No call sites needed to change — every existing consumer of the touched components already passed compatible props.

## Test plan
- [x] `bun run types` — 0 errors (was 3)
- [x] `bun run lint` — clean
- [ ] Open `/users/{id}` — hero avatar still renders, `VariantBadge` chips under team names render with `mt-1` spacing
- [ ] Open the commendation dialog from a profile both with and without `initialExistingCommendations` — fetches in the absent case, uses provided data otherwise
- [ ] Settings → delete avatar — confirmation dialog appears, cancel/confirm both behave correctly
- [ ] Profile → delete own comment — confirmation dialog appears, cancel/confirm both behave correctly