### PR TITLE
feat: tournament organizers schedule per-match date and venue

### DIFF
--- a/app/Http/Controllers/TournamentController.php
+++ b/app/Http/Controllers/TournamentController.php
@@ -159,6 +159,7 @@ final class TournamentController extends Controller
         $canStart = $user && $user->can('start', $tournament) && $tournament->canStart();
         $canCancel = $user && $user->can('cancel', $tournament);
         $canApprove = $user && $user->can('approveTeam', $tournament);
+        $canScheduleMatches = $user && $user->can('scheduleMatches', $tournament);
 
         return Inertia::render('tournaments/show', [
             'tournament' => $tournament,
@@ -169,6 +170,7 @@ final class TournamentController extends Controller
                 'canStart' => $canStart,
                 'canCancel' => $canCancel,
                 'canApprove' => $canApprove,
+                'canScheduleMatches' => $canScheduleMatches,
             ],
         ]);
     }

--- a/app/Http/Controllers/TournamentMatchController.php
+++ b/app/Http/Controllers/TournamentMatchController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\FootballMatch;
+use App\Models\Tournament;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+final class TournamentMatchController extends Controller
+{
+    /**
+     * Update an individual tournament match's schedule (date/time/location).
+     */
+    public function update(Request $request, Tournament $tournament, FootballMatch $match): RedirectResponse
+    {
+        $this->authorize('scheduleMatches', $tournament);
+
+        if ($match->tournament_id !== $tournament->id) {
+            abort(404);
+        }
+
+        if (in_array($match->status, ['in_progress', 'completed'], true)) {
+            abort(403, 'No se puede modificar un partido que ya empezó o terminó.');
+        }
+
+        $data = $request->validate([
+            'scheduled_at' => ['nullable', 'date', 'after_or_equal:today'],
+            'location' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $match->update([
+            'scheduled_at' => $data['scheduled_at'] ?? null,
+            'location' => $data['location'] ?? null,
+        ]);
+
+        return back()->with('success', 'Partido programado correctamente.');
+    }
+}

--- a/app/Policies/TournamentPolicy.php
+++ b/app/Policies/TournamentPolicy.php
@@ -104,6 +104,15 @@ final class TournamentPolicy
     }
 
     /**
+     * Determine whether the user can schedule (set date/time/location for) tournament matches.
+     */
+    public function scheduleMatches(User $user, Tournament $tournament): bool
+    {
+        return $tournament->isOrganizer($user->id)
+            && ! in_array($tournament->status, ['completed', 'cancelled'], true);
+    }
+
+    /**
      * Determine whether the user can register a team for the tournament.
      */
     public function register(User $user, Tournament $tournament, Team $team): bool

--- a/app/Services/TournamentService.php
+++ b/app/Services/TournamentService.php
@@ -282,8 +282,8 @@ final class TournamentService
                 'variant' => $tournament->variant,
                 'status' => 'confirmed',
                 'match_type' => 'competitive',
-                'scheduled_at' => $tournament->starts_at,
-                'location' => 'TBD',
+                'scheduled_at' => null,
+                'location' => null,
                 'created_by' => $tournament->organizer_id,
                 'confirmed_at' => now(),
             ]);
@@ -304,8 +304,8 @@ final class TournamentService
                     'variant' => $tournament->variant,
                     'status' => 'pending',
                     'match_type' => 'competitive',
-                    'scheduled_at' => $tournament->starts_at,
-                    'location' => 'TBD',
+                    'scheduled_at' => null,
+                    'location' => null,
                     'created_by' => $tournament->organizer_id,
                 ]);
             }

