### PR TITLE
fix: re-land polish sweep (error toasts, confirm dialogs, aria-labels)

### DIFF
--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -197,6 +197,7 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                                 variant="ghost"
                                 size="icon"
                                 className="group h-9 w-9 cursor-pointer"
+                                aria-label="Buscar"
                             >
                                 <Search className="!size-5 opacity-80 group-hover:opacity-100" />
                             </Button>

--- a/resources/js/components/create-team-modal.tsx
+++ b/resources/js/components/create-team-modal.tsx
@@ -22,6 +22,7 @@ import { useForm } from '@inertiajs/react';
 import { Plus } from 'lucide-react';
 import type { FormEventHandler, ReactNode } from 'react';
 import { useState } from 'react';
+import { toast } from 'sonner';
 
 interface Props {
     trigger?: ReactNode;
@@ -42,6 +43,7 @@ export function CreateTeamModal({ trigger }: Props) {
                 setOpen(false);
                 reset();
             },
+            onError: () => toast.error('Error al crear el equipo'),
         });
     };
 

--- a/resources/js/components/goal-scorers-list.tsx
+++ b/resources/js/components/goal-scorers-list.tsx
@@ -1,8 +1,19 @@
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import matchEvents from '@/routes/match-events';
 import { router } from '@inertiajs/react';
 import { Pencil, Target, Trash2 } from 'lucide-react';
