### PR TITLE
refactor: decompose matches/show.tsx into focused components

### DIFF
--- a/resources/js/components/match/complete-match-dialog.tsx
+++ b/resources/js/components/match/complete-match-dialog.tsx
@@ -1,0 +1,175 @@
+import type { MatchEvent, MatchPageMatch } from '@/components/match/types';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { AlertCircle, Target } from 'lucide-react';
+
+interface CompleteMatchDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    match: MatchPageMatch;
+    events: MatchEvent[];
+    onConfirm: () => void;
+}
+
+export function CompleteMatchDialog({
+    open,
+    onOpenChange,
+    match,
+    events,
+    onConfirm,
+}: CompleteMatchDialogProps) {
+    const homeScore = match.home_score ?? 0;
+    const awayScore = match.away_score ?? 0;
+
+    const homeRegisteredGoals = events.filter(
+        (e) =>
+            Number(e.team_id) === Number(match.home_team.id) &&
+            e.event_type === 'goal',
+    ).length;
+    const awayRegisteredGoals = match.away_team
+        ? events.filter(
+              (e) =>
+                  match.away_team &&
+                  Number(e.team_id) === Number(match.away_team.id) &&
+                  e.event_type === 'goal',
+          ).length
+        : 0;
+
+    const hasScoreMismatch =
+        homeRegisteredGoals !== homeScore ||
+        (!!match.away_team && awayRegisteredGoals !== awayScore);
+
+    const isTournamentDraw = !!match.tournament_id && homeScore === awayScore;
+
+    const homeGoals = events
+        .filter(
+            (e) =>
+                Number(e.team_id) === Number(match.home_team.id) &&
+                e.event_type === 'goal',
+        )
+        .sort((a, b) => (a.minute || 0) - (b.minute || 0));
+
+    const awayGoals = match.away_team
+        ? events
+              .filter(
+                  (e) =>
+                      match.away_team &&
+                      Number(e.team_id) === Number(match.away_team.id) &&
+                      e.event_type === 'goal',
+              )
+              .sort((a, b) => (a.minute || 0) - (b.minute || 0))
+        : [];
+
+    const hasAnyGoals = homeGoals.length + awayGoals.length > 0;
+
+    return (
+        <AlertDialog open={open} onOpenChange={onOpenChange}>
+            <AlertDialogContent className="max-w-md">
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Completar Partido</AlertDialogTitle>
+                    <AlertDialogDescription asChild>
+                        <div className="space-y-4">
+                            <p>
+                                ¿Estás seguro de que quieres marcar este partido
+                                como completado?
+                            </p>
+
+                            <div className="rounded-lg border bg-muted/50 p-4">
+                                <div className="flex items-center justify-center gap-4 text-lg font-bold">
+                                    <span>{match.home_team.name}</span>
+                                    <span className="rounded-md bg-background px-3 py-1 text-2xl">
+                                        {homeScore} - {awayScore}
+                                    </span>
+                                    <span>{match.away_team?.name}</span>
+                                </div>
+
+                                {hasAnyGoals && (
+                                    <div className="mt-3 grid grid-cols-2 gap-4 border-t pt-3">
+                                        <div className="space-y-1">
+                                            {homeGoals.map((goal) => (
+                                                <div
+                                                    key={goal.id}
+                                                    className="flex items-center gap-1.5 text-xs"
+                                                >
+                                                    <Target className="h-3 w-3 text-green-600" />
+                                                    <span className="truncate">
+                                                        {goal.user?.name ||
+                                                            'Sin asignar'}
+                                                    </span>
+                                                    {goal.minute && (
+                                                        <span className="text-muted-foreground">
+                                                            {goal.minute}'
+                                                        </span>
+                                                    )}
+                                                </div>
+                                            ))}
+                                        </div>
+                                        <div className="space-y-1">
+                                            {awayGoals.map((goal) => (
+                                                <div
+                                                    key={goal.id}
+                                                    className="flex items-center gap-1.5 text-xs"
+                                                >
+                                                    <Target className="h-3 w-3 text-green-600" />
+                                                    <span className="truncate">
+                                                        {goal.user?.name ||
+                                                            'Sin asignar'}
+                                                    </span>
+                                                    {goal.minute && (
+                                                        <span className="text-muted-foreground">
+                                                            {goal.minute}'
+                                                        </span>
+                                                    )}
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+
+                            {homeScore === 0 && awayScore === 0 && (
+                                <div className="flex items-center gap-2 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-700 dark:text-yellow-400">
+                                    <AlertCircle className="h-4 w-4 flex-shrink-0" />
+                                    El partido terminará 0 - 0
+                                </div>
+                            )}
+
+                            {hasScoreMismatch && (
+                                <div className="flex items-center gap-2 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-700 dark:text-yellow-400">
+                                    <AlertCircle className="h-4 w-4 flex-shrink-0" />
+                                    Los goles registrados no coinciden con el
+                                    marcador
+                                </div>
+                            )}
+
+                            {isTournamentDraw && (
+                                <div className="flex items-center gap-2 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-700 dark:text-red-400">
+                                    <AlertCircle className="h-4 w-4 flex-shrink-0" />
+                                    Los partidos de torneo no pueden terminar en
+                                    empate. Actualiza el marcador.
+                                </div>
+                            )}
+                        </div>
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                    <AlertDialogAction
+                        onClick={onConfirm}
+                        disabled={isTournamentDraw}
+                    >
+                        Completar Partido
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+}

--- a/resources/js/components/match/match-hero.tsx
+++ b/resources/js/components/match/match-hero.tsx
@@ -1,0 +1,389 @@
+import { CreateMatchRequestDialog } from '@/components/create-match-request-dialog';
+import { GoalScorersList } from '@/components/goal-scorers-list';
+import type {
+    LineupPlayer,
+    MatchEvent,
+    MatchPageMatch,
+    MatchPageTeam,
+} from '@/components/match/types';
+import { RecordGoalDialog } from '@/components/record-goal-dialog';
+import { TeamAvatar } from '@/components/team-avatar';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import { VariantBadge } from '@/components/variant-badge';
+import { useMatchCountdown } from '@/hooks/use-match-countdown';
+import {
+    formatMatchDate,
+    formatMatchTime,
+    getMatchStatusColor,
+    getMatchStatusText,
+} from '@/lib/match-format';
+import matches from '@/routes/matches';
+import { Link } from '@inertiajs/react';
+import {
+    Calendar,
+    Clock,
+    Edit,
+    MapPin,
+    Plus,
+    Shield,
+    Swords,
+    Trophy,
+    Users,
+    X,
+} from 'lucide-react';
+import { useState } from 'react';
+
+interface MatchHeroProps {
+    match: MatchPageMatch;
+    isHomeLeader: boolean;
+    isAwayLeader: boolean;
+    isLeader: boolean;
+    eligibleTeams: MatchPageTeam[];
+    homeLineup: LineupPlayer[];
+    awayLineup: LineupPlayer[];
+    events: MatchEvent[];
+    onCancelClick: () => void;
+    onCompleteClick: () => void;
+}
+
+export function MatchHero({
+    match,
+    isHomeLeader,
+    isAwayLeader,
+    isLeader,
+    eligibleTeams,
+    homeLineup,
+    awayLineup,
+    events,
+    onCancelClick,
+    onCompleteClick,
+}: MatchHeroProps) {
+    const { countdown, hasStarted: matchHasStarted } = useMatchCountdown(
+        match.scheduled_at,
+    );
+    const [recordGoalDialog, setRecordGoalDialog] = useState<{
+        open: boolean;
+        team: 'home' | 'away' | null;
+    }>({ open: false, team: null });
+
+    const homeScore = match.home_score ?? 0;
+    const awayScore = match.away_score ?? 0;
+
+    const showScore =
+        match.status === 'confirmed' ||
+        match.status === 'in_progress' ||
+        match.status === 'completed';
+
+    return (
+        <>
+            <div className="relative overflow-hidden rounded-xl border bg-gradient-to-br from-background via-background to-muted/20 p-6 md:p-8">
+                <div className="absolute top-0 right-0 -mt-16 -mr-16 h-64 w-64 rounded-full bg-primary/5 blur-3xl" />
+                <div className="absolute bottom-0 left-0 -mb-16 -ml-16 h-64 w-64 rounded-full bg-primary/5 blur-3xl" />
+
+                <div className="relative">
+                    {/* Status badges */}
+                    <div className="mb-4 flex flex-wrap items-center gap-2">
+                        <Badge className={getMatchStatusColor(match.status)}>
+                            {getMatchStatusText(match.status)}
+                        </Badge>
+                        <VariantBadge variant={match.variant} />
+                        <Badge variant="outline">
+                            {match.match_type === 'friendly'
+                                ? 'Amistoso'
+                                : 'Competitivo'}
+                        </Badge>
+                    </div>
+
+                    {/* Matchup */}
+                    <div className="grid grid-cols-1 items-center gap-6 md:grid-cols-[1fr,auto,1fr]">
+                        {/* Home team */}
+                        <div className="flex flex-col items-center md:items-end">
+                            <Link
+                                href={`/teams/${match.home_team.id}`}
+                                className="group flex flex-col items-center gap-3 rounded-lg p-4 transition-colors hover:bg-muted/50 md:flex-row md:justify-end"
+                            >
+                                <TeamAvatar
+                                    name={match.home_team.name}
+                                    logoUrl={match.home_team.logo_url}
+                                    size="lg"
+                                    className="h-20 w-20"
+                                />
+                                <div className="text-center md:text-right">
+                                    <h2 className="text-2xl font-bold">
+                                        {match.home_team.name}
+                                    </h2>
+                                    <div className="mt-1 flex items-center justify-center gap-1 md:justify-end">
+                                        <Shield className="h-4 w-4 text-muted-foreground" />
+                                        <p className="text-sm text-muted-foreground">
+                                            Local
+                                        </p>
+                                    </div>
+                                </div>
+                            </Link>
+                            {(match.status === 'in_progress' ||
+                                match.status === 'completed') && (
+                                <GoalScorersList
+                                    events={events}
+                                    teamId={match.home_team.id}
+                                    isLeader={isHomeLeader}
+                                    alignment="right"
+                                    matchStatus={match.status}
+                                    onRecordGoal={() =>
+                                        setRecordGoalDialog({
+                                            open: true,
+                                            team: 'home',
+                                        })
+                                    }
+                                />
+                            )}
+                        </div>
+
+                        {/* Score / countdown / placeholder */}
+                        <div className="flex flex-col items-center justify-center gap-3">
+                            {showScore ? (
+                                <>
+                                    {!matchHasStarted &&
+                                        countdown &&
+                                        match.status !== 'completed' && (
+                                            <div className="flex items-center gap-1.5 rounded-full border bg-card/80 px-3 py-1 text-xs backdrop-blur-sm">
+                                                <Clock className="h-3 w-3 text-muted-foreground" />
+                                                <span className="font-medium">
+                                                    {countdown}
+                                                </span>
+                                            </div>
+                                        )}
+
+                                    <div className="rounded-xl border bg-card/80 px-4 py-3 shadow-lg backdrop-blur-sm md:px-6">
+                                        <div className="flex items-center gap-3 md:gap-4">
+                                            <div className="flex items-center gap-2">
+                                                {isHomeLeader &&
+                                                    match.status !==
+                                                        'completed' &&
+                                                    matchHasStarted && (
+                                                        <Button
+                                                            variant="ghost"
+                                                            size="icon"
+                                                            className="h-7 w-7 rounded-full"
+                                                            onClick={() =>
+                                                                setRecordGoalDialog(
+                                                                    {
+                                                                        open: true,
+                                                                        team: 'home',
+                                                                    },
+                                                                )
+                                                            }
+                                                        >
+                                                            <Plus className="h-3.5 w-3.5" />
+                                                        </Button>
+                                                    )}
+                                                <div
+                                                    className={`flex h-12 w-12 items-center justify-center rounded-lg text-3xl font-bold md:h-14 md:w-14 ${
+                                                        match.status ===
+                                                            'completed' &&
+                                                        homeScore > awayScore
+                                                            ? 'text-primary'
+                                                            : ''
+                                                    }`}
+                                                >
+                                                    {homeScore}
+                                                </div>
+                                            </div>
+
+                                            <span className="text-xl font-bold text-muted-foreground md:text-2xl">
+                                                -
+                                            </span>
+
+                                            <div className="flex items-center gap-2">
+                                                <div
+                                                    className={`flex h-12 w-12 items-center justify-center rounded-lg text-3xl font-bold md:h-14 md:w-14 ${
+                                                        match.status ===
+                                                            'completed' &&
+                                                        awayScore > homeScore
+                                                            ? 'text-primary'
+                                                            : ''
+                                                    }`}
+                                                >
+                                                    {awayScore}
+                                                </div>
+                                                {isAwayLeader &&
+                                                    match.status !==
+                                                        'completed' &&
+                                                    matchHasStarted && (
+                                                        <Button
+                                                            variant="ghost"
+                                                            size="icon"
+                                                            className="h-7 w-7 rounded-full"
+                                                            onClick={() =>
+                                                                setRecordGoalDialog(
+                                                                    {
+                                                                        open: true,
+                                                                        team: 'away',
+                                                                    },
+                                                                )
+                                                            }
+                                                        >
+                                                            <Plus className="h-3.5 w-3.5" />
+                                                        </Button>
+                                                    )}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </>
+                            ) : (
+                                <div className="rounded-full border bg-card p-4 shadow-sm">
+                                    <Swords className="h-8 w-8 text-muted-foreground" />
+                                </div>
+                            )}
+                        </div>
+
+                        {/* Away team */}
+                        <div className="flex flex-col items-center md:items-start">
+                            {match.away_team ? (
+                                <Link
+                                    href={`/teams/${match.away_team.id}`}
+                                    className="group flex flex-col items-center gap-3 rounded-lg p-4 transition-colors hover:bg-muted/50 md:flex-row"
+                                >
+                                    <TeamAvatar
+                                        name={match.away_team.name}
+                                        logoUrl={match.away_team.logo_url}
+                                        size="lg"
+                                        className="h-20 w-20"
+                                    />
+                                    <div className="text-center md:text-left">
+                                        <h2 className="text-2xl font-bold">
+                                            {match.away_team.name}
+                                        </h2>
+                                        <p className="mt-1 text-sm text-muted-foreground">
+                                            Visitante
+                                        </p>
+                                    </div>
+                                </Link>
+                            ) : (
+                                <div className="flex flex-col items-center gap-3 rounded-lg border-2 border-dashed bg-muted/30 p-6 md:flex-row">
+                                    <div className="rounded-full bg-muted p-4">
+                                        <Users className="h-8 w-8 text-muted-foreground" />
+                                    </div>
+                                    <div className="text-center md:text-left">
+                                        <h3 className="text-lg font-semibold">
+                                            Buscando Rival
+                                        </h3>
+                                        <p className="text-sm text-muted-foreground">
+                                            Esperando solicitudes de equipos
+                                        </p>
+                                    </div>
+                                </div>
+                            )}
+                            {(match.status === 'in_progress' ||
+                                match.status === 'completed') &&
+                                match.away_team && (
+                                    <GoalScorersList
+                                        events={events}
+                                        teamId={match.away_team.id}
+                                        isLeader={isAwayLeader}
+                                        alignment="left"
+                                        matchStatus={match.status}
+                                        onRecordGoal={() =>
+                                            setRecordGoalDialog({
+                                                open: true,
+                                                team: 'away',
+                                            })
+                                        }
+                                    />
+                                )}
+                        </div>
+                    </div>
+
+                    {/* Match info row */}
+                    <div className="mt-6 flex flex-wrap items-center justify-center gap-6 text-sm">
+                        <div className="flex items-center gap-2">
+                            <Calendar className="h-4 w-4 text-muted-foreground" />
+                            <span className="font-medium">
+                                {formatMatchDate(match.scheduled_at)}
+                            </span>
+                        </div>
+                        <Separator orientation="vertical" className="h-4" />
+                        <div className="flex items-center gap-2">
+                            <Clock className="h-4 w-4 text-muted-foreground" />
+                            <span className="font-medium">
+                                {formatMatchTime(match.scheduled_at)}
+                            </span>
+                        </div>
+                        <Separator orientation="vertical" className="h-4" />
+                        <div className="flex items-center gap-2">
+                            <MapPin className="h-4 w-4 text-muted-foreground" />
+                            <span className="font-medium">
+                                {match.location}
+                            </span>
+                        </div>
+                    </div>
+
+                    {/* Action buttons */}
+                    <div className="mt-6 flex flex-wrap justify-center gap-3">
+                        {isHomeLeader && match.status === 'available' && (
+                            <>
+                                <Button asChild variant="outline">
+                                    <Link href={matches.edit(match.id).url}>
+                                        <Edit className="mr-2 h-4 w-4" />
+                                        Editar
+                                    </Link>
+                                </Button>
+                                <Button
+                                    variant="destructive"
+                                    onClick={onCancelClick}
+                                >
+                                    <X className="mr-2 h-4 w-4" />
+                                    Cancelar Partido
+                                </Button>
+                            </>
+                        )}
+                        {isLeader && match.status === 'in_progress' && (
+                            <Button
+                                onClick={onCompleteClick}
+                                disabled={!matchHasStarted}
+                                title={
+                                    !matchHasStarted
+                                        ? 'No se puede completar el partido antes de que comience'
+                                        : ''
+                                }
+                            >
+                                <Trophy className="mr-2 h-4 w-4" />
+                                Completar Partido
+                            </Button>
+                        )}
+                        {!isLeader &&
+                            match.status === 'available' &&
+                            eligibleTeams.length > 0 && (
+                                <CreateMatchRequestDialog
+                                    matchId={match.id}
+                                    eligibleTeams={eligibleTeams}
+                                />
+                            )}
+                    </div>
+                </div>
+            </div>
+
+            <RecordGoalDialog
+                matchId={match.id}
+                teamId={
+                    recordGoalDialog.team === 'home'
+                        ? match.home_team.id
+                        : (match.away_team?.id ?? 0)
+                }
+                teamName={
+                    recordGoalDialog.team === 'home'
+                        ? match.home_team.name
+                        : (match.away_team?.name ?? '')
+                }
+                availablePlayers={
+                    recordGoalDialog.team === 'home' ? homeLineup : awayLineup
+                }
+                open={recordGoalDialog.open}
+                onOpenChange={(open) =>
+                    setRecordGoalDialog((prev) => ({ ...prev, open }))
+                }
+            />
+        </>
+    );
+}

--- a/resources/js/components/match/match-requests-card.tsx
+++ b/resources/js/components/match/match-requests-card.tsx
@@ -1,0 +1,74 @@
+import type { MatchRequest } from '@/components/match/types';
+import { TeamAvatar } from '@/components/team-avatar';
+import { Button } from '@/components/ui/button';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+
+interface MatchRequestsCardProps {
+    requests: MatchRequest[];
+    onAccept: (requestId: number) => void;
+    onReject: (requestId: number) => void;
+}
+
+export function MatchRequestsCard({
+    requests,
+    onAccept,
+    onReject,
+}: MatchRequestsCardProps) {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Solicitudes de Partido</CardTitle>
+                <CardDescription>
+                    Equipos interesados en jugar este partido
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                <div className="space-y-3">
+                    {requests.map((request) => (
+                        <div
+                            key={request.id}
+                            className="flex items-start gap-4 rounded-lg border bg-card p-4 transition-colors hover:bg-muted/50"
+                        >
+                            <TeamAvatar
+                                name={request.requesting_team.name}
+                                logoUrl={request.requesting_team.logo_url}
+                                size="md"
+                            />
+                            <div className="min-w-0 flex-1">
+                                <p className="font-semibold">
+                                    {request.requesting_team.name}
+                                </p>
+                                {request.message && (
+                                    <p className="mt-1 text-sm text-muted-foreground">
+                                        {request.message}
+                                    </p>
+                                )}
+                                <div className="mt-3 flex gap-2">
+                                    <Button
+                                        size="sm"
+                                        onClick={() => onAccept(request.id)}
+                                    >
+                                        Aceptar
+                                    </Button>
+                                    <Button
+                                        size="sm"
+                                        variant="outline"
+                                        onClick={() => onReject(request.id)}
+                                    >
+                                        Rechazar
+                                    </Button>
+                                </div>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/match/opposing-leaders-card.tsx
+++ b/resources/js/components/match/opposing-leaders-card.tsx
@@ -1,0 +1,87 @@
+import type { OpposingTeamLeader } from '@/components/match/types';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import { UserAvatar } from '@/components/user-avatar';
+import { UserNameLink } from '@/components/user-name-link';
+import { Phone } from 'lucide-react';
+
+const getWhatsAppUrl = (phone: string): string => {
+    const cleaned = phone.replace(/[^\d+]/g, '');
+    return `https://wa.me/${cleaned}`;
+};
+
+interface OpposingLeadersCardProps {
+    leaders: OpposingTeamLeader[];
+}
+
+export function OpposingLeadersCard({ leaders }: OpposingLeadersCardProps) {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Contacto del Equipo Rival</CardTitle>
+                <CardDescription>
+                    Coordina los detalles del partido con los líderes del equipo
+                    oponente
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                <div className="space-y-3">
+                    {leaders.map((leader) => (
+                        <div
+                            key={leader.id}
+                            className="flex items-center justify-between rounded-lg border bg-card p-4"
+                        >
+                            <div className="flex items-center gap-3">
+                                <UserAvatar name={leader.user.name} size="sm" />
+                                <div>
+                                    <p className="font-medium">
+                                        <UserNameLink user={leader.user} />
+                                    </p>
+                                    <div className="mt-1 flex items-center gap-2">
+                                        <Badge
+                                            variant="outline"
+                                            className="text-xs"
+                                        >
+                                            {leader.role === 'captain'
+                                                ? 'Capitán'
+                                                : 'Subcapitán'}
+                                        </Badge>
+                                        {leader.user.phone_number && (
+                                            <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                                                <Phone className="h-3 w-3" />
+                                                <span>
+                                                    {leader.user.phone_number}
+                                                </span>
+                                            </div>
+                                        )}
+                                    </div>
+                                </div>
+                            </div>
+                            {leader.user.phone_number && (
+                                <Button asChild variant="outline" size="sm">
+                                    <a
+                                        href={getWhatsAppUrl(
+                                            leader.user.phone_number,
+                                        )}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        <Phone className="mr-2 h-4 w-4" />
+                                        WhatsApp
+                                    </a>
+                                </Button>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/match/types.ts
+++ b/resources/js/components/match/types.ts
@@ -1,0 +1,73 @@
+// Local match-page types. These are the enriched shapes that the match
+// detail page and its subcomponents share. They differ from the global
+// `FootballMatch` type in that `home_team` is required and team members
+// are eagerly loaded.
+
+export interface MatchPageUser {
+    id: number;
+    name: string;
+}
+
+export interface MatchPageTeam {
+    id: number;
+    name: string;
+    variant: string;
+    logo_url?: string;
+    team_members?: Array<{
+        id: number;
+        user: MatchPageUser;
+    }>;
+}
+
+export interface LineupPlayer {
+    id: number;
+    user_id: number;
+    user: MatchPageUser;
+}
+
+export interface MatchEvent {
+    id: number;
+    team_id: number;
+    user_id?: number;
+    user?: MatchPageUser;
+    event_type: string;
+    minute?: number;
+    description?: string;
+}
+
+export interface MatchRequest {
+    id: number;
+    requesting_team_id: number;
+    status: string;
+    message?: string;
+    requesting_team: MatchPageTeam;
+}
+
+export interface OpposingTeamLeader {
+    id: number;
+    user_id: number;
+    role: string;
+    user: {
+        id: number;
+        name: string;
+        phone_number?: string;
+    };
+}
+
+export interface MatchPageMatch {
+    id: number;
+    home_team_id: number;
+    away_team_id?: number;
+    tournament_id?: number;
+    variant: string;
+    scheduled_at: string;
+    location: string;
+    match_type: string;
+    status: string;
+    home_score?: number;
+    away_score?: number;
+    notes?: string;
+    home_team: MatchPageTeam;
+    away_team?: MatchPageTeam;
+    match_requests?: MatchRequest[];
+}

--- a/resources/js/lib/match-format.ts
+++ b/resources/js/lib/match-format.ts
@@ -1,0 +1,51 @@
+export const getMatchStatusColor = (status: string): string => {
+    switch (status) {
+        case 'available':
+            return 'bg-green-500/10 text-green-700 dark:text-green-400 border-green-500/20';
+        case 'confirmed':
+            return 'bg-blue-500/10 text-blue-700 dark:text-blue-400 border-blue-500/20';
+        case 'in_progress':
+            return 'bg-orange-500/10 text-orange-700 dark:text-orange-400 border-orange-500/20';
+        case 'completed':
+            return 'bg-gray-500/10 text-gray-700 dark:text-gray-400 border-gray-500/20';
+        case 'cancelled':
+            return 'bg-red-500/10 text-red-700 dark:text-red-400 border-red-500/20';
+        default:
+            return 'bg-gray-500/10 text-gray-700 dark:text-gray-400 border-gray-500/20';
+    }
+};
+
+export const getMatchStatusText = (status: string): string => {
+    switch (status) {
+        case 'available':
+            return 'Disponible';
+        case 'confirmed':
+            return 'Confirmado';
+        case 'in_progress':
+            return 'En Vivo';
+        case 'completed':
+            return 'Completado';
+        case 'cancelled':
+            return 'Cancelado';
+        default:
+            return status;
+    }
+};
+
+export const formatMatchDate = (dateString: string): string => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('es-ES', {
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+    });
+};
+
+export const formatMatchTime = (dateString: string): string => {
+    const date = new Date(dateString);
+    return date.toLocaleTimeString('es-ES', {
+        hour: 'numeric',
+        minute: '2-digit',
+    });
+};

--- a/resources/js/pages/matches/show.tsx
+++ b/resources/js/pages/matches/show.tsx
@@ -1,9 +1,16 @@
 import { AvailabilityPanel } from '@/components/availability-panel';
 import { AvailabilitySelector } from '@/components/availability-selector';
-import { CreateMatchRequestDialog } from '@/components/create-match-request-dialog';
-import { GoalScorersList } from '@/components/goal-scorers-list';
-import { RecordGoalDialog } from '@/components/record-goal-dialog';
-import { TeamAvatar } from '@/components/team-avatar';
+import { CompleteMatchDialog } from '@/components/match/complete-match-dialog';
+import { MatchHero } from '@/components/match/match-hero';
+import { MatchRequestsCard } from '@/components/match/match-requests-card';
+import { OpposingLeadersCard } from '@/components/match/opposing-leaders-card';
+import type {
+    LineupPlayer,
+    MatchEvent,
+    MatchPageMatch,
+    MatchPageTeam,
+    OpposingTeamLeader,
+} from '@/components/match/types';
 import {
     AlertDialog,
     AlertDialogAction,
@@ -14,7 +21,6 @@ import {
     AlertDialogHeader,
     AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
     Card,
@@ -23,10 +29,6 @@ import {
     CardHeader,
     CardTitle,
 } from '@/components/ui/card';
-import { Separator } from '@/components/ui/separator';
-import { UserAvatar } from '@/components/user-avatar';
-import { UserNameLink } from '@/components/user-name-link';
-import { VariantBadge } from '@/components/variant-badge';
 import AppLayout from '@/layouts/app-layout';
 import matchRequests from '@/routes/match-requests';
 import matches from '@/routes/matches';
@@ -36,102 +38,16 @@ import type {
     MatchAvailability,
 } from '@/types';
 import { Head, Link, router, usePage } from '@inertiajs/react';
-import {
-    AlertCircle,
-    Calendar,
-    Clock,
-    Edit,
-    MapPin,
-    Phone,
-    Plus,
-    Shield,
-    Swords,
-    Target,
-    Trophy,
-    Users,
-    X,
-} from 'lucide-react';
+import { Users } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
-interface Team {
-    id: number;
-    name: string;
-    variant: string;
-    logo_url?: string;
-    team_members?: Array<{
-        id: number;
-        user: {
-            id: number;
-            name: string;
-        };
-    }>;
-}
-
-interface User {
-    id: number;
-    name: string;
-}
-
-interface LineupPlayer {
-    id: number;
-    user_id: number;
-    user: User;
-}
-
-interface MatchEvent {
-    id: number;
-    team_id: number;
-    user_id?: number;
-    user?: User;
-    event_type: string;
-    minute?: number;
-    description?: string;
-}
-
-interface MatchRequest {
-    id: number;
-    requesting_team_id: number;
-    status: string;
-    message?: string;
-    requesting_team: Team;
-}
-
-interface Match {
-    id: number;
-    home_team_id: number;
-    away_team_id?: number;
-    tournament_id?: number;
-    variant: string;
-    scheduled_at: string;
-    location: string;
-    match_type: string;
-    status: string;
-    home_score?: number;
-    away_score?: number;
-    notes?: string;
-    home_team: Team;
-    away_team?: Team;
-    match_requests?: MatchRequest[];
-}
-
-interface OpposingTeamLeader {
-    id: number;
-    user_id: number;
-    role: string;
-    user: {
-        id: number;
-        name: string;
-        phone_number?: string;
-    };
-}
-
 interface Props {
-    match: Match;
+    match: MatchPageMatch;
     isHomeLeader: boolean;
     isAwayLeader: boolean;
     isLeader: boolean;
-    eligibleTeams: Team[];
+    eligibleTeams: MatchPageTeam[];
     homeLineup: LineupPlayer[];
     awayLineup: LineupPlayer[];
     events: MatchEvent[];
@@ -143,71 +59,6 @@ interface Props {
     homeAvailabilityStats: AvailabilityStats;
     awayAvailabilityStats: AvailabilityStats | null;
 }
-
-const getStatusColor = (status: string): string => {
-    switch (status) {
-        case 'available':
-            return 'bg-green-500/10 text-green-700 dark:text-green-400 border-green-500/20';
-        case 'confirmed':
-            return 'bg-blue-500/10 text-blue-700 dark:text-blue-400 border-blue-500/20';
-        case 'in_progress':
-            return 'bg-orange-500/10 text-orange-700 dark:text-orange-400 border-orange-500/20';
-        case 'completed':
-            return 'bg-gray-500/10 text-gray-700 dark:text-gray-400 border-gray-500/20';
-        case 'cancelled':
-            return 'bg-red-500/10 text-red-700 dark:text-red-400 border-red-500/20';
-        default:
-            return 'bg-gray-500/10 text-gray-700 dark:text-gray-400 border-gray-500/20';
-    }
-};
-
-const getStatusText = (status: string): string => {
-    switch (status) {
-        case 'available':
-            return 'Disponible';
-        case 'confirmed':
-            return 'Confirmado';
-        case 'in_progress':
-            return 'En Vivo';
-        case 'completed':
-            return 'Completado';
-        case 'cancelled':
-            return 'Cancelado';
-        default:
-            return status;
-    }
-};
-
-const formatDate = (dateString: string): string => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('es-ES', {
-        weekday: 'long',
-        month: 'long',
-        day: 'numeric',
-        year: 'numeric',
-    });
-};
-
-const formatTime = (dateString: string): string => {
-    const date = new Date(dateString);
-    return date.toLocaleTimeString('es-ES', {
-        hour: 'numeric',
-        minute: '2-digit',
-    });
-};
-
-const formatPhoneForWhatsApp = (phone: string): string => {
-    // Remove all non-digit characters except +
-    const cleaned = phone.replace(/[^\d+]/g, '');
-    // If it doesn't start with +, assume it's a local number and add country code
-    // For now, we'll just return the cleaned number
-    return cleaned;
-};
-
-const getWhatsAppUrl = (phone: string): string => {
-    const formatted = formatPhoneForWhatsApp(phone);
-    return `https://wa.me/${formatted}`;
-};
 
 export default function Show({
     match,
@@ -230,74 +81,6 @@ export default function Show({
         .props;
     const [showCancelDialog, setShowCancelDialog] = useState(false);
     const [showCompleteDialog, setShowCompleteDialog] = useState(false);
-
-    const [countdown, setCountdown] = useState<string>('');
-    const [matchHasStarted, setMatchHasStarted] = useState(false);
-    const [recordGoalDialog, setRecordGoalDialog] = useState<{
-        open: boolean;
-        team: 'home' | 'away' | null;
-    }>({ open: false, team: null });
-
-    // Calculate registered goals for each team
-    const homeRegisteredGoals = events.filter(
-        (e) =>
-            Number(e.team_id) === Number(match.home_team.id) &&
-            e.event_type === 'goal',
-    ).length;
-    const awayRegisteredGoals = match.away_team
-        ? events.filter(
-              (e) =>
-                  match.away_team &&
-                  Number(e.team_id) === Number(match.away_team.id) &&
-                  e.event_type === 'goal',
-          ).length
-        : 0;
-
-    // Check if match time has been reached and calculate countdown
-    useEffect(() => {
-        const updateCountdown = () => {
-            const matchTime = new Date(match.scheduled_at);
-            const currentTime = new Date();
-            const timeDiff = matchTime.getTime() - currentTime.getTime();
-
-            if (timeDiff <= 0) {
-                setMatchHasStarted(true);
-                setCountdown('');
-                return;
-            }
-
-            setMatchHasStarted(false);
-
-            // Calculate time units
-            const days = Math.floor(timeDiff / (1000 * 60 * 60 * 24));
-            const hours = Math.floor(
-                (timeDiff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60),
-            );
-            const minutes = Math.floor(
-                (timeDiff % (1000 * 60 * 60)) / (1000 * 60),
-            );
-            const seconds = Math.floor((timeDiff % (1000 * 60)) / 1000);
-
-            // Format countdown string
-            if (days > 0) {
-                setCountdown(`${days}d ${hours}h ${minutes}m`);
-            } else if (hours > 0) {
-                setCountdown(`${hours}h ${minutes}m`);
-            } else if (minutes > 0) {
-                setCountdown(`${minutes}m ${seconds}s`);
-            } else {
-                setCountdown(`${seconds}s`);
-            }
-        };
-
-        // Update immediately
-        updateCountdown();
-
-        // Update every second
-        const interval = setInterval(updateCountdown, 1000);
-
-        return () => clearInterval(interval);
-    }, [match.scheduled_at]);
 
     const breadcrumbs: BreadcrumbItem[] = [
         {
@@ -385,18 +168,6 @@ export default function Show({
         );
     };
 
-    const homeScore = match.home_score ?? 0;
-    const awayScore = match.away_score ?? 0;
-
-    // Check for score/goal mismatch (safety net)
-    const hasScoreMismatch =
-        homeRegisteredGoals !== homeScore ||
-        (match.away_team && awayRegisteredGoals !== awayScore);
-
-    // Tournament draw check
-    const isTournamentDraw =
-        match.tournament_id && homeScore === awayScore;
-
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head
@@ -404,513 +175,46 @@ export default function Show({
             />
 
             <div className="flex h-full flex-1 flex-col gap-6 overflow-auto p-4 md:p-6">
-                {/* Hero Section - Match Header */}
-                <div className="relative overflow-hidden rounded-xl border bg-gradient-to-br from-background via-background to-muted/20 p-6 md:p-8">
-                    <div className="absolute top-0 right-0 -mt-16 -mr-16 h-64 w-64 rounded-full bg-primary/5 blur-3xl" />
-                    <div className="absolute bottom-0 left-0 -mb-16 -ml-16 h-64 w-64 rounded-full bg-primary/5 blur-3xl" />
-
-                    <div className="relative">
-                        {/* Insignias de Estado */}
-                        <div className="mb-4 flex flex-wrap items-center gap-2">
-                            <Badge className={getStatusColor(match.status)}>
-                                {getStatusText(match.status)}
-                            </Badge>
-                            <VariantBadge variant={match.variant} />
-                            <Badge variant="outline">
-                                {match.match_type === 'friendly'
-                                    ? 'Amistoso'
-                                    : 'Competitivo'}
-                            </Badge>
-                        </div>
-
-                        {/* Enfrentamiento */}
-                        <div className="grid grid-cols-1 items-center gap-6 md:grid-cols-[1fr,auto,1fr]">
-                            {/* Equipo Local */}
-                            <div className="flex flex-col items-center md:items-end">
-                                <Link
-                                    href={`/teams/${match.home_team.id}`}
-                                    className="group flex flex-col items-center gap-3 rounded-lg p-4 transition-colors hover:bg-muted/50 md:flex-row md:justify-end"
-                                >
-                                    <TeamAvatar
-                                        name={match.home_team.name}
-                                        logoUrl={match.home_team.logo_url}
-                                        size="lg"
-                                        className="h-20 w-20"
-                                    />
-                                    <div className="text-center md:text-right">
-                                        <h2 className="text-2xl font-bold">
-                                            {match.home_team.name}
-                                        </h2>
-                                        <div className="mt-1 flex items-center justify-center gap-1 md:justify-end">
-                                            <Shield className="h-4 w-4 text-muted-foreground" />
-                                            <p className="text-sm text-muted-foreground">
-                                                Local
-                                            </p>
-                                        </div>
-                                    </div>
-                                </Link>
-                                {(match.status === 'in_progress' ||
-                                    match.status === 'completed') && (
-                                    <GoalScorersList
-                                        events={events}
-                                        teamId={match.home_team.id}
-                                        isLeader={isHomeLeader}
-                                        alignment="right"
-                                        matchStatus={match.status}
-                                        onRecordGoal={() =>
-                                            setRecordGoalDialog({
-                                                open: true,
-                                                team: 'home',
-                                            })
-                                        }
-                                    />
-                                )}
-                            </div>
-
-                            {/* Marcador Integrado */}
-                            <div className="flex flex-col items-center justify-center gap-3">
-                                {match.status === 'confirmed' ||
-                                match.status === 'in_progress' ||
-                                match.status === 'completed' ? (
-                                    <>
-                                        {/* Countdown Timer */}
-                                        {!matchHasStarted &&
-                                            countdown &&
-                                            match.status !== 'completed' && (
-                                                <div className="flex items-center gap-1.5 rounded-full border bg-card/80 px-3 py-1 text-xs backdrop-blur-sm">
-                                                    <Clock className="h-3 w-3 text-muted-foreground" />
-                                                    <span className="font-medium">
-                                                        {countdown}
-                                                    </span>
-                                                </div>
-                                            )}
-
-                                        {/* Score Display */}
-                                        <div className="rounded-xl border bg-card/80 px-4 py-3 shadow-lg backdrop-blur-sm md:px-6">
-                                            <div className="flex items-center gap-3 md:gap-4">
-                                                {/* Home Score */}
-                                                <div className="flex items-center gap-2">
-                                                    {isHomeLeader &&
-                                                        match.status !==
-                                                            'completed' &&
-                                                        matchHasStarted && (
-                                                            <Button
-                                                                variant="ghost"
-                                                                size="icon"
-                                                                className="h-7 w-7 rounded-full"
-                                                                onClick={() =>
-                                                                    setRecordGoalDialog(
-                                                                        {
-                                                                            open: true,
-                                                                            team: 'home',
-                                                                        },
-                                                                    )
-                                                                }
-                                                            >
-                                                                <Plus className="h-3.5 w-3.5" />
-                                                            </Button>
-                                                        )}
-                                                    <div
-                                                        className={`flex h-12 w-12 items-center justify-center rounded-lg text-3xl font-bold md:h-14 md:w-14 ${
-                                                            match.status ===
-                                                                'completed' &&
-                                                            homeScore >
-                                                                awayScore
-                                                                ? 'text-primary'
-                                                                : ''
-                                                        }`}
-                                                    >
-                                                        {homeScore}
-                                                    </div>
-                                                </div>
-
-                                                <span className="text-xl font-bold text-muted-foreground md:text-2xl">
-                                                    -
-                                                </span>
-
-                                                {/* Away Score */}
-                                                <div className="flex items-center gap-2">
-                                                    <div
-                                                        className={`flex h-12 w-12 items-center justify-center rounded-lg text-3xl font-bold md:h-14 md:w-14 ${
-                                                            match.status ===
-                                                                'completed' &&
-                                                            awayScore >
-                                                                homeScore
-                                                                ? 'text-primary'
-                                                                : ''
-                                                        }`}
-                                                    >
-                                                        {awayScore}
-                                                    </div>
-                                                    {isAwayLeader &&
-                                                        match.status !==
-                                                            'completed' &&
-                                                        matchHasStarted && (
-                                                            <Button
-                                                                variant="ghost"
-                                                                size="icon"
-                                                                className="h-7 w-7 rounded-full"
-                                                                onClick={() =>
-                                                                    setRecordGoalDialog(
-                                                                        {
-                                                                            open: true,
-                                                                            team: 'away',
-                                                                        },
-                                                                    )
-                                                                }
-                                                            >
-                                                                <Plus className="h-3.5 w-3.5" />
-                                                            </Button>
-                                                        )}
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </>
-                                ) : (
-                                    <div className="rounded-full border bg-card p-4 shadow-sm">
-                                        <Swords className="h-8 w-8 text-muted-foreground" />
-                                    </div>
-                                )}
-                            </div>
-
-                            {/* Equipo Visitante */}
-                            <div className="flex flex-col items-center md:items-start">
-                                {match.away_team ? (
-                                    <Link
-                                        href={`/teams/${match.away_team.id}`}
-                                        className="group flex flex-col items-center gap-3 rounded-lg p-4 transition-colors hover:bg-muted/50 md:flex-row"
-                                    >
-                                        <TeamAvatar
-                                            name={match.away_team.name}
-                                            logoUrl={match.away_team.logo_url}
-                                            size="lg"
-                                            className="h-20 w-20"
-                                        />
-                                        <div className="text-center md:text-left">
-                                            <h2 className="text-2xl font-bold">
-                                                {match.away_team.name}
-                                            </h2>
-                                            <p className="mt-1 text-sm text-muted-foreground">
-                                                Visitante
-                                            </p>
-                                        </div>
-                                    </Link>
-                                ) : (
-                                    <div className="flex flex-col items-center gap-3 rounded-lg border-2 border-dashed bg-muted/30 p-6 md:flex-row">
-                                        <div className="rounded-full bg-muted p-4">
-                                            <Users className="h-8 w-8 text-muted-foreground" />
-                                        </div>
-                                        <div className="text-center md:text-left">
-                                            <h3 className="text-lg font-semibold">
-                                                Buscando Rival
-                                            </h3>
-                                            <p className="text-sm text-muted-foreground">
-                                                Esperando solicitudes de equipos
-                                            </p>
-                                        </div>
-                                    </div>
-                                )}
-                                {(match.status === 'in_progress' ||
-                                    match.status === 'completed') &&
-                                    match.away_team && (
-                                        <GoalScorersList
-                                            events={events}
-                                            teamId={match.away_team.id}
-                                            isLeader={isAwayLeader}
-                                            alignment="left"
-                                            matchStatus={match.status}
-                                            onRecordGoal={() =>
-                                                setRecordGoalDialog({
-                                                    open: true,
-                                                    team: 'away',
-                                                })
-                                            }
-                                        />
-                                    )}
-                            </div>
-                        </div>
-
-                        {/* Información del Partido */}
-                        <div className="mt-6 flex flex-wrap items-center justify-center gap-6 text-sm">
-                            <div className="flex items-center gap-2">
-                                <Calendar className="h-4 w-4 text-muted-foreground" />
-                                <span className="font-medium">
-                                    {formatDate(match.scheduled_at)}
-                                </span>
-                            </div>
-                            <Separator orientation="vertical" className="h-4" />
-                            <div className="flex items-center gap-2">
-                                <Clock className="h-4 w-4 text-muted-foreground" />
-                                <span className="font-medium">
-                                    {formatTime(match.scheduled_at)}
-                                </span>
-                            </div>
-                            <Separator orientation="vertical" className="h-4" />
-                            <div className="flex items-center gap-2">
-                                <MapPin className="h-4 w-4 text-muted-foreground" />
-                                <span className="font-medium">
-                                    {match.location}
-                                </span>
-                            </div>
-                        </div>
-
-                        {/* Botones de Acción */}
-                        <div className="mt-6 flex flex-wrap justify-center gap-3">
-                            {isHomeLeader && match.status === 'available' && (
-                                <>
-                                    <Button asChild variant="outline">
-                                        <Link href={matches.edit(match.id).url}>
-                                            <Edit className="mr-2 h-4 w-4" />
-                                            Editar
-                                        </Link>
-                                    </Button>
-                                    <Button
-                                        variant="destructive"
-                                        onClick={() =>
-                                            setShowCancelDialog(true)
-                                        }
-                                    >
-                                        <X className="mr-2 h-4 w-4" />
-                                        Cancelar Partido
-                                    </Button>
-                                </>
-                            )}
-                            {isLeader && match.status === 'in_progress' && (
-                                <Button
-                                    onClick={() => setShowCompleteDialog(true)}
-                                    disabled={!matchHasStarted}
-                                    title={
-                                        !matchHasStarted
-                                            ? 'No se puede completar el partido antes de que comience'
-                                            : ''
-                                    }
-                                >
-                                    <Trophy className="mr-2 h-4 w-4" />
-                                    Completar Partido
-                                </Button>
-                            )}
-                            {!isLeader &&
-                                match.status === 'available' &&
-                                eligibleTeams.length > 0 && (
-                                    <CreateMatchRequestDialog
-                                        matchId={match.id}
-                                        eligibleTeams={eligibleTeams}
-                                    />
-                                )}
-                        </div>
-                    </div>
-                </div>
-
-                {/* Dialog para registrar goles */}
-                <RecordGoalDialog
-                    matchId={match.id}
-                    teamId={
-                        recordGoalDialog.team === 'home'
-                            ? match.home_team.id
-                            : (match.away_team?.id ?? 0)
-                    }
-                    teamName={
-                        recordGoalDialog.team === 'home'
-                            ? match.home_team.name
-                            : (match.away_team?.name ?? '')
-                    }
-                    availablePlayers={
-                        recordGoalDialog.team === 'home'
-                            ? homeLineup
-                            : awayLineup
-                    }
-                    open={recordGoalDialog.open}
-                    onOpenChange={(open) =>
-                        setRecordGoalDialog((prev) => ({ ...prev, open }))
-                    }
+                <MatchHero
+                    match={match}
+                    isHomeLeader={isHomeLeader}
+                    isAwayLeader={isAwayLeader}
+                    isLeader={isLeader}
+                    eligibleTeams={eligibleTeams}
+                    homeLineup={homeLineup}
+                    awayLineup={awayLineup}
+                    events={events}
+                    onCancelClick={() => setShowCancelDialog(true)}
+                    onCompleteClick={() => setShowCompleteDialog(true)}
                 />
 
-                {/* Contenido Principal */}
                 <div className="grid gap-6 lg:grid-cols-3">
-                    {/* Columna Izquierda - Contenido Principal */}
+                    {/* Main column */}
                     <div className="space-y-6 lg:col-span-2">
-                        {/* Solicitudes de Partido */}
                         {isHomeLeader &&
                             match.status === 'available' &&
                             match.match_requests &&
                             match.match_requests.length > 0 && (
-                                <Card>
-                                    <CardHeader>
-                                        <CardTitle>
-                                            Solicitudes de Partido
-                                        </CardTitle>
-                                        <CardDescription>
-                                            Equipos interesados en jugar este
-                                            partido
-                                        </CardDescription>
-                                    </CardHeader>
-                                    <CardContent>
-                                        <div className="space-y-3">
-                                            {match.match_requests.map(
-                                                (request) => (
-                                                    <div
-                                                        key={request.id}
-                                                        className="flex items-start gap-4 rounded-lg border bg-card p-4 transition-colors hover:bg-muted/50"
-                                                    >
-                                                        <TeamAvatar
-                                                            name={
-                                                                request
-                                                                    .requesting_team
-                                                                    .name
-                                                            }
-                                                            logoUrl={
-                                                                request
-                                                                    .requesting_team
-                                                                    .logo_url
-                                                            }
-                                                            size="md"
-                                                        />
-                                                        <div className="min-w-0 flex-1">
-                                                            <p className="font-semibold">
-                                                                {
-                                                                    request
-                                                                        .requesting_team
-                                                                        .name
-                                                                }
-                                                            </p>
-                                                            {request.message && (
-                                                                <p className="mt-1 text-sm text-muted-foreground">
-                                                                    {
-                                                                        request.message
-                                                                    }
-                                                                </p>
-                                                            )}
-                                                            <div className="mt-3 flex gap-2">
-                                                                <Button
-                                                                    size="sm"
-                                                                    onClick={() =>
-                                                                        handleAcceptRequest(
-                                                                            request.id,
-                                                                        )
-                                                                    }
-                                                                >
-                                                                    Aceptar
-                                                                </Button>
-                                                                <Button
-                                                                    size="sm"
-                                                                    variant="outline"
-                                                                    onClick={() =>
-                                                                        handleRejectRequest(
-                                                                            request.id,
-                                                                        )
-                                                                    }
-                                                                >
-                                                                    Rechazar
-                                                                </Button>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                ),
-                                            )}
-                                        </div>
-                                    </CardContent>
-                                </Card>
+                                <MatchRequestsCard
+                                    requests={match.match_requests}
+                                    onAccept={handleAcceptRequest}
+                                    onReject={handleRejectRequest}
+                                />
                             )}
 
-                        {/* Contacto del Equipo Rival */}
                         {isLeader &&
                             (match.status === 'confirmed' ||
                                 match.status === 'in_progress' ||
                                 match.status === 'completed') &&
                             opposingTeamLeaders.length > 0 && (
-                                <Card>
-                                    <CardHeader>
-                                        <CardTitle>
-                                            Contacto del Equipo Rival
-                                        </CardTitle>
-                                        <CardDescription>
-                                            Coordina los detalles del partido
-                                            con los líderes del equipo oponente
-                                        </CardDescription>
-                                    </CardHeader>
-                                    <CardContent>
-                                        <div className="space-y-3">
-                                            {opposingTeamLeaders.map(
-                                                (leader) => (
-                                                    <div
-                                                        key={leader.id}
-                                                        className="flex items-center justify-between rounded-lg border bg-card p-4"
-                                                    >
-                                                        <div className="flex items-center gap-3">
-                                                            <UserAvatar
-                                                                name={
-                                                                    leader.user
-                                                                        .name
-                                                                }
-                                                                size="sm"
-                                                            />
-                                                            <div>
-                                                                <p className="font-medium">
-                                                                    <UserNameLink
-                                                                        user={
-                                                                            leader.user
-                                                                        }
-                                                                    />
-                                                                </p>
-                                                                <div className="mt-1 flex items-center gap-2">
-                                                                    <Badge
-                                                                        variant="outline"
-                                                                        className="text-xs"
-                                                                    >
-                                                                        {leader.role ===
-                                                                        'captain'
-                                                                            ? 'Capitán'
-                                                                            : 'Subcapitán'}
-                                                                    </Badge>
-                                                                    {leader.user
-                                                                        .phone_number && (
-                                                                        <div className="flex items-center gap-1 text-sm text-muted-foreground">
-                                                                            <Phone className="h-3 w-3" />
-                                                                            <span>
-                                                                                {
-                                                                                    leader
-                                                                                        .user
-                                                                                        .phone_number
-                                                                                }
-                                                                            </span>
-                                                                        </div>
-                                                                    )}
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                        {leader.user
-                                                            .phone_number && (
-                                                            <Button
-                                                                asChild
-                                                                variant="outline"
-                                                                size="sm"
-                                                            >
-                                                                <a
-                                                                    href={getWhatsAppUrl(
-                                                                        leader
-                                                                            .user
-                                                                            .phone_number,
-                                                                    )}
-                                                                    target="_blank"
-                                                                    rel="noopener noreferrer"
-                                                                >
-                                                                    <Phone className="mr-2 h-4 w-4" />
-                                                                    WhatsApp
-                                                                </a>
-                                                            </Button>
-                                                        )}
-                                                    </div>
-                                                ),
-                                            )}
-                                        </div>
-                                    </CardContent>
-                                </Card>
+                                <OpposingLeadersCard
+                                    leaders={opposingTeamLeaders}
+                                />
                             )}
                     </div>
 
-                    {/* Columna Derecha - Barra Lateral */}
+                    {/* Sidebar */}
                     <div className="space-y-6">
-                        {/* Selector de Disponibilidad */}
                         {(match.status === 'confirmed' ||
                             match.status === 'available') &&
                             userTeamId && (
@@ -922,7 +226,6 @@ export default function Show({
                                 />
                             )}
 
-                        {/* Panel de Disponibilidad Consolidado */}
                         {(match.status === 'confirmed' ||
                             match.status === 'available') &&
                             homeAvailabilityStats && (
@@ -947,7 +250,6 @@ export default function Show({
                                 />
                             )}
 
-                        {/* Gestión de Alineación */}
                         {isLeader &&
                             (match.status === 'confirmed' ||
                                 match.status === 'in_progress') && (
@@ -1020,7 +322,6 @@ export default function Show({
                 </div>
             </div>
 
-            {/* Diálogo de Cancelación */}
             <AlertDialog
                 open={showCancelDialog}
                 onOpenChange={setShowCancelDialog}
@@ -1046,168 +347,13 @@ export default function Show({
                 </AlertDialogContent>
             </AlertDialog>
 
-            {/* Diálogo de Finalización */}
-            <AlertDialog
+            <CompleteMatchDialog
                 open={showCompleteDialog}
                 onOpenChange={setShowCompleteDialog}
-            >
-                <AlertDialogContent className="max-w-md">
-                    <AlertDialogHeader>
-                        <AlertDialogTitle>Completar Partido</AlertDialogTitle>
-                        <AlertDialogDescription asChild>
-                            <div className="space-y-4">
-                                <p>
-                                    ¿Estás seguro de que quieres marcar este
-                                    partido como completado?
-                                </p>
-
-                                {/* Score Summary */}
-                                <div className="rounded-lg border bg-muted/50 p-4">
-                                    <div className="flex items-center justify-center gap-4 text-lg font-bold">
-                                        <span>
-                                            {match.home_team.name}
-                                        </span>
-                                        <span className="rounded-md bg-background px-3 py-1 text-2xl">
-                                            {homeScore} - {awayScore}
-                                        </span>
-                                        <span>
-                                            {match.away_team?.name}
-                                        </span>
-                                    </div>
-
-                                    {/* Goal scorers */}
-                                    {events.filter(
-                                        (e) => e.event_type === 'goal',
-                                    ).length > 0 && (
-                                        <div className="mt-3 grid grid-cols-2 gap-4 border-t pt-3">
-                                            <div className="space-y-1">
-                                                {events
-                                                    .filter(
-                                                        (e) =>
-                                                            Number(
-                                                                e.team_id,
-                                                            ) ===
-                                                                Number(
-                                                                    match
-                                                                        .home_team
-                                                                        .id,
-                                                                ) &&
-                                                            e.event_type ===
-                                                                'goal',
-                                                    )
-                                                    .sort(
-                                                        (a, b) =>
-                                                            (a.minute || 0) -
-                                                            (b.minute || 0),
-                                                    )
-                                                    .map((goal) => (
-                                                        <div
-                                                            key={goal.id}
-                                                            className="flex items-center gap-1.5 text-xs"
-                                                        >
-                                                            <Target className="h-3 w-3 text-green-600" />
-                                                            <span className="truncate">
-                                                                {goal.user
-                                                                    ?.name ||
-                                                                    'Sin asignar'}
-                                                            </span>
-                                                            {goal.minute && (
-                                                                <span className="text-muted-foreground">
-                                                                    {
-                                                                        goal.minute
-                                                                    }
-                                                                    '
-                                                                </span>
-                                                            )}
-                                                        </div>
-                                                    ))}
-                                            </div>
-                                            <div className="space-y-1">
-                                                {events
-                                                    .filter(
-                                                        (e) =>
-                                                            match.away_team &&
-                                                            Number(
-                                                                e.team_id,
-                                                            ) ===
-                                                                Number(
-                                                                    match
-                                                                        .away_team
-                                                                        .id,
-                                                                ) &&
-                                                            e.event_type ===
-                                                                'goal',
-                                                    )
-                                                    .sort(
-                                                        (a, b) =>
-                                                            (a.minute || 0) -
-                                                            (b.minute || 0),
-                                                    )
-                                                    .map((goal) => (
-                                                        <div
-                                                            key={goal.id}
-                                                            className="flex items-center gap-1.5 text-xs"
-                                                        >
-                                                            <Target className="h-3 w-3 text-green-600" />
-                                                            <span className="truncate">
-                                                                {goal.user
-                                                                    ?.name ||
-                                                                    'Sin asignar'}
-                                                            </span>
-                                                            {goal.minute && (
-                                                                <span className="text-muted-foreground">
-                                                                    {
-                                                                        goal.minute
-                                                                    }
-                                                                    '
-                                                                </span>
-                                                            )}
-                                                        </div>
-                                                    ))}
-                                            </div>
-                                        </div>
-                                    )}
-                                </div>
-
-                                {/* Warnings */}
-                                {homeScore === 0 &&
-                                    awayScore === 0 && (
-                                        <div className="flex items-center gap-2 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-700 dark:text-yellow-400">
-                                            <AlertCircle className="h-4 w-4 flex-shrink-0" />
-                                            El partido terminará 0 - 0
-                                        </div>
-                                    )}
-
-                                {hasScoreMismatch && (
-                                    <div className="flex items-center gap-2 rounded-md border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-700 dark:text-yellow-400">
-                                        <AlertCircle className="h-4 w-4 flex-shrink-0" />
-                                        Los goles registrados no coinciden con
-                                        el marcador
-                                    </div>
-                                )}
-
-                                {isTournamentDraw && (
-                                    <div className="flex items-center gap-2 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-700 dark:text-red-400">
-                                        <AlertCircle className="h-4 w-4 flex-shrink-0" />
-                                        Los partidos de torneo no pueden
-                                        terminar en empate. Actualiza el
-                                        marcador.
-                                    </div>
-                                )}
-                            </div>
-                        </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                        <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                        <AlertDialogAction
-                            onClick={handleCompleteMatch}
-                            disabled={!!isTournamentDraw}
-                        >
-                            Completar Partido
-                        </AlertDialogAction>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
+                match={match}
+                events={events}
+                onConfirm={handleCompleteMatch}
+            />
         </AppLayout>
     );
 }


### PR DESCRIPTION
## Summary
- Cuts the match detail page from **1207 → 359 lines** (-70%) by splitting it into focused subcomponents under \`resources/js/components/match/\`. Pure decomposition — no behavior changes, no styling tweaks, no logic moves beyond what's needed to draw module boundaries.
- New \`resources/js/components/match/\` folder mirrors the existing \`tournament/\` convention:
  - \`types.ts\` — page-local enriched \`MatchPageMatch\`/\`MatchPageTeam\`/\`MatchEvent\`/\`MatchRequest\`/\`OpposingTeamLeader\`/\`LineupPlayer\` (kept separate from the global \`FootballMatch\` because show.tsx requires \`home_team\` and eagerly-loaded members)
  - \`match-hero.tsx\` — status badges, both team panels, integrated score + countdown, info row, action buttons row, plus the colocated \`RecordGoalDialog\` state (only used here)
  - \`match-requests-card.tsx\` — home leader's incoming match-request list
  - \`opposing-leaders-card.tsx\` — contact card; the small WhatsApp URL helper is colocated here since it has no other consumer
  - \`complete-match-dialog.tsx\` — the 156-line dialog with goal breakdown, score-mismatch warning, tournament-draw guard. Now self-contained: takes \`match\`/\`events\`/\`onConfirm\`, computes its own derived values.
- New \`resources/js/lib/match-format.ts\` for the status colour/text and date/time helpers, prefixed \`match\` so they're reusable by other match surfaces (dashboard match cards, etc.) later.
- The inline \`useEffect\` countdown is replaced by the existing \`useMatchCountdown\` hook at \`hooks/use-match-countdown.ts\`, which already encoded the exact same logic and was previously unused.

\`show.tsx\` retains: layout shell, breadcrumb, flash toast effect, the four action handlers (accept/reject/cancel/complete), the small cancel \`AlertDialog\`, and the sidebar (which is already composed of existing \`AvailabilitySelector\`/\`AvailabilityPanel\` components).

### Why this matters
- The page is the largest in the app and was the next most likely place to grow bugs. The split makes future polish work — applying the same hero/AlertDialog patterns we landed in #79 — easier to do in isolation.
- Sets up reuse: \`match-format.ts\` can now feed dashboard cards; \`MatchHero\` could be reused on a public match preview if/when that ships.

## Test plan
- [x] \`bun run types\` — clean
- [x] \`bun run lint\` — clean
- [x] \`composer test\` — 297 passed, 1284 assertions
- [ ] Open a confirmed match — hero, score, countdown, info row all render identically
- [ ] As home leader, click cancel on an available match — dialog opens, cancel works
- [ ] As any leader during \`in_progress\`, click complete — dialog shows score, scorers, warnings; tournament-draw block still gates the confirm button
- [ ] As home leader on an available match with pending requests — accept/reject buttons still trigger toasts
- [ ] As either leader on a confirmed/in-progress/completed match with opponent leader phone numbers — WhatsApp link still opens correctly