--- a/database/migrations/2026_04_25_163750_make_match_schedule_nullable.php
+++ b/database/migrations/2026_04_25_163750_make_match_schedule_nullable.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('matches', function (Blueprint $table) {
+            $table->dateTime('scheduled_at')->nullable()->change();
+            $table->string('location')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('matches', function (Blueprint $table) {
+            $table->dateTime('scheduled_at')->nullable(false)->change();
+            $table->string('location')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/js/components/match-card.tsx
+++ b/resources/js/components/match-card.tsx
@@ -19,8 +19,8 @@ interface Match {
     home_team_id: number;
     away_team_id?: number;
     variant: string;
-    scheduled_at: string;
-    location: string;
+    scheduled_at: string | null;
+    location: string | null;
     match_type: string;
     status: string;
     home_score?: number;
@@ -34,7 +34,8 @@ interface MatchCardProps {
     match: Match;
 }
 
-const formatDate = (dateString: string): string => {
+const formatDate = (dateString: string | null): string => {
+    if (!dateString) return 'Por programar';
     const date = new Date(dateString);
     return date.toLocaleDateString('es-ES', {
         month: 'short',
@@ -43,7 +44,8 @@ const formatDate = (dateString: string): string => {
     });
 };
 
-const formatTime = (dateString: string): string => {
+const formatTime = (dateString: string | null): string => {
+    if (!dateString) return '—';
     const date = new Date(dateString);
     return date.toLocaleTimeString('es-ES', {
         hour: 'numeric',
@@ -179,7 +181,9 @@ export function MatchCard({ match }: MatchCardProps) {
                 <div className="flex items-center justify-between text-sm text-muted-foreground">
                     <div className="flex min-w-0 flex-1 items-center gap-2">
                         <MapPin className="h-4 w-4 flex-shrink-0" />
-                        <span className="line-clamp-1">{match.location}</span>
+                        <span className="line-clamp-1">
+                            {match.location ?? 'Por definir'}
+                        </span>
                     </div>
                     <div className="flex flex-shrink-0 items-center gap-2">
                         <Trophy className="h-4 w-4" />

--- a/resources/js/components/match/match-hero.tsx
+++ b/resources/js/components/match/match-hero.tsx
@@ -316,7 +316,7 @@ export function MatchHero({
                         <div className="flex items-center gap-2">
                             <MapPin className="h-4 w-4 text-muted-foreground" />
                             <span className="font-medium">
-                                {match.location}
+                                {match.location ?? 'Por definir'}
                             </span>
                         </div>
                     </div>

--- a/resources/js/components/match/types.ts
+++ b/resources/js/components/match/types.ts
@@ -60,8 +60,8 @@ export interface MatchPageMatch {
     away_team_id?: number;
     tournament_id?: number;
     variant: string;
-    scheduled_at: string;
-    location: string;
+    scheduled_at: string | null;
+    location: string | null;
     match_type: string;
     status: string;
     home_score?: number;

--- a/resources/js/components/score-tracker.tsx
+++ b/resources/js/components/score-tracker.tsx
@@ -24,7 +24,7 @@ interface Match {
     home_score?: number;
     away_score?: number;
     status: string;
-    scheduled_at: string;
+    scheduled_at: string | null;
     home_team: Team;
     away_team?: Team;
 }
@@ -45,8 +45,10 @@ export function ScoreTracker({ match, isLeader }: Props) {
 
     // Calculate countdown and check if match has started
     useEffect(() => {
+        if (!match.scheduled_at) return;
+        const scheduledAt = match.scheduled_at;
         const updateCountdown = () => {
-            const matchTime = new Date(match.scheduled_at);
+            const matchTime = new Date(scheduledAt);
             const currentTime = new Date();
             const timeDiff = matchTime.getTime() - currentTime.getTime();
 

--- a/resources/js/hooks/use-match-countdown.ts
+++ b/resources/js/hooks/use-match-countdown.ts
@@ -5,11 +5,13 @@ interface CountdownResult {
     hasStarted: boolean;
 }
 
-export function useMatchCountdown(scheduledAt: string): CountdownResult {
+export function useMatchCountdown(scheduledAt: string | null): CountdownResult {
     const [countdown, setCountdown] = useState<string>('');
     const [hasStarted, setHasStarted] = useState(false);
 
     useEffect(() => {
+        if (!scheduledAt) return;
+
         const updateCountdown = () => {
             const matchTime = new Date(scheduledAt);
             const currentTime = new Date();

--- a/resources/js/lib/match-format.ts
+++ b/resources/js/lib/match-format.ts
@@ -32,7 +32,8 @@ export const getMatchStatusText = (status: string): string => {
     }
 };
 
-export const formatMatchDate = (dateString: string): string => {
+export const formatMatchDate = (dateString: string | null): string => {
+    if (!dateString) return 'Por programar';
     const date = new Date(dateString);
     return date.toLocaleDateString('es-ES', {
         weekday: 'long',
@@ -42,7 +43,8 @@ export const formatMatchDate = (dateString: string): string => {
     });
 };
 
-export const formatMatchTime = (dateString: string): string => {
+export const formatMatchTime = (dateString: string | null): string => {
+    if (!dateString) return '—';
     const date = new Date(dateString);
     return date.toLocaleTimeString('es-ES', {
         hour: 'numeric',

--- a/resources/js/pages/matches/edit.tsx
+++ b/resources/js/pages/matches/edit.tsx
@@ -29,8 +29,8 @@ interface Team {
 
 interface Match {
     id: number;
-    scheduled_at: string;
-    location: string;
+    scheduled_at: string | null;
+    location: string | null;
     location_coords?: string;
     match_type: string;
     notes?: string;
@@ -58,8 +58,8 @@ export default function Edit({ match }: Props) {
     ];
 
     const { data, setData, put, processing, errors } = useForm({
-        scheduled_at: match.scheduled_at.slice(0, 16), // Format for datetime-local input
-        location: match.location,
+        scheduled_at: match.scheduled_at?.slice(0, 16) ?? '',
+        location: match.location ?? '',
         location_coords: match.location_coords || '',
         match_type: match.match_type,
         notes: match.notes || '',

--- a/resources/js/pages/matches/index.tsx
+++ b/resources/js/pages/matches/index.tsx
@@ -30,8 +30,8 @@ interface Match {
     home_team_id: number;
     away_team_id?: number;
     variant: string;
-    scheduled_at: string;
-    location: string;
+    scheduled_at: string | null;
+    location: string | null;
     match_type: string;
     status: string;
     home_score?: number;
@@ -69,12 +69,14 @@ export default function Index({
         const past: Match[] = [];
 
         for (const match of myMatches) {
-            const matchDate = new Date(match.scheduled_at);
+            const matchDate = match.scheduled_at
+                ? new Date(match.scheduled_at)
+                : null;
             // Consider a match as "past" if it's completed OR if the scheduled time has passed
             if (
                 match.status === 'completed' ||
                 match.status === 'cancelled' ||
-                matchDate < now
+                (matchDate && matchDate < now)
             ) {
                 past.push(match);
             } else {
@@ -82,17 +84,16 @@ export default function Index({
             }
         }
 
-        // Sort upcoming by date ascending (soonest first)
-        upcoming.sort(
-            (a, b) =>
-                new Date(a.scheduled_at).getTime() -
-                new Date(b.scheduled_at).getTime(),
-        );
+        const dateValue = (m: Match) =>
+            m.scheduled_at ? new Date(m.scheduled_at).getTime() : Infinity;
+
+        // Sort upcoming by date ascending (soonest first; unscheduled at the end)
+        upcoming.sort((a, b) => dateValue(a) - dateValue(b));
         // Sort past by date descending (most recent first)
         past.sort(
             (a, b) =>
-                new Date(b.scheduled_at).getTime() -
-                new Date(a.scheduled_at).getTime(),
+                (b.scheduled_at ? new Date(b.scheduled_at).getTime() : 0) -
+                (a.scheduled_at ? new Date(a.scheduled_at).getTime() : 0),
         );
 
         return { upcomingMatches: upcoming, pastMatches: past };
@@ -104,7 +105,9 @@ export default function Index({
                 match.home_team.name
                     .toLowerCase()
                     .includes(searchQuery.toLowerCase()) ||
-                match.location.toLowerCase().includes(searchQuery.toLowerCase())
+                (match.location ?? '')
+                    .toLowerCase()
+                    .includes(searchQuery.toLowerCase())
             );
         });
     }, [availableMatches, searchQuery]);

--- a/resources/js/pages/tournaments/show.tsx
+++ b/resources/js/pages/tournaments/show.tsx
@@ -20,6 +20,16 @@ import {
     CardHeader,
     CardTitle,
 } from '@/components/ui/card';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Progress } from '@/components/ui/progress';
 import {
     Select,
@@ -32,6 +42,7 @@ import { Separator } from '@/components/ui/separator';
 import { UserAvatar } from '@/components/user-avatar';
 import { VariantBadge } from '@/components/variant-badge';
 import AppLayout from '@/layouts/app-layout';
+import tournamentMatches from '@/routes/tournaments/matches';
 import type {
     BreadcrumbItem,
     FootballMatch,
@@ -42,11 +53,14 @@ import type {
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import {
     Calendar,
+    CalendarClock,
     Check,
     Clock,
     Edit,
     Info,
     Loader2,
+    MapPin,
+    Pencil,
     Play,
     Trash2,
     Trophy,
@@ -73,7 +87,156 @@ interface PageProps {
         canStart: boolean;
         canCancel: boolean;
         canApprove: boolean;
+        canScheduleMatches: boolean;
     };
+}
+
+function formatScheduledAt(value: string | null): string {
+    if (!value) return 'Sin programar';
+    const date = new Date(value);
+    return date.toLocaleString('es-UY', {
+        day: 'numeric',
+        month: 'short',
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+}
+
+function toLocalDatetimeInputValue(value: string | null): string {
+    if (!value) return '';
+    const date = new Date(value);
+    const offsetMs = date.getTimezoneOffset() * 60_000;
+    return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
+function ScheduleMatchDialog({
+    match,
+    tournamentId,
+    open,
+    onOpenChange,
+}: {
+    match: FootballMatch | null;
+    tournamentId: number;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}) {
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                {match && (
+                    <ScheduleMatchForm
+                        key={match.id}
+                        match={match}
+                        tournamentId={tournamentId}
+                        onClose={() => onOpenChange(false)}
+                    />
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function ScheduleMatchForm({
+    match,
+    tournamentId,
+    onClose,
+}: {
+    match: FootballMatch;
+    tournamentId: number;
+    onClose: () => void;
+}) {
+    const [scheduledAt, setScheduledAt] = useState(() =>
+        toLocalDatetimeInputValue(match.scheduled_at),
+    );
+    const [location, setLocation] = useState(() => match.location ?? '');
+    const [submitting, setSubmitting] = useState(false);
+    const [errors, setErrors] = useState<Record<string, string>>({});
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        setSubmitting(true);
+        router.patch(
+            tournamentMatches.update([tournamentId, match.id]).url,
+            {
+                scheduled_at: scheduledAt || null,
+                location: location.trim() || null,
+            },
+            {
+                preserveScroll: true,
+                onSuccess: () => {
+                    onClose();
+                },
+                onError: (errs) => {
+                    setErrors(errs as Record<string, string>);
+                    toast.error('Revisá los datos del partido.');
+                },
+                onFinish: () => setSubmitting(false),
+            },
+        );
+    };
+
+    const homeName = match.home_team?.name ?? 'Por definir';
+    const awayName = match.away_team?.name ?? 'Por definir';
+
+    return (
+        <>
+            <DialogHeader>
+                <DialogTitle>Programar partido</DialogTitle>
+                <DialogDescription>
+                    {homeName} vs {awayName}
+                </DialogDescription>
+            </DialogHeader>
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="space-y-2">
+                    <Label htmlFor="scheduled_at">Fecha y hora</Label>
+                    <Input
+                        id="scheduled_at"
+                        type="datetime-local"
+                        value={scheduledAt}
+                        onChange={(e) => setScheduledAt(e.target.value)}
+                    />
+                    {errors.scheduled_at && (
+                        <p className="text-sm text-destructive">
+                            {errors.scheduled_at}
+                        </p>
+                    )}
+                </div>
+                <div className="space-y-2">
+                    <Label htmlFor="location">Cancha</Label>
+                    <Input
+                        id="location"
+                        type="text"
+                        placeholder="Ej: Cancha 3 — Complejo Norte"
+                        value={location}
+                        onChange={(e) => setLocation(e.target.value)}
+                        maxLength={255}
+                    />
+                    {errors.location && (
+                        <p className="text-sm text-destructive">
+                            {errors.location}
+                        </p>
+                    )}
+                </div>
+                <DialogFooter>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={onClose}
+                        disabled={submitting}
+                    >
+                        Cancelar
+                    </Button>
+                    <Button type="submit" disabled={submitting}>
+                        {submitting ? (
+                            <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                            'Guardar'
+                        )}
+                    </Button>
+                </DialogFooter>
+            </form>
+        </>
+    );
 }
 
 const statusConfig = {
@@ -152,6 +315,9 @@ export default function TournamentShow({
     const [showCancelDialog, setShowCancelDialog] = useState(false);
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
     const [withdrawId, setWithdrawId] = useState<number | null>(null);
+    const [scheduleMatch, setScheduleMatch] = useState<FootballMatch | null>(
+        null,
+    );
 
     const [processing, setProcessing] = useState(false);
     const { flash } = usePage<{
@@ -471,12 +637,134 @@ export default function TournamentShow({
                     <div className="space-y-6 lg:col-span-2">
                         {/* Bracket */}
                         {hasBracket ? (
-                            <section className="space-y-4">
-                                <h2 className="text-lg font-semibold">
-                                    Bracket
-                                </h2>
-                                <TournamentBracket rounds={tournament.rounds} />
-                            </section>
+                            <>
+                                <section className="space-y-4">
+                                    <h2 className="text-lg font-semibold">
+                                        Bracket
+                                    </h2>
+                                    <TournamentBracket
+                                        rounds={tournament.rounds}
+                                    />
+                                </section>
+
+                                <Card>
+                                    <CardHeader>
+                                        <CardTitle className="text-base">
+                                            Programación de partidos
+                                        </CardTitle>
+                                        <CardDescription>
+                                            {permissions.canScheduleMatches
+                                                ? 'Definí la fecha, hora y cancha de cada partido.'
+                                                : 'Fechas y canchas confirmadas por el organizador.'}
+                                        </CardDescription>
+                                    </CardHeader>
+                                    <CardContent className="space-y-6">
+                                        {tournament.rounds.map((round) => (
+                                            <div
+                                                key={round.id}
+                                                className="space-y-2"
+                                            >
+                                                <h3 className="text-sm font-medium text-muted-foreground">
+                                                    {round.name}
+                                                </h3>
+                                                <div className="space-y-2">
+                                                    {(round.matches?.length ??
+                                                        0) === 0 ? (
+                                                        <p className="text-sm text-muted-foreground">
+                                                            Sin partidos
+                                                        </p>
+                                                    ) : (
+                                                        round.matches!.map(
+                                                            (match) => {
+                                                                const home =
+                                                                    match
+                                                                        .home_team
+                                                                        ?.name ??
+                                                                    'Por definir';
+                                                                const away =
+                                                                    match
+                                                                        .away_team
+                                                                        ?.name ??
+                                                                    'Por definir';
+                                                                const isLocked =
+                                                                    match.status ===
+                                                                        'in_progress' ||
+                                                                    match.status ===
+                                                                        'completed';
+                                                                const canEditMatch =
+                                                                    permissions.canScheduleMatches &&
+                                                                    !isLocked;
+                                                                return (
+                                                                    <div
+                                                                        key={
+                                                                            match.id
+                                                                        }
+                                                                        className="flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+                                                                    >
+                                                                        <div className="min-w-0 flex-1">
+                                                                            <p className="truncate text-sm font-medium">
+                                                                                {
+                                                                                    home
+                                                                                }{' '}
+                                                                                <span className="text-muted-foreground">
+                                                                                    vs
+                                                                                </span>{' '}
+                                                                                {
+                                                                                    away
+                                                                                }
+                                                                            </p>
+                                                                            <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                                                                                <span className="flex items-center gap-1">
+                                                                                    <CalendarClock className="size-3.5" />
+                                                                                    {match.scheduled_at ? (
+                                                                                        formatScheduledAt(
+                                                                                            match.scheduled_at,
+                                                                                        )
+                                                                                    ) : (
+                                                                                        <Badge
+                                                                                            variant="outline"
+                                                                                            className="font-normal"
+                                                                                        >
+                                                                                            Sin
+                                                                                            programar
+                                                                                        </Badge>
+                                                                                    )}
+                                                                                </span>
+                                                                                <span className="flex items-center gap-1">
+                                                                                    <MapPin className="size-3.5" />
+                                                                                    {match.location ??
+                                                                                        'Por definir'}
+                                                                                </span>
+                                                                            </div>
+                                                                        </div>
+                                                                        {canEditMatch && (
+                                                                            <Button
+                                                                                size="sm"
+                                                                                variant="outline"
+                                                                                onClick={() =>
+                                                                                    setScheduleMatch(
+                                                                                        match,
+                                                                                    )
+                                                                                }
+                                                                                className="gap-1.5"
+                                                                            >
+                                                                                <Pencil className="size-3.5" />
+                                                                                {match.scheduled_at
+                                                                                    ? 'Editar'
+                                                                                    : 'Programar'}
+                                                                            </Button>
+                                                                        )}
+                                                                    </div>
+                                                                );
+                                                            },
+                                                        )
+                                                    )}
+                                                </div>
+                                            </div>
+                                        ))}
+                                    </CardContent>
+                                </Card>
+                            </>
                         ) : (
                             (tournament.status === 'draft' ||
                                 tournament.status === 'registration_open') && (
@@ -1025,6 +1313,13 @@ export default function TournamentShow({
                     </AlertDialogFooter>
                 </AlertDialogContent>
             </AlertDialog>
+
+            <ScheduleMatchDialog
+                tournamentId={tournament.id}
+                match={scheduleMatch}
+                open={scheduleMatch !== null}
+                onOpenChange={(open) => !open && setScheduleMatch(null)}
+            />
 
             <AlertDialog
                 open={withdrawId !== null}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -314,8 +314,8 @@ export interface FootballMatch {
     tournament_round?: TournamentRound;
     bracket_position?: number;
     variant: string;
-    scheduled_at: string;
-    location: string;
+    scheduled_at: string | null;
+    location: string | null;
     location_coords?: string;
     match_type: string;
     status: string;

--- a/routes/tournaments.php
+++ b/routes/tournaments.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\TournamentController;
 use App\Http\Controllers\TournamentLogoController;
+use App\Http\Controllers\TournamentMatchController;
 use App\Http\Controllers\TournamentRegistrationController;
 use Illuminate\Support\Facades\Route;
 
@@ -19,6 +20,9 @@ Route::middleware(['auth', 'verified', 'throttle:tournaments', 'onboarding'])->g
     Route::post('/tournaments/{id}/open-registration', [TournamentController::class, 'openRegistration'])->name('tournaments.open-registration');
     Route::post('/tournaments/{id}/start', [TournamentController::class, 'start'])->name('tournaments.start');
     Route::post('/tournaments/{id}/cancel', [TournamentController::class, 'cancel'])->name('tournaments.cancel');
+
+    // Tournament Match Scheduling
+    Route::patch('/tournaments/{tournament}/matches/{match}', [TournamentMatchController::class, 'update'])->name('tournaments.matches.update');
 
     // Tournament Logo
     Route::post('/tournaments/{id}/logo', [TournamentLogoController::class, 'store'])->name('tournaments.logo.store');

--- a/tests/Feature/TournamentMatchScheduleTest.php
+++ b/tests/Feature/TournamentMatchScheduleTest.php
@@ -1,0 +1,161 @@
+<?php
+
+use App\Models\FootballMatch;
+use App\Models\Team;
+use App\Models\Tournament;
+use App\Models\TournamentTeam;
+use App\Models\User;
+use App\Services\TournamentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function startTournamentWithMatches(User $organizer, int $teamCount = 4): Tournament
+{
+    $tournament = Tournament::factory()->create([
+        'organizer_id' => $organizer->id,
+        'status' => 'registration_open',
+        'variant' => 'football_11',
+        'starts_at' => now()->addDays(3),
+    ]);
+
+    for ($i = 0; $i < $teamCount; $i++) {
+        $team = Team::factory()->create(['variant' => 'football_11']);
+        TournamentTeam::factory()->create([
+            'tournament_id' => $tournament->id,
+            'team_id' => $team->id,
+            'status' => 'approved',
+            'registered_by' => $organizer->id,
+        ]);
+    }
+
+    app(TournamentService::class)->startTournament($tournament);
+
+    return $tournament->fresh();
+}
+
+test('bracket generation leaves matches unscheduled', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = startTournamentWithMatches($organizer);
+
+    $matches = FootballMatch::where('tournament_id', $tournament->id)->get();
+
+    expect($matches)->not->toBeEmpty();
+    foreach ($matches as $match) {
+        expect($match->scheduled_at)->toBeNull();
+        expect($match->location)->toBeNull();
+    }
+});
+
+test('organizer can schedule a tournament match', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = startTournamentWithMatches($organizer);
+    $match = FootballMatch::where('tournament_id', $tournament->id)
+        ->whereNotNull('home_team_id')
+        ->first();
+
+    $this->actingAs($organizer);
+
+    $scheduledAt = now()->addDays(5)->setTime(18, 30);
+
+    $response = $this->patch(
+        "/tournaments/{$tournament->id}/matches/{$match->id}",
+        [
+            'scheduled_at' => $scheduledAt->toDateTimeString(),
+            'location' => 'Cancha 3 — Complejo Norte',
+        ],
+    );
+
+    $response->assertRedirect();
+
+    $match->refresh();
+    expect($match->scheduled_at->format('Y-m-d H:i'))
+        ->toBe($scheduledAt->format('Y-m-d H:i'));
+    expect($match->location)->toBe('Cancha 3 — Complejo Norte');
+});
+
+test('non-organizer cannot schedule a tournament match', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $intruder = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = startTournamentWithMatches($organizer);
+    $match = FootballMatch::where('tournament_id', $tournament->id)
+        ->whereNotNull('home_team_id')
+        ->first();
+
+    $this->actingAs($intruder);
+
+    $response = $this->patch(
+        "/tournaments/{$tournament->id}/matches/{$match->id}",
+        [
+            'scheduled_at' => now()->addDays(5)->toDateTimeString(),
+            'location' => 'Hack',
+        ],
+    );
+
+    $response->assertForbidden();
+    expect($match->fresh()->scheduled_at)->toBeNull();
+});
+
+test('cannot schedule a match for a date in the past', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = startTournamentWithMatches($organizer);
+    $match = FootballMatch::where('tournament_id', $tournament->id)
+        ->whereNotNull('home_team_id')
+        ->first();
+
+    $this->actingAs($organizer);
+
+    $response = $this->patch(
+        "/tournaments/{$tournament->id}/matches/{$match->id}",
+        [
+            'scheduled_at' => now()->subDays(1)->toDateTimeString(),
+            'location' => 'Cancha 1',
+        ],
+    );
+
+    $response->assertSessionHasErrors('scheduled_at');
+    expect($match->fresh()->scheduled_at)->toBeNull();
+});
+
+test('cannot edit a completed match', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = startTournamentWithMatches($organizer);
+    $match = FootballMatch::where('tournament_id', $tournament->id)
+        ->whereNotNull('home_team_id')
+        ->first();
+    $match->update(['status' => 'completed']);
+
+    $this->actingAs($organizer);
+
+    $response = $this->patch(
+        "/tournaments/{$tournament->id}/matches/{$match->id}",
+        [
+            'scheduled_at' => now()->addDays(2)->toDateTimeString(),
+            'location' => 'Otra cancha',
+        ],
+    );
+
+    $response->assertForbidden();
+});
+
+test('match must belong to the given tournament', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournamentA = startTournamentWithMatches($organizer);
+    $tournamentB = startTournamentWithMatches($organizer);
+
+    $matchFromB = FootballMatch::where('tournament_id', $tournamentB->id)
+        ->whereNotNull('home_team_id')
+        ->first();
+
+    $this->actingAs($organizer);
+
+    $response = $this->patch(
+        "/tournaments/{$tournamentA->id}/matches/{$matchFromB->id}",
+        [
+            'scheduled_at' => now()->addDays(2)->toDateTimeString(),
+            'location' => 'Cancha 1',
+        ],
+    );
+
+    $response->assertNotFound();
+});


### PR DESCRIPTION
## Summary
- Bracket generation no longer auto-stamps every match with the tournament's `starts_at` (which surfaced as "23:00" for users). Matches are created unscheduled.
- Tournament organizers get a new "Programación de partidos" panel on the tournament dashboard to set/edit each match's date, time, and cancha. Locked statuses (in-progress, completed) hide the edit affordance.
- Match views (cards, hero, lists) gracefully render "Por programar" / "Por definir" when a match has no schedule yet.

## Notable changes
- `matches.scheduled_at` and `matches.location` are now nullable (new migration).
- `TournamentService::generateBracket()` writes `null` for both fields instead of copying `starts_at` / `'TBD'`.
- New `TournamentMatchController@update` (`PATCH /tournaments/{tournament}/matches/{match}`), gated by a new `TournamentPolicy::scheduleMatches` ability.
- Validation: `scheduled_at` must be `after_or_equal:today`; matches in `in_progress` or `completed` reject edits with 403; cross-tournament match IDs return 404.

## Test plan
- [x] `php artisan test --filter=TournamentMatchScheduleTest` — 6 new tests cover unscheduled bracket generation, organizer success, non-organizer 403, past-date rejection, locked-status block, and cross-tournament 404.
- [x] Full regression: `composer test`.
- [x] Manual: start a tournament, confirm matches show "Sin programar" in the bracket panel; edit one as organizer with a future datetime + cancha; reload and confirm persistence.
- [x] Manual: log in as a non-organizer, confirm the schedule list renders without edit buttons.

## Migration note
This PR makes `scheduled_at`/`location` nullable but does not backfill existing tournaments whose matches were stamped with the old default. If any production tournaments have garbage `23:00` timestamps, those should be cleared via tinker after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)