+import { useState } from 'react';
 import { toast } from 'sonner';
 
 interface User {
@@ -37,6 +48,8 @@ export function GoalScorersList({
     matchStatus,
     onRecordGoal,
 }: GoalScorersListProps) {
+    const [goalToDelete, setGoalToDelete] = useState<number | null>(null);
+
     // Ensure type consistency by converting both to numbers for comparison
     const goals = events
         .filter(
@@ -45,12 +58,15 @@ export function GoalScorersList({
         )
         .sort((a, b) => (a.minute || 0) - (b.minute || 0));
 
-    const handleDeleteEvent = (eventId: number) => {
-        router.delete(matchEvents.destroy(eventId).url, {
+    const handleDeleteEvent = () => {
+        if (goalToDelete === null) return;
+        router.delete(matchEvents.destroy(goalToDelete).url, {
             onSuccess: () => {
+                setGoalToDelete(null);
                 toast.success('Gol eliminado exitosamente');
             },
             onError: () => {
+                setGoalToDelete(null);
                 toast.error('Error al eliminar el gol');
             },
         });
@@ -61,73 +77,102 @@ export function GoalScorersList({
     }
 
     return (
-        <div
-            className={cn(
-                'mt-2 max-h-28 space-y-1 overflow-y-auto',
-                alignment === 'right' ? 'text-right' : 'text-left',
-            )}
-        >
-            {goals.map((goal) => (
-                <div
-                    key={goal.id}
-                    className={cn(
-                        'group flex items-center gap-1.5 text-xs',
-                        alignment === 'right'
-                            ? 'flex-row-reverse justify-start'
-                            : 'flex-row justify-start',
-                    )}
-                >
-                    <Target className="h-3 w-3 flex-shrink-0 text-green-600" />
-                    <span
-                        className={cn(
-                            'truncate',
-                            !goal.user && 'text-muted-foreground italic',
-                        )}
-                    >
-                        {goal.user?.name || 'Sin asignar'}
-                    </span>
-                    <span className="text-muted-foreground">
-                        {goal.minute}'
-                    </span>
-                    {isLeader &&
-                        (matchStatus === 'in_progress' ||
-                            matchStatus === 'completed') && (
-                            <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100"
-                                onClick={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    handleDeleteEvent(goal.id);
-                                }}
-                            >
-                                <Trash2 className="h-3 w-3 text-destructive" />
-                            </Button>
-                        )}
-                </div>
-            ))}
-
-            {isLeader &&
-                (matchStatus === 'in_progress' ||
-                    matchStatus === 'completed') && (
-                    <Button
-                        variant="ghost"
-                        size="sm"
-                        className={cn(
-                            'mt-1 h-6 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground',
-                            alignment === 'right' && 'ml-auto',
-                        )}
-                        onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            onRecordGoal?.();
-                        }}
-                    >
-                        <Pencil className="h-3 w-3" />
-                        <span>Registrar Gol</span>
-                    </Button>
+        <>
+            <div
+                className={cn(
+                    'mt-2 max-h-28 space-y-1 overflow-y-auto',
+                    alignment === 'right' ? 'text-right' : 'text-left',
                 )}
-        </div>
+            >
+                {goals.map((goal) => (
+                    <div
+                        key={goal.id}
+                        className={cn(
+                            'group flex items-center gap-1.5 text-xs',
+                            alignment === 'right'
+                                ? 'flex-row-reverse justify-start'
+                                : 'flex-row justify-start',
+                        )}
+                    >
+                        <Target className="h-3 w-3 flex-shrink-0 text-green-600" />
+                        <span
+                            className={cn(
+                                'truncate',
+                                !goal.user && 'text-muted-foreground italic',
+                            )}
+                        >
+                            {goal.user?.name || 'Sin asignar'}
+                        </span>
+                        <span className="text-muted-foreground">
+                            {goal.minute}'
+                        </span>
+                        {isLeader &&
+                            (matchStatus === 'in_progress' ||
+                                matchStatus === 'completed') && (
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-4 w-4 opacity-0 transition-opacity group-hover:opacity-100"
+                                    aria-label="Eliminar gol"
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        e.stopPropagation();
+                                        setGoalToDelete(goal.id);
+                                    }}
+                                >
+                                    <Trash2 className="h-3 w-3 text-destructive" />
+                                </Button>
+                            )}
+                    </div>
+                ))}
+
+                {isLeader &&
+                    (matchStatus === 'in_progress' ||
+                        matchStatus === 'completed') && (
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            className={cn(
+                                'mt-1 h-6 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground',
+                                alignment === 'right' && 'ml-auto',
+                            )}
+                            onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                onRecordGoal?.();
+                            }}
+                        >
+                            <Pencil className="h-3 w-3" />
+                            <span>Registrar Gol</span>
+                        </Button>
+                    )}
+            </div>
+
+            <AlertDialog
+                open={goalToDelete !== null}
+                onOpenChange={(open) => {
+                    if (!open) setGoalToDelete(null);
+                }}
+            >
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Eliminar Gol</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            ¿Estás seguro de que quieres eliminar este gol? Esta
+                            acción no se puede deshacer.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                        <AlertDialogAction
+                            onClick={handleDeleteEvent}
+                            className="text-destructive-foreground bg-destructive hover:bg-destructive/90"
+                        >
+                            Eliminar
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </>
     );
 }

--- a/resources/js/components/invite-team-member-modal.tsx
+++ b/resources/js/components/invite-team-member-modal.tsx
@@ -195,6 +195,7 @@ export function InviteTeamMemberModal({ teamId, teamName }: Props) {
                                         size="icon"
                                         onClick={copyToClipboard}
                                         className="shrink-0"
+                                        aria-label="Copiar enlace de invitación"
                                     >
                                         {copied ? (
                                             <Check className="h-4 w-4 text-green-600" />

--- a/resources/js/components/match/match-hero.tsx
+++ b/resources/js/components/match/match-hero.tsx
@@ -166,6 +166,7 @@ export function MatchHero({
                                                             variant="ghost"
                                                             size="icon"
                                                             className="h-7 w-7 rounded-full"
+                                                            aria-label="Registrar gol local"
                                                             onClick={() =>
                                                                 setRecordGoalDialog(
                                                                     {
@@ -215,6 +216,7 @@ export function MatchHero({
                                                             variant="ghost"
                                                             size="icon"
                                                             className="h-7 w-7 rounded-full"
+                                                            aria-label="Registrar gol visitante"
                                                             onClick={() =>
                                                                 setRecordGoalDialog(
                                                                     {

--- a/resources/js/components/score-tracker.tsx
+++ b/resources/js/components/score-tracker.tsx
@@ -169,6 +169,7 @@ export function ScoreTracker({ match, isLeader }: Props) {
                                     variant="outline"
                                     size="icon"
                                     className="h-8 w-8"
+                                    aria-label="Restar gol local"
                                     onClick={decrementHomeScore}
                                     disabled={
                                         processing ||
@@ -187,6 +188,7 @@ export function ScoreTracker({ match, isLeader }: Props) {
                                     variant="outline"
                                     size="icon"
                                     className="h-8 w-8"
+                                    aria-label="Sumar gol local"
                                     onClick={incrementHomeScore}
                                     disabled={processing || !matchHasStarted}
                                 >
@@ -210,6 +212,7 @@ export function ScoreTracker({ match, isLeader }: Props) {
                                     variant="outline"
                                     size="icon"
                                     className="h-8 w-8"
+                                    aria-label="Restar gol visitante"
                                     onClick={decrementAwayScore}
                                     disabled={
                                         processing ||
@@ -228,6 +231,7 @@ export function ScoreTracker({ match, isLeader }: Props) {
                                     variant="outline"
                                     size="icon"
                                     className="h-8 w-8"
+                                    aria-label="Sumar gol visitante"
                                     onClick={incrementAwayScore}
                                     disabled={processing || !matchHasStarted}
                                 >

--- a/resources/js/components/two-factor-setup-modal.tsx
+++ b/resources/js/components/two-factor-setup-modal.tsx
@@ -190,6 +190,7 @@ function TwoFactorSetupStep({
                                     <button
                                         onClick={() => copy(manualSetupKey)}
                                         className="border-l border-border px-3 hover:bg-muted"
+                                        aria-label="Copiar clave de configuración"
                                     >
                                         <IconComponent className="w-4" />
                                     </button>

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -112,6 +112,7 @@ export default function Dashboard({
         router.delete(`/join-requests/${requestId}`, {
             preserveScroll: true,
             onSuccess: () => toast.success('Solicitud cancelada'),
+            onError: () => toast.error('Error al cancelar la solicitud'),
         });
     };
 
@@ -355,6 +356,7 @@ export default function Dashboard({
                                                             )
                                                         }
                                                         title="Cancelar solicitud"
+                                                        aria-label="Cancelar solicitud"
                                                     >
                                                         <X className="h-4 w-4" />
                                                     </Button>

--- a/resources/js/pages/onboarding/phone-number.tsx
+++ b/resources/js/pages/onboarding/phone-number.tsx
@@ -9,6 +9,7 @@ import { User } from '@/types';
 import { Head, router, useForm } from '@inertiajs/react';
 import { Phone, SkipForward } from 'lucide-react';
 import { useState } from 'react';
+import { toast } from 'sonner';
 
 interface Props {
     user: Pick<User, 'name' | 'email' | 'phone_number'>;
@@ -23,7 +24,9 @@ export default function PhoneNumber({ user }: Props) {
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
-        post(update().url);
+        post(update().url, {
+            onError: () => toast.error('Error al guardar el número'),
+        });
     };
 
     const handleSkip = () => {
@@ -33,6 +36,7 @@ export default function PhoneNumber({ user }: Props) {
             {},
             {
                 onFinish: () => setIsSkipping(false),
+                onError: () => toast.error('Error al omitir este paso'),
             },
         );
     };

--- a/resources/js/pages/teams/accept-invitation.tsx
+++ b/resources/js/pages/teams/accept-invitation.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/card';
 import { VariantBadge } from '@/components/variant-badge';
 import { Head, useForm } from '@inertiajs/react';
+import { toast } from 'sonner';
 
 interface Team {
     id: number;
@@ -40,7 +41,9 @@ export default function AcceptInvitation({ invitation, team, inviter }: Props) {
     const { post, processing } = useForm();
 
     const handleAccept = () => {
-        post(`/teams/invite/${invitation.token}/accept`);
+        post(`/teams/invite/${invitation.token}/accept`, {
+            onError: () => toast.error('Error al aceptar la invitación'),
+        });
     };
 
     return (

--- a/resources/js/pages/teams/show.tsx
+++ b/resources/js/pages/teams/show.tsx
@@ -171,6 +171,9 @@ export default function Show({
             (m.role === 'captain' || m.role === 'co_captain'),
     );
     const [showLeaveDialog, setShowLeaveDialog] = useState(false);
+    const [invitationToRevoke, setInvitationToRevoke] = useState<number | null>(
+        null,
+    );
     // Stable "now" reference captured once on mount for relative-time labels.
     const [nowMs] = useState(() => Date.now());
 
@@ -241,14 +244,21 @@ export default function Show({
             .catch(() => toast.error('No se pudo copiar el enlace'));
     };
 
-    const handleRevokeInvitation = (invitationId: number) => {
+    const handleRevokeInvitation = () => {
+        if (invitationToRevoke === null) return;
         router.post(
-            teamInvitations.revoke(invitationId).url,
+            teamInvitations.revoke(invitationToRevoke).url,
             {},
             {
                 preserveScroll: true,
-                onSuccess: () => toast.success('Invitación cancelada'),
-                onError: () => toast.error('Error al cancelar la invitación'),
+                onSuccess: () => {
+                    setInvitationToRevoke(null);
+                    toast.success('Invitación cancelada');
+                },
+                onError: () => {
+                    setInvitationToRevoke(null);
+                    toast.error('Error al cancelar la invitación');
+                },
             },
         );
     };
@@ -718,7 +728,7 @@ export default function Show({
                                                                 size="sm"
                                                                 variant="destructive"
                                                                 onClick={() =>
-                                                                    handleRevokeInvitation(
+                                                                    setInvitationToRevoke(
                                                                         invitation.id,
                                                                     )
                                                                 }
@@ -842,6 +852,36 @@ export default function Show({
                                 className="text-destructive-foreground bg-destructive hover:bg-destructive/90"
                             >
                                 Abandonar Equipo
+                            </AlertDialogAction>
+                        </AlertDialogFooter>
+                    </AlertDialogContent>
+                </AlertDialog>
+
+                {/* Revoke Invitation Confirmation Dialog */}
+                <AlertDialog
+                    open={invitationToRevoke !== null}
+                    onOpenChange={(open) => {
+                        if (!open) setInvitationToRevoke(null);
+                    }}
+                >
+                    <AlertDialogContent>
+                        <AlertDialogHeader>
+                            <AlertDialogTitle>
+                                Cancelar Invitación
+                            </AlertDialogTitle>
+                            <AlertDialogDescription>
+                                ¿Estás seguro de que quieres cancelar esta
+                                invitación? El enlace dejará de funcionar y
+                                deberás enviar una nueva invitación.
+                            </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                            <AlertDialogCancel>Volver</AlertDialogCancel>
+                            <AlertDialogAction
+                                onClick={handleRevokeInvitation}
+                                className="text-destructive-foreground bg-destructive hover:bg-destructive/90"
+                            >
+                                Cancelar Invitación
                             </AlertDialogAction>
                         </AlertDialogFooter>
                     </AlertDialogContent>


### PR DESCRIPTION
## Summary
Re-lands the work from PR #84, which was orphaned when its base branch `refactor/decompose-matches-show` was squash-merged into dev (#83) minutes before #84 merged into that now-obsolete base. The commit never propagated to dev.

This is a clean cherry-pick of `b61908e` onto current dev.

### Changes (11 files)
- **Error toasts (Part D):** added missing `onError` handlers in `create-team-modal`, `accept-invitation`, `dashboard` (cancel join request), and `onboarding/phone-number` (both submit + skip).
- **Confirmation dialogs (Part C):** added AlertDialog guards to goal deletion (`goal-scorers-list`) and team invitation revocation (`teams/show`).
- **Accessibility (Part E):** added `aria-label` to 10 icon-only buttons across score-tracker, match-hero, goal-scorers-list, invite-team-member-modal, dashboard, app-header, and two-factor-setup-modal.

## Test plan
- [x] `bun run types` clean
- [x] `bun run lint` clean
- [ ] Smoke: trigger a create-team validation error → toast shows
- [ ] Smoke: click trash on a goal scorer → AlertDialog appears
- [ ] Smoke: revoke a team invitation → AlertDialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)