### PR TITLE
feat: per-match scheduling, edit guard, and league + group-stage tournament formats

### DIFF
--- a/app/Http/Controllers/MatchController.php
+++ b/app/Http/Controllers/MatchController.php
@@ -469,8 +469,9 @@ final class MatchController extends Controller
             abort(403, 'No autorizado');
         }
 
-        // Check if match time has been reached
-        if ($match->scheduled_at->isFuture()) {
+        // Check if match time has been reached (skip when no schedule is set,
+        // e.g. league matches without a fixed kickoff time)
+        if ($match->scheduled_at !== null && $match->scheduled_at->isFuture()) {
             return back()->with('error', 'No se puede completar el partido antes de que comience');
         }
 

--- a/app/Http/Controllers/TournamentController.php
+++ b/app/Http/Controllers/TournamentController.php
@@ -159,6 +159,7 @@ final class TournamentController extends Controller
         $canStart = $user && $user->can('start', $tournament) && $tournament->canStart();
         $canCancel = $user && $user->can('cancel', $tournament);
         $canApprove = $user && $user->can('approveTeam', $tournament);
+        $canScheduleMatches = $user && $user->can('scheduleMatches', $tournament);
 
         return Inertia::render('tournaments/show', [
             'tournament' => $tournament,
@@ -169,6 +170,7 @@ final class TournamentController extends Controller
                 'canStart' => $canStart,
                 'canCancel' => $canCancel,
                 'canApprove' => $canApprove,
+                'canScheduleMatches' => $canScheduleMatches,
             ],
         ]);
     }

--- a/app/Http/Controllers/TournamentController.php
+++ b/app/Http/Controllers/TournamentController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Team;
 use App\Models\Tournament;
+use App\Services\StandingsService;
 use App\Services\TournamentService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -92,18 +93,7 @@ final class TournamentController extends Controller
     {
         $this->authorize('create', Tournament::class);
 
-        $validated = $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'description' => ['nullable', 'string', 'max:5000'],
-            'logo' => ['nullable', 'image', 'mimes:jpg,jpeg,png,webp', 'max:2048'],
-            'visibility' => ['required', 'in:public,invite_only'],
-            'variant' => ['required', 'in:football_11,football_7,football_5,futsal'],
-            'max_teams' => ['required', 'integer', 'in:4,8,16,32,64'],
-            'min_teams' => ['required', 'integer', 'min:2'],
-            'registration_deadline' => array_filter(['nullable', 'date', 'after:now', $request->starts_at ? 'before:starts_at' : null]),
-            'starts_at' => array_filter(['nullable', 'date', 'after_or_equal:now', $request->ends_at ? 'before:ends_at' : null]),
-            'ends_at' => array_filter(['nullable', 'date', $request->starts_at ? 'after:starts_at' : null]),
-        ]);
+        $validated = $request->validate($this->tournamentRules($request));
 
         try {
             $user = Auth::user();
@@ -133,6 +123,8 @@ final class TournamentController extends Controller
             'tournamentTeams.registeredBy:id,name',
             'rounds.matches.homeTeam',
             'rounds.matches.awayTeam',
+            'groups.teams.team',
+            'groups.matches',
         ])
             ->withCount(['tournamentTeams as registered_teams_count' => function ($query) {
                 $query->whereIn('status', ['pending', 'approved']);
@@ -161,8 +153,23 @@ final class TournamentController extends Controller
         $canApprove = $user && $user->can('approveTeam', $tournament);
         $canScheduleMatches = $user && $user->can('scheduleMatches', $tournament);
 
+        $standings = null;
+        $groupStandings = null;
+        $canDrawGroups = false;
+
+        if ($tournament->isLeague()) {
+            $standings = $this->buildLeagueStandings($tournament);
+        }
+
+        if ($tournament->isGroupStageKnockout()) {
+            $groupStandings = $this->buildGroupStandings($tournament);
+            $canDrawGroups = $user && $user->can('drawGroups', $tournament);
+        }
+
         return Inertia::render('tournaments/show', [
             'tournament' => $tournament,
+            'standings' => $standings,
+            'groupStandings' => $groupStandings,
             'userTeams' => $userTeams,
             'permissions' => [
                 'canEdit' => $canEdit,
@@ -171,8 +178,112 @@ final class TournamentController extends Controller
                 'canCancel' => $canCancel,
                 'canApprove' => $canApprove,
                 'canScheduleMatches' => $canScheduleMatches,
+                'canDrawGroups' => $canDrawGroups,
             ],
         ]);
+    }
+
+    /**
+     * Build the league standings rows enriched with team data for Inertia.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildLeagueStandings(Tournament $tournament): array
+    {
+        $teamIds = $tournament->approvedTeams()->pluck('team_id');
+        $matches = $tournament->matches()->get();
+
+        $rows = app(StandingsService::class)->compute($matches, $teamIds, $tournament->id);
+
+        return $this->attachTeamsToRows($rows, $tournament);
+    }
+
+    /**
+     * Build per-group standings keyed by tournament_group_id.
+     *
+     * @return array<int, array<int, array<string, mixed>>>
+     */
+    private function buildGroupStandings(Tournament $tournament): array
+    {
+        $service = app(StandingsService::class);
+        $byGroup = [];
+
+        foreach ($tournament->groups as $group) {
+            $rows = $service->forGroup($group);
+            $byGroup[$group->id] = $this->attachTeamsToRows($rows, $tournament);
+        }
+
+        return $byGroup;
+    }
+
+    /**
+     * @param  array<int, \App\Support\StandingRow>  $rows
+     * @return array<int, array<string, mixed>>
+     */
+    private function attachTeamsToRows(array $rows, Tournament $tournament): array
+    {
+        $teamMap = [];
+        foreach ($tournament->tournamentTeams as $tt) {
+            if ($tt->team) {
+                $teamMap[$tt->team_id] = $tt->team;
+            }
+        }
+
+        $out = [];
+        foreach ($rows as $row) {
+            $out[] = $row->toArray() + [
+                'team' => $teamMap[$row->teamId] ?? null,
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Build validation rules for tournament create/update, branching on format.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    private function tournamentRules(Request $request, bool $isUpdate = false): array
+    {
+        $format = $request->input('format', 'single_elimination');
+
+        $rules = [
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:5000'],
+            'logo' => ['nullable', 'image', 'mimes:jpg,jpeg,png,webp', 'max:2048'],
+            'visibility' => ['required', 'in:public,invite_only'],
+            'variant' => ['required', 'in:football_11,football_7,football_5,futsal'],
+            'format' => ['nullable', 'in:single_elimination,league,group_stage_knockout'],
+            'min_teams' => ['required', 'integer', 'min:2'],
+            'registration_deadline' => array_filter([
+                'nullable', 'date',
+                $isUpdate ? null : 'after:now',
+                $request->starts_at ? 'before:starts_at' : null,
+            ]),
+            'starts_at' => array_filter([
+                'nullable', 'date',
+                $isUpdate ? null : 'after_or_equal:now',
+                $request->ends_at ? 'before:ends_at' : null,
+            ]),
+            'ends_at' => array_filter([
+                'nullable', 'date',
+                $request->starts_at ? 'after:starts_at' : null,
+            ]),
+        ];
+
+        if ($format === 'group_stage_knockout') {
+            $rules['group_count'] = ['required', 'integer', 'in:2,4,8,16'];
+            $rules['group_size'] = ['required', 'integer', 'min:2', 'max:16'];
+            // max_teams is derived from group_count × group_size in the service.
+            $rules['max_teams'] = ['nullable', 'integer'];
+        } elseif ($format === 'league') {
+            $rules['max_teams'] = ['required', 'integer', 'min:2', 'max:64'];
+        } else {
+            $rules['max_teams'] = ['required', 'integer', 'in:4,8,16,32,64'];
+        }
+
+        return $rules;
     }
 
     /**
@@ -204,18 +315,7 @@ final class TournamentController extends Controller
 
         $this->authorize('update', $tournament);
 
-        $validated = $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'description' => ['nullable', 'string', 'max:5000'],
-            'logo' => ['nullable', 'image', 'mimes:jpg,jpeg,png,webp', 'max:2048'],
-            'visibility' => ['required', 'in:public,invite_only'],
-            'variant' => ['required', 'in:football_11,football_7,football_5,futsal'],
-            'max_teams' => ['required', 'integer', 'in:4,8,16,32,64'],
-            'min_teams' => ['required', 'integer', 'min:2'],
-            'registration_deadline' => array_filter(['nullable', 'date', $request->starts_at ? 'before:starts_at' : null]),
-            'starts_at' => array_filter(['nullable', 'date', $request->ends_at ? 'before:ends_at' : null]),
-            'ends_at' => array_filter(['nullable', 'date', $request->starts_at ? 'after:starts_at' : null]),
-        ]);
+        $validated = $request->validate($this->tournamentRules($request, isUpdate: true));
 
         try {
             unset($validated['logo']);

--- a/app/Http/Controllers/TournamentController.php
+++ b/app/Http/Controllers/TournamentController.php
@@ -151,7 +151,7 @@ final class TournamentController extends Controller
         })->where('variant', $tournament->variant)->get(['id', 'name', 'variant']) : collect();
 
         // Check if user can perform various actions
-        $canEdit = $user && $user->can('update', $tournament);
+        $canEdit = $user && $user->can('update', $tournament) && $tournament->canBeEdited();
         $canDelete = $user && $user->can('delete', $tournament);
         // canStart combines the policy check (organizer + valid status) with the
         // model's runtime readiness check (enough approved teams, power of 2)
@@ -178,11 +178,17 @@ final class TournamentController extends Controller
     /**
      * Show the form for editing the specified tournament.
      */
-    public function edit(int $id): Response
+    public function edit(int $id): Response|\Illuminate\Http\RedirectResponse
     {
         $tournament = Tournament::findOrFail($id);
 
         $this->authorize('update', $tournament);
+
+        if (! $tournament->canBeEdited()) {
+            return redirect()
+                ->route('tournaments.show', $tournament->id)
+                ->with('error', 'Este torneo ya no se puede editar.');
+        }
 
         return Inertia::render('tournaments/edit', [
             'tournament' => $tournament,

--- a/app/Http/Controllers/TournamentGroupController.php
+++ b/app/Http/Controllers/TournamentGroupController.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\Tournament;
+use App\Models\TournamentTeam;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+final class TournamentGroupController extends Controller
+{
+    /**
+     * Save the organizer's group draw. Accepts an `assignments` array of
+     * { tournament_team_id, tournament_group_id } and writes them in a
+     * single transaction. Group-id may be null to "unassign" a team.
+     */
+    public function assign(Request $request, int $tournamentId)
+    {
+        $tournament = Tournament::with('groups')->findOrFail($tournamentId);
+        $this->authorize('drawGroups', $tournament);
+
+        $validated = $request->validate([
+            'assignments' => ['required', 'array', 'min:1'],
+            'assignments.*.tournament_team_id' => ['required', 'integer'],
+            'assignments.*.tournament_group_id' => ['nullable', 'integer'],
+        ]);
+
+        $groupIdsForTournament = $tournament->groups->pluck('id')->all();
+        $teamIdsForTournament = TournamentTeam::where('tournament_id', $tournament->id)
+            ->where('status', 'approved')
+            ->pluck('id')
+            ->all();
+
+        // Validate every team and group belong to this tournament.
+        foreach ($validated['assignments'] as $assignment) {
+            if (! in_array($assignment['tournament_team_id'], $teamIdsForTournament, true)) {
+                throw ValidationException::withMessages([
+                    'error' => 'Una o más asignaciones referencian un equipo que no pertenece a este torneo.',
+                ]);
+            }
+            if ($assignment['tournament_group_id'] !== null
+                && ! in_array($assignment['tournament_group_id'], $groupIdsForTournament, true)) {
+                throw ValidationException::withMessages([
+                    'error' => 'Una o más asignaciones referencian un grupo que no pertenece a este torneo.',
+                ]);
+            }
+        }
+
+        // Validate group capacity.
+        $assignmentsByGroup = [];
+        foreach ($validated['assignments'] as $assignment) {
+            if ($assignment['tournament_group_id'] !== null) {
+                $assignmentsByGroup[$assignment['tournament_group_id']] = ($assignmentsByGroup[$assignment['tournament_group_id']] ?? 0) + 1;
+            }
+        }
+        $capacity = (int) $tournament->group_size;
+        foreach ($assignmentsByGroup as $groupId => $count) {
+            if ($count > $capacity) {
+                throw ValidationException::withMessages([
+                    'error' => "Un grupo no puede tener más de {$capacity} equipos.",
+                ]);
+            }
+        }
+
+        DB::transaction(function () use ($validated) {
+            foreach ($validated['assignments'] as $assignment) {
+                TournamentTeam::where('id', $assignment['tournament_team_id'])
+                    ->update(['tournament_group_id' => $assignment['tournament_group_id']]);
+            }
+        });
+
+        return redirect()->route('tournaments.show', $tournament->id)
+            ->with('success', 'Sorteo guardado.');
+    }
+
+    /**
+     * Clear all group assignments for this tournament's approved teams.
+     */
+    public function clear(int $tournamentId)
+    {
+        $tournament = Tournament::findOrFail($tournamentId);
+        $this->authorize('drawGroups', $tournament);
+
+        TournamentTeam::where('tournament_id', $tournament->id)
+            ->update(['tournament_group_id' => null]);
+
+        return redirect()->route('tournaments.show', $tournament->id)
+            ->with('success', 'Sorteo reiniciado.');
+    }
+}

--- a/app/Http/Controllers/TournamentMatchController.php
+++ b/app/Http/Controllers/TournamentMatchController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\FootballMatch;
+use App\Models\Tournament;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+final class TournamentMatchController extends Controller
+{
+    /**
+     * Update an individual tournament match's schedule (date/time/location).
+     */
+    public function update(Request $request, Tournament $tournament, FootballMatch $match): RedirectResponse
+    {
+        $this->authorize('scheduleMatches', $tournament);
+
+        if ($match->tournament_id !== $tournament->id) {
+            abort(404);
+        }
+
+        if (in_array($match->status, ['in_progress', 'completed'], true)) {
+            abort(403, 'No se puede modificar un partido que ya empezó o terminó.');
+        }
+
+        $data = $request->validate([
+            'scheduled_at' => ['nullable', 'date', 'after_or_equal:today'],
+            'location' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $match->update([
+            'scheduled_at' => $data['scheduled_at'] ?? null,
+            'location' => $data['location'] ?? null,
+        ]);
+
+        return back()->with('success', 'Partido programado correctamente.');
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -46,6 +46,10 @@ class HandleInertiaRequests extends Middleware
                 'user' => $request->user(),
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
+            'flash' => [
+                'success' => fn () => $request->session()->get('success'),
+                'error' => fn () => $request->session()->get('error'),
+            ],
         ];
     }
 }

--- a/app/Models/FootballMatch.php
+++ b/app/Models/FootballMatch.php
@@ -30,7 +30,9 @@ final class FootballMatch extends Model
         'away_team_id',
         'tournament_id',
         'tournament_round_id',
+        'tournament_group_id',
         'bracket_position',
+        'matchday',
         'variant',
         'scheduled_at',
         'location',
@@ -101,6 +103,27 @@ final class FootballMatch extends Model
     public function tournamentRound(): BelongsTo
     {
         return $this->belongsTo(TournamentRound::class);
+    }
+
+    /**
+     * Get the tournament group this match belongs to (group_stage_knockout only).
+     */
+    public function tournamentGroup(): BelongsTo
+    {
+        return $this->belongsTo(TournamentGroup::class, 'tournament_group_id');
+    }
+
+    public function isGroupMatch(): bool
+    {
+        return $this->tournament_group_id !== null;
+    }
+
+    public function isLeagueMatch(): bool
+    {
+        return $this->tournament_id !== null
+            && $this->matchday !== null
+            && $this->tournament_group_id === null
+            && $this->bracket_position === null;
     }
 
     /**

--- a/app/Models/Tournament.php
+++ b/app/Models/Tournament.php
@@ -28,6 +28,10 @@ final class Tournament extends Model
         'visibility',
         'status',
         'variant',
+        'format',
+        'phase',
+        'group_count',
+        'group_size',
         'max_teams',
         'min_teams',
         'registration_deadline',
@@ -55,6 +59,8 @@ final class Tournament extends Model
             'registration_deadline' => 'datetime',
             'starts_at' => 'datetime',
             'ends_at' => 'datetime',
+            'group_count' => 'integer',
+            'group_size' => 'integer',
         ];
     }
 
@@ -134,6 +140,39 @@ final class Tournament extends Model
     public function matches(): HasMany
     {
         return $this->hasMany(FootballMatch::class);
+    }
+
+    /**
+     * Get the groups (only populated for group_stage_knockout format).
+     */
+    public function groups(): HasMany
+    {
+        return $this->hasMany(TournamentGroup::class)->orderBy('position');
+    }
+
+    public function isSingleElimination(): bool
+    {
+        return $this->format === 'single_elimination';
+    }
+
+    public function isLeague(): bool
+    {
+        return $this->format === 'league';
+    }
+
+    public function isGroupStageKnockout(): bool
+    {
+        return $this->format === 'group_stage_knockout';
+    }
+
+    public function inGroupStage(): bool
+    {
+        return $this->phase === 'group_stage';
+    }
+
+    public function inKnockout(): bool
+    {
+        return $this->phase === 'knockout';
     }
 
     /**
@@ -225,13 +264,16 @@ final class Tournament extends Model
 
         $approvedCount = $this->getApprovedTeamsCount();
 
-        // Must have at least min_teams
         if ($approvedCount < $this->min_teams) {
             return false;
         }
 
-        // Must be a power of 2
-        return $this->isPowerOfTwo($approvedCount);
+        return match ($this->format) {
+            'league' => $approvedCount >= 2,
+            'group_stage_knockout' => $approvedCount === ($this->group_count * $this->group_size)
+                && $this->approvedTeams()->whereNull('tournament_group_id')->doesntExist(),
+            default => $this->isPowerOfTwo($approvedCount),
+        };
     }
 
     /**

--- a/app/Models/TournamentGroup.php
+++ b/app/Models/TournamentGroup.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+final class TournamentGroup extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'tournament_id',
+        'name',
+        'position',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'position' => 'integer',
+        ];
+    }
+
+    public function tournament(): BelongsTo
+    {
+        return $this->belongsTo(Tournament::class);
+    }
+
+    /**
+     * Teams assigned to this group (via tournament_teams pivot).
+     */
+    public function teams(): HasMany
+    {
+        return $this->hasMany(TournamentTeam::class);
+    }
+
+    /**
+     * Matches played within this group.
+     */
+    public function matches(): HasMany
+    {
+        return $this->hasMany(FootballMatch::class);
+    }
+}

--- a/app/Models/TournamentTeam.php
+++ b/app/Models/TournamentTeam.php
@@ -22,6 +22,7 @@ final class TournamentTeam extends Model
         'team_id',
         'status',
         'seed',
+        'tournament_group_id',
         'registered_by',
         'registered_at',
         'approved_at',
@@ -62,6 +63,14 @@ final class TournamentTeam extends Model
     public function registeredBy(): BelongsTo
     {
         return $this->belongsTo(User::class, 'registered_by');
+    }
+
+    /**
+     * Get the group this team has been drawn into (group_stage_knockout only).
+     */
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(TournamentGroup::class, 'tournament_group_id');
     }
 
     /**

--- a/app/Policies/TournamentPolicy.php
+++ b/app/Policies/TournamentPolicy.php
@@ -104,6 +104,15 @@ final class TournamentPolicy
     }
 
     /**
+     * Determine whether the user can schedule (set date/time/location for) tournament matches.
+     */
+    public function scheduleMatches(User $user, Tournament $tournament): bool
+    {
+        return $tournament->isOrganizer($user->id)
+            && ! in_array($tournament->status, ['completed', 'cancelled'], true);
+    }
+
+    /**
      * Determine whether the user can register a team for the tournament.
      */
     public function register(User $user, Tournament $tournament, Team $team): bool

--- a/app/Policies/TournamentPolicy.php
+++ b/app/Policies/TournamentPolicy.php
@@ -113,6 +113,16 @@ final class TournamentPolicy
     }
 
     /**
+     * Determine whether the user can draw teams into groups (pre-start only).
+     */
+    public function drawGroups(User $user, Tournament $tournament): bool
+    {
+        return $tournament->isOrganizer($user->id)
+            && $tournament->isGroupStageKnockout()
+            && in_array($tournament->status, ['draft', 'registration_open'], true);
+    }
+
+    /**
      * Determine whether the user can register a team for the tournament.
      */
     public function register(User $user, Tournament $tournament, Team $team): bool

--- a/app/Services/MatchService.php
+++ b/app/Services/MatchService.php
@@ -397,19 +397,22 @@ final class MatchService
      */
     public function completeMatch(FootballMatch $match): FootballMatch
     {
-        // Verify match is in progress
         if (! $match->isInProgress()) {
             throw new \Exception('Can only complete in-progress matches');
         }
 
-        // Verify match time has been reached
-        if ($match->scheduled_at->isFuture()) {
+        if ($match->scheduled_at !== null && $match->scheduled_at->isFuture()) {
             throw new \Exception('Cannot complete match before it has started');
         }
 
-        // Tournament matches cannot end in a draw
+        // Draws are forbidden only for knockout matches (single-elim or the
+        // knockout phase of group_stage_knockout). League and group-stage
+        // matches accept draws as valid results.
         if ($match->isTournamentMatch() && $match->home_score === $match->away_score) {
-            throw new \Exception('Tournament matches cannot end in a draw. Please update the score to reflect a winner.');
+            $tournament = $match->tournament;
+            if ($tournament->isSingleElimination() || $tournament->inKnockout()) {
+                throw new \Exception('Tournament matches cannot end in a draw. Please update the score to reflect a winner.');
+            }
         }
 
         $match->update([
@@ -417,10 +420,17 @@ final class MatchService
             'completed_at' => now(),
         ]);
 
-        // If this is a tournament match, advance the winner
         if ($match->isTournamentMatch()) {
             $tournamentService = app(TournamentService::class);
-            $tournamentService->advanceWinner($match);
+            $tournament = $match->tournament;
+
+            if ($tournament->isSingleElimination() || $tournament->inKnockout()) {
+                $tournamentService->advanceWinner($match);
+            } elseif ($tournament->isLeague()) {
+                $tournamentService->completeLeagueIfDone($tournament);
+            } elseif ($tournament->inGroupStage()) {
+                $tournamentService->maybeTransitionToKnockout($tournament);
+            }
         }
 
         return $match->fresh();

--- a/app/Services/StandingsService.php
+++ b/app/Services/StandingsService.php
@@ -1,0 +1,338 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\FootballMatch;
+use App\Models\Tournament;
+use App\Models\TournamentGroup;
+use App\Support\StandingRow;
+use Illuminate\Support\Collection;
+
+class StandingsService
+{
+    public const WIN_POINTS = 3;
+
+    public const DRAW_POINTS = 1;
+
+    public const LOSS_POINTS = 0;
+
+    /**
+     * Compute a standings table from a set of matches over a fixed team set.
+     *
+     * Tiebreakers applied in order: points → goal difference → goals scored →
+     * head-to-head (mini-table over only matches between the tied teams) →
+     * seeded random shuffle (only when teams in the tied subgroup have actually
+     * played each other; otherwise input order is preserved).
+     *
+     * @param  Collection<int, FootballMatch>  $matches
+     * @param  Collection<int, int>  $teamIds
+     * @return array<int, StandingRow>
+     */
+    public function compute(Collection $matches, Collection $teamIds, ?int $rngSeed = null): array
+    {
+        $teamIdList = $teamIds->values()->all();
+
+        $aggregates = [];
+        foreach ($teamIdList as $teamId) {
+            $aggregates[$teamId] = $this->emptyAggregate($teamId);
+        }
+
+        $completed = $matches->filter(fn (FootballMatch $m) => $m->status === 'completed'
+            && $m->home_score !== null
+            && $m->away_score !== null
+            && in_array($m->home_team_id, $teamIdList, true)
+            && in_array($m->away_team_id, $teamIdList, true)
+        )->values();
+
+        foreach ($completed as $match) {
+            $this->applyMatch($aggregates, $match);
+        }
+
+        // Preserve registration/input order as the stable starting order.
+        $ordered = array_values(array_map(fn (int $id) => $aggregates[$id], $teamIdList));
+
+        // Stable sort by primary stats (points → GD → GF).
+        $this->stableSort($ordered, fn (array $a, array $b) => [$b['points'], $b['goal_difference'], $b['goals_for']]
+            <=> [$a['points'], $a['goal_difference'], $a['goals_for']]);
+
+        $ordered = $this->resolveTies($ordered, $completed, $rngSeed);
+
+        return $this->toStandingRows($ordered);
+    }
+
+    /**
+     * Compute league standings (all approved teams over all tournament matches).
+     *
+     * @return array<int, StandingRow>
+     */
+    public function forLeague(Tournament $tournament): array
+    {
+        $teamIds = $tournament->approvedTeams()->pluck('team_id');
+        $matches = $tournament->matches()->get();
+
+        return $this->compute($matches, $teamIds, $tournament->id);
+    }
+
+    /**
+     * Compute standings for a single group.
+     *
+     * @return array<int, StandingRow>
+     */
+    public function forGroup(TournamentGroup $group): array
+    {
+        $group->loadMissing(['teams', 'matches']);
+        $teamIds = $group->teams->pluck('team_id');
+
+        return $this->compute($group->matches, $teamIds, $group->tournament_id);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function emptyAggregate(int $teamId): array
+    {
+        return [
+            'team_id' => $teamId,
+            'played' => 0,
+            'wins' => 0,
+            'draws' => 0,
+            'losses' => 0,
+            'goals_for' => 0,
+            'goals_against' => 0,
+            'goal_difference' => 0,
+            'points' => 0,
+        ];
+    }
+
+    /**
+     * @param  array<int, array<string, int>>  $aggregates
+     */
+    private function applyMatch(array &$aggregates, FootballMatch $match): void
+    {
+        $home = &$aggregates[$match->home_team_id];
+        $away = &$aggregates[$match->away_team_id];
+
+        $home['played']++;
+        $away['played']++;
+        $home['goals_for'] += $match->home_score;
+        $home['goals_against'] += $match->away_score;
+        $away['goals_for'] += $match->away_score;
+        $away['goals_against'] += $match->home_score;
+
+        if ($match->home_score > $match->away_score) {
+            $home['wins']++;
+            $away['losses']++;
+            $home['points'] += self::WIN_POINTS;
+            $away['points'] += self::LOSS_POINTS;
+        } elseif ($match->away_score > $match->home_score) {
+            $away['wins']++;
+            $home['losses']++;
+            $away['points'] += self::WIN_POINTS;
+            $home['points'] += self::LOSS_POINTS;
+        } else {
+            $home['draws']++;
+            $away['draws']++;
+            $home['points'] += self::DRAW_POINTS;
+            $away['points'] += self::DRAW_POINTS;
+        }
+
+        $home['goal_difference'] = $home['goals_for'] - $home['goals_against'];
+        $away['goal_difference'] = $away['goals_for'] - $away['goals_against'];
+    }
+
+    /**
+     * Walk the ordered list, find adjacent runs that tie on (points, GD, GF),
+     * and resolve each run via head-to-head + RNG (only when actually played).
+     *
+     * @param  array<int, array<string, int>>  $ordered
+     * @param  Collection<int, FootballMatch>  $matches
+     * @return array<int, array<string, int|bool>>
+     */
+    private function resolveTies(array $ordered, Collection $matches, ?int $rngSeed): array
+    {
+        $resolved = [];
+        $i = 0;
+        $n = count($ordered);
+
+        while ($i < $n) {
+            $group = [$ordered[$i]];
+            $j = $i + 1;
+            while ($j < $n && $this->primaryEqual($ordered[$i], $ordered[$j])) {
+                $group[] = $ordered[$j];
+                $j++;
+            }
+
+            if (count($group) > 1) {
+                $group = $this->resolveTiedGroup($group, $matches, $rngSeed);
+            }
+
+            foreach ($group as $row) {
+                $resolved[] = $row;
+            }
+            $i = $j;
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<int, array<string, int>>  $group
+     * @param  Collection<int, FootballMatch>  $matches
+     * @return array<int, array<string, int|bool>>
+     */
+    private function resolveTiedGroup(array $group, Collection $matches, ?int $rngSeed): array
+    {
+        $tiedIds = array_column($group, 'team_id');
+
+        $h2hMatches = $matches->filter(fn (FootballMatch $m) => in_array($m->home_team_id, $tiedIds, true)
+            && in_array($m->away_team_id, $tiedIds, true)
+        )->values();
+
+        $miniAggregates = [];
+        foreach ($tiedIds as $teamId) {
+            $miniAggregates[$teamId] = $this->emptyAggregate($teamId);
+        }
+        foreach ($h2hMatches as $match) {
+            $this->applyMatch($miniAggregates, $match);
+        }
+
+        // Stable sort by H2H mini-table.
+        $this->stableSort($group, function (array $a, array $b) use ($miniAggregates) {
+            $ma = $miniAggregates[$a['team_id']];
+            $mb = $miniAggregates[$b['team_id']];
+
+            return [$mb['points'], $mb['goal_difference'], $mb['goals_for']]
+                <=> [$ma['points'], $ma['goal_difference'], $ma['goals_for']];
+        });
+
+        // Find runs that are still tied in the mini-table; only RNG-shuffle if
+        // the subgroup has actually played each other.
+        $resolved = [];
+        $i = 0;
+        $n = count($group);
+        while ($i < $n) {
+            $sub = [$group[$i]];
+            $j = $i + 1;
+            $miniA = $miniAggregates[$group[$i]['team_id']];
+            while ($j < $n) {
+                $miniB = $miniAggregates[$group[$j]['team_id']];
+                if ($this->aggregatesEqual($miniA, $miniB)) {
+                    $sub[] = $group[$j];
+                    $j++;
+                } else {
+                    break;
+                }
+            }
+
+            if (count($sub) > 1) {
+                $subTeamIds = array_column($sub, 'team_id');
+                if ($this->subgroupHasPlayed($h2hMatches, $subTeamIds)) {
+                    $sub = $this->shuffleDeterministic($sub, $rngSeed);
+                    for ($k = 1; $k < count($sub); $k++) {
+                        $sub[$k]['_tied_with_above'] = true;
+                    }
+                }
+            }
+
+            foreach ($sub as $row) {
+                $resolved[] = $row;
+            }
+            $i = $j;
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<string, int>  $a
+     * @param  array<string, int>  $b
+     */
+    private function primaryEqual(array $a, array $b): bool
+    {
+        return $this->aggregatesEqual($a, $b);
+    }
+
+    /**
+     * @param  array<string, int>  $a
+     * @param  array<string, int>  $b
+     */
+    private function aggregatesEqual(array $a, array $b): bool
+    {
+        return $a['points'] === $b['points']
+            && $a['goal_difference'] === $b['goal_difference']
+            && $a['goals_for'] === $b['goals_for'];
+    }
+
+    /**
+     * @param  Collection<int, FootballMatch>  $matches
+     * @param  array<int, int>  $teamIds
+     */
+    private function subgroupHasPlayed(Collection $matches, array $teamIds): bool
+    {
+        foreach ($matches as $match) {
+            if (in_array($match->home_team_id, $teamIds, true)
+                && in_array($match->away_team_id, $teamIds, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<int, array<string, int>>  $items
+     * @return array<int, array<string, int>>
+     */
+    private function shuffleDeterministic(array $items, ?int $rngSeed): array
+    {
+        $seed = ($rngSeed ?? 0) + array_sum(array_column($items, 'team_id'));
+        mt_srand($seed);
+        for ($k = count($items) - 1; $k > 0; $k--) {
+            $r = mt_rand(0, $k);
+            [$items[$k], $items[$r]] = [$items[$r], $items[$k]];
+        }
+        // Restore non-deterministic state so unrelated callers aren't affected.
+        mt_srand();
+
+        return $items;
+    }
+
+    /**
+     * Stable sort (preserves input order for equal elements). PHP's usort is
+     * stable since 8.0 but we wrap it for clarity.
+     *
+     * @param  array<int, mixed>  $items
+     */
+    private function stableSort(array &$items, callable $comparator): void
+    {
+        usort($items, $comparator);
+    }
+
+    /**
+     * @param  array<int, array<string, int|bool>>  $ordered
+     * @return array<int, StandingRow>
+     */
+    private function toStandingRows(array $ordered): array
+    {
+        $rows = [];
+        $position = 1;
+        foreach ($ordered as $aggregate) {
+            $rows[] = new StandingRow(
+                teamId: $aggregate['team_id'],
+                played: $aggregate['played'],
+                wins: $aggregate['wins'],
+                draws: $aggregate['draws'],
+                losses: $aggregate['losses'],
+                goalsFor: $aggregate['goals_for'],
+                goalsAgainst: $aggregate['goals_against'],
+                goalDifference: $aggregate['goal_difference'],
+                points: $aggregate['points'],
+                position: $position,
+                tiedWithAbove: $aggregate['_tied_with_above'] ?? false,
+            );
+            $position++;
+        }
+
+        return $rows;
+    }
+}

--- a/app/Services/Tournament/RoundRobinScheduler.php
+++ b/app/Services/Tournament/RoundRobinScheduler.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Tournament;
+
+final class RoundRobinScheduler
+{
+    /**
+     * Generate a single round-robin schedule using the circle method.
+     *
+     * Returns one fixture per pair of teams across `n - 1` matchdays (n/2
+     * matches per matchday). If team count is odd, a phantom BYE is added and
+     * fixtures involving it are skipped. Home/away alternates per round so the
+     * fixed-position team gets a balanced split.
+     *
+     * @param  array<int, int>  $teamIds
+     * @return array<int, array{matchday: int, home: int, away: int}>
+     */
+    public function generate(array $teamIds): array
+    {
+        $teams = array_values($teamIds);
+        if (count($teams) < 2) {
+            return [];
+        }
+
+        if (count($teams) % 2 === 1) {
+            $teams[] = -1; // BYE sentinel
+        }
+
+        $n = count($teams);
+        $rounds = $n - 1;
+        $half = intdiv($n, 2);
+
+        // We rotate indices into $teams instead of the array itself so the
+        // fixed team (position 0) is always the original first team.
+        $positions = range(0, $n - 1);
+        $fixtures = [];
+
+        for ($r = 0; $r < $rounds; $r++) {
+            $matchday = $r + 1;
+
+            for ($i = 0; $i < $half; $i++) {
+                $home = $teams[$positions[$i]];
+                $away = $teams[$positions[$n - 1 - $i]];
+
+                if ($home === -1 || $away === -1) {
+                    continue;
+                }
+
+                if ($r % 2 === 1) {
+                    $fixtures[] = ['matchday' => $matchday, 'home' => $away, 'away' => $home];
+                } else {
+                    $fixtures[] = ['matchday' => $matchday, 'home' => $home, 'away' => $away];
+                }
+            }
+
+            // Rotate: keep position[0] fixed, move last index to position 1,
+            // shift the rest right by one.
+            $last = $positions[$n - 1];
+            for ($k = $n - 1; $k > 1; $k--) {
+                $positions[$k] = $positions[$k - 1];
+            }
+            $positions[1] = $last;
+        }
+
+        return $fixtures;
+    }
+}

--- a/app/Services/TournamentService.php
+++ b/app/Services/TournamentService.php
@@ -282,8 +282,8 @@ final class TournamentService
                 'variant' => $tournament->variant,
                 'status' => 'confirmed',
                 'match_type' => 'competitive',
-                'scheduled_at' => $tournament->starts_at,
-                'location' => 'TBD',
+                'scheduled_at' => null,
+                'location' => null,
                 'created_by' => $tournament->organizer_id,
                 'confirmed_at' => now(),
             ]);
@@ -304,8 +304,8 @@ final class TournamentService
                     'variant' => $tournament->variant,
                     'status' => 'pending',
                     'match_type' => 'competitive',
-                    'scheduled_at' => $tournament->starts_at,
-                    'location' => 'TBD',
+                    'scheduled_at' => null,
+                    'location' => null,
                     'created_by' => $tournament->organizer_id,
                 ]);
             }

--- a/app/Services/TournamentService.php
+++ b/app/Services/TournamentService.php
@@ -7,9 +7,12 @@ namespace App\Services;
 use App\Models\FootballMatch;
 use App\Models\Team;
 use App\Models\Tournament;
+use App\Models\TournamentGroup;
 use App\Models\TournamentRound;
 use App\Models\TournamentTeam;
 use App\Models\User;
+use App\Services\Tournament\RoundRobinScheduler;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 final class TournamentService
@@ -19,11 +22,12 @@ final class TournamentService
      */
     public function createTournament(User $user, array $data): Tournament
     {
-        // Validate max_teams is power of 2
-        $maxTeams = (int) ($data['max_teams'] ?? 8);
-        if (! $this->isPowerOfTwo($maxTeams)) {
-            throw new \InvalidArgumentException('Max teams must be a power of 2 (4, 8, 16, 32, 64)');
-        }
+        $format = $data['format'] ?? 'single_elimination';
+        $groupCount = isset($data['group_count']) ? (int) $data['group_count'] : null;
+        $groupSize = isset($data['group_size']) ? (int) $data['group_size'] : null;
+
+        $maxTeams = $this->resolveMaxTeams($format, $data, $groupCount, $groupSize);
+        $this->validateFormatConfig($format, $maxTeams, $groupCount, $groupSize);
 
         $tournament = Tournament::create([
             'name' => $data['name'],
@@ -33,12 +37,20 @@ final class TournamentService
             'visibility' => $data['visibility'] ?? 'public',
             'status' => $data['status'] ?? 'draft',
             'variant' => $data['variant'],
+            'format' => $format,
+            'phase' => 'not_started',
+            'group_count' => $format === 'group_stage_knockout' ? $groupCount : null,
+            'group_size' => $format === 'group_stage_knockout' ? $groupSize : null,
             'max_teams' => $maxTeams,
             'min_teams' => $data['min_teams'] ?? 4,
             'registration_deadline' => $data['registration_deadline'] ?? null,
             'starts_at' => $data['starts_at'] ?? null,
             'ends_at' => $data['ends_at'] ?? null,
         ]);
+
+        if ($format === 'group_stage_knockout') {
+            $this->createGroups($tournament);
+        }
 
         return $tournament;
     }
@@ -52,16 +64,22 @@ final class TournamentService
             throw new \RuntimeException('Tournament cannot be edited in its current status');
         }
 
-        // Validate max_teams is power of 2 if being changed
-        if (isset($data['max_teams'])) {
-            if (! $this->isPowerOfTwo((int) $data['max_teams'])) {
-                throw new \InvalidArgumentException('Max teams must be a power of 2 (4, 8, 16, 32, 64)');
+        // Format cannot change once any team has registered.
+        if (isset($data['format']) && $data['format'] !== $tournament->format) {
+            if ($tournament->getRegisteredTeamsCount() > 0) {
+                throw new \InvalidArgumentException('Cannot change tournament format after teams have registered');
             }
+        }
 
-            // Check if reducing max_teams would exclude already registered teams
-            if ($data['max_teams'] < $tournament->getRegisteredTeamsCount()) {
-                throw new \InvalidArgumentException('Cannot reduce max teams below current registered count');
-            }
+        $format = $data['format'] ?? $tournament->format;
+        $groupCount = $data['group_count'] ?? $tournament->group_count;
+        $groupSize = $data['group_size'] ?? $tournament->group_size;
+
+        $maxTeams = $this->resolveMaxTeams($format, $data, $groupCount, $groupSize, fallback: $tournament->max_teams);
+        $this->validateFormatConfig($format, $maxTeams, $groupCount, $groupSize);
+
+        if ($maxTeams < $tournament->getRegisteredTeamsCount()) {
+            throw new \InvalidArgumentException('Cannot reduce max teams below current registered count');
         }
 
         $tournament->update([
@@ -70,7 +88,10 @@ final class TournamentService
             'logo_path' => $data['logo_path'] ?? $tournament->logo_path,
             'visibility' => $data['visibility'] ?? $tournament->visibility,
             'variant' => $data['variant'] ?? $tournament->variant,
-            'max_teams' => $data['max_teams'] ?? $tournament->max_teams,
+            'format' => $format,
+            'group_count' => $format === 'group_stage_knockout' ? $groupCount : null,
+            'group_size' => $format === 'group_stage_knockout' ? $groupSize : null,
+            'max_teams' => $maxTeams,
             'min_teams' => $data['min_teams'] ?? $tournament->min_teams,
             'registration_deadline' => $data['registration_deadline'] ?? $tournament->registration_deadline,
             'starts_at' => $data['starts_at'] ?? $tournament->starts_at,
@@ -202,7 +223,7 @@ final class TournamentService
     }
 
     /**
-     * Start the tournament and generate bracket.
+     * Start the tournament and generate the schedule for its format.
      */
     public function startTournament(Tournament $tournament): void
     {
@@ -216,62 +237,389 @@ final class TournamentService
             throw new \RuntimeException("Tournament needs at least {$tournament->min_teams} teams to start");
         }
 
-        if (! $this->isPowerOfTwo($approvedCount)) {
-            throw new \RuntimeException('Number of approved teams must be a power of 2 (4, 8, 16, 32, 64)');
-        }
+        DB::transaction(function () use ($tournament, $approvedCount) {
+            if ($tournament->isLeague()) {
+                if ($approvedCount < 2) {
+                    throw new \RuntimeException('League tournaments need at least 2 teams to start');
+                }
+                $tournament->update(['status' => 'in_progress', 'phase' => 'league']);
+                $this->generateLeagueSchedule($tournament);
 
-        DB::transaction(function () use ($tournament) {
-            $tournament->update(['status' => 'in_progress']);
+                return;
+            }
+
+            if ($tournament->isGroupStageKnockout()) {
+                $expected = (int) $tournament->group_count * (int) $tournament->group_size;
+                if ($approvedCount !== $expected) {
+                    throw new \RuntimeException("Tournament needs exactly {$expected} approved teams to start");
+                }
+                if ($tournament->approvedTeams()->whereNull('tournament_group_id')->exists()) {
+                    throw new \RuntimeException('All approved teams must be assigned to a group before starting');
+                }
+                $tournament->update(['status' => 'in_progress', 'phase' => 'group_stage']);
+                $this->generateGroupStageMatches($tournament);
+
+                return;
+            }
+
+            // Default: single-elimination
+            if (! $this->isPowerOfTwo($approvedCount)) {
+                throw new \RuntimeException('Number of approved teams must be a power of 2 (4, 8, 16, 32, 64)');
+            }
+            $tournament->update(['status' => 'in_progress', 'phase' => 'knockout']);
             $this->generateBracket($tournament);
         });
     }
 
     /**
-     * Generate tournament bracket.
+     * Generate the league schedule (round-robin, one matchday per round).
      */
-    public function generateBracket(Tournament $tournament): void
+    public function generateLeagueSchedule(Tournament $tournament): void
     {
-        // Get approved teams ordered by seed (nulls last)
-        $teams = $tournament->tournamentTeams()
-            ->where('status', 'approved')
-            ->with('team')
+        $teamIds = $tournament->approvedTeams()
             ->orderByRaw('seed IS NULL, seed ASC')
-            ->get();
+            ->pluck('team_id')
+            ->all();
 
-        // Assign seeds if not set
-        $teams = $teams->map(function ($tournamentTeam, $index) {
-            if ($tournamentTeam->seed === null) {
-                $tournamentTeam->seed = $index + 1;
-                $tournamentTeam->save();
+        $fixtures = (new RoundRobinScheduler)->generate($teamIds);
+
+        $matchdays = [];
+        foreach ($fixtures as $fixture) {
+            $matchdays[$fixture['matchday']][] = $fixture;
+        }
+
+        foreach ($matchdays as $matchdayNum => $matches) {
+            $round = TournamentRound::create([
+                'tournament_id' => $tournament->id,
+                'round_number' => $matchdayNum,
+                'name' => "Jornada {$matchdayNum}",
+                'starts_at' => $tournament->starts_at,
+            ]);
+
+            foreach ($matches as $fixture) {
+                FootballMatch::create([
+                    'tournament_id' => $tournament->id,
+                    'tournament_round_id' => $round->id,
+                    'matchday' => $matchdayNum,
+                    'home_team_id' => $fixture['home'],
+                    'away_team_id' => $fixture['away'],
+                    'bracket_position' => null,
+                    'variant' => $tournament->variant,
+                    'status' => 'confirmed',
+                    'match_type' => 'competitive',
+                    'scheduled_at' => null,
+                    'location' => null,
+                    'created_by' => $tournament->organizer_id,
+                    'confirmed_at' => now(),
+                ]);
+            }
+        }
+    }
+
+    /**
+     * If every league match is completed, mark the tournament completed.
+     */
+    public function completeLeagueIfDone(Tournament $tournament): void
+    {
+        if (! $tournament->isLeague()) {
+            return;
+        }
+
+        $hasIncomplete = $tournament->matches()
+            ->where('status', '!=', 'completed')
+            ->exists();
+
+        if (! $hasIncomplete) {
+            $tournament->update([
+                'status' => 'completed',
+                'phase' => 'completed',
+                'ends_at' => now(),
+            ]);
+        }
+    }
+
+    /**
+     * Generate group-stage round-robin matches for every group, sharing one
+     * `tournament_round` per matchday across all groups.
+     */
+    public function generateGroupStageMatches(Tournament $tournament): void
+    {
+        $groups = $tournament->groups()->with('teams')->get();
+
+        if ($groups->isEmpty()) {
+            throw new \RuntimeException('Tournament has no groups defined');
+        }
+
+        $scheduler = new RoundRobinScheduler;
+        $byMatchday = [];
+
+        foreach ($groups as $group) {
+            $teamIds = $group->teams->pluck('team_id')->all();
+            $fixtures = $scheduler->generate($teamIds);
+            foreach ($fixtures as $fixture) {
+                $byMatchday[$fixture['matchday']][] = [
+                    'group_id' => $group->id,
+                    'home' => $fixture['home'],
+                    'away' => $fixture['away'],
+                ];
+            }
+        }
+
+        ksort($byMatchday);
+
+        foreach ($byMatchday as $matchdayNum => $matches) {
+            $round = TournamentRound::create([
+                'tournament_id' => $tournament->id,
+                'round_number' => $matchdayNum,
+                'name' => "Jornada {$matchdayNum} - Fase de grupos",
+                'starts_at' => $tournament->starts_at,
+            ]);
+
+            foreach ($matches as $fixture) {
+                FootballMatch::create([
+                    'tournament_id' => $tournament->id,
+                    'tournament_round_id' => $round->id,
+                    'tournament_group_id' => $fixture['group_id'],
+                    'matchday' => $matchdayNum,
+                    'home_team_id' => $fixture['home'],
+                    'away_team_id' => $fixture['away'],
+                    'bracket_position' => null,
+                    'variant' => $tournament->variant,
+                    'status' => 'confirmed',
+                    'match_type' => 'competitive',
+                    'scheduled_at' => null,
+                    'location' => null,
+                    'created_by' => $tournament->organizer_id,
+                    'confirmed_at' => now(),
+                ]);
+            }
+        }
+    }
+
+    /**
+     * If every group-stage match is completed, compute advancers, generate the
+     * knockout bracket, and flip the tournament into the knockout phase.
+     */
+    public function maybeTransitionToKnockout(Tournament $tournament): void
+    {
+        if (! $tournament->isGroupStageKnockout() || ! $tournament->inGroupStage()) {
+            return;
+        }
+
+        $hasIncomplete = $tournament->matches()
+            ->whereNotNull('tournament_group_id')
+            ->where('status', '!=', 'completed')
+            ->exists();
+
+        if ($hasIncomplete) {
+            return;
+        }
+
+        DB::transaction(function () use ($tournament) {
+            $lastMatchday = (int) $tournament->matches()
+                ->whereNotNull('matchday')
+                ->max('matchday');
+
+            $standingsService = app(StandingsService::class);
+            $advancers = []; // group_position => [rank => team_id]
+
+            $tournament->load('groups.teams', 'groups.matches');
+            $groups = $tournament->groups->sortBy('position')->values();
+
+            foreach ($groups as $group) {
+                $rows = $standingsService->forGroup($group);
+                $advancers[$group->position] = [
+                    0 => $rows[0]->teamId,
+                    1 => $rows[1]->teamId,
+                ];
             }
 
-            return $tournamentTeam;
+            $pairings = $this->groupKnockoutPairings((int) $tournament->group_count);
+
+            // Flatten pairings into bracket-ordered team_ids: pos 0 home, pos 0 away, pos 1 home, ...
+            $orderedTeamIds = [];
+            foreach ($pairings as $pairing) {
+                $orderedTeamIds[] = $advancers[$pairing['home_group_pos']][$pairing['home_rank']];
+                $orderedTeamIds[] = $advancers[$pairing['away_group_pos']][$pairing['away_rank']];
+            }
+
+            $tournamentTeams = TournamentTeam::where('tournament_id', $tournament->id)
+                ->whereIn('team_id', $orderedTeamIds)
+                ->get()
+                ->keyBy('team_id');
+
+            $teamsOrdered = collect($orderedTeamIds)
+                ->map(fn (int $teamId) => $tournamentTeams[$teamId])
+                ->values();
+
+            $this->generateBracket($tournament, $teamsOrdered, $lastMatchday + 1);
+            $tournament->update(['phase' => 'knockout']);
         });
+    }
+
+    /**
+     * Cross-bracket pairings for the knockout phase of a group_stage_knockout
+     * tournament. Returns one entry per first-round bracket position, keyed by
+     * bracket_position, mapping to the (home_group_pos, home_rank, away_group_pos,
+     * away_rank) of the advancers to slot into that match.
+     *
+     * Pairs adjacent groups (0,1) (2,3) ... and mirrors them across the bracket
+     * so group winners can only meet at later rounds.
+     *
+     * @return array<int, array{home_group_pos: int, home_rank: int, away_group_pos: int, away_rank: int}>
+     */
+    private function groupKnockoutPairings(int $groupCount): array
+    {
+        if (! $this->isPowerOfTwo($groupCount) || $groupCount < 2) {
+            throw new \RuntimeException('Group count must be a power of 2 ≥ 2');
+        }
+
+        $pairings = [];
+        $half = intdiv($groupCount, 2);
+
+        for ($i = 0; $i < $groupCount; $i += 2) {
+            $primaryPos = intdiv($i, 2);
+            $mirrorPos = $primaryPos + $half;
+
+            $pairings[$primaryPos] = [
+                'home_group_pos' => $i,
+                'home_rank' => 0,
+                'away_group_pos' => $i + 1,
+                'away_rank' => 1,
+            ];
+
+            $pairings[$mirrorPos] = [
+                'home_group_pos' => $i + 1,
+                'home_rank' => 0,
+                'away_group_pos' => $i,
+                'away_rank' => 1,
+            ];
+        }
+
+        ksort($pairings);
+
+        return $pairings;
+    }
+
+    /**
+     * Auto-create groups when a group_stage_knockout tournament is created.
+     */
+    private function createGroups(Tournament $tournament): void
+    {
+        $count = (int) $tournament->group_count;
+        for ($i = 0; $i < $count; $i++) {
+            TournamentGroup::create([
+                'tournament_id' => $tournament->id,
+                'name' => chr(ord('A') + $i),
+                'position' => $i,
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function resolveMaxTeams(string $format, array $data, ?int $groupCount, ?int $groupSize, ?int $fallback = null): int
+    {
+        if ($format === 'group_stage_knockout') {
+            if ($groupCount && $groupSize) {
+                return $groupCount * $groupSize;
+            }
+        }
+
+        if (isset($data['max_teams'])) {
+            return (int) $data['max_teams'];
+        }
+
+        return $fallback ?? 8;
+    }
+
+    private function validateFormatConfig(string $format, int $maxTeams, ?int $groupCount, ?int $groupSize): void
+    {
+        if (! in_array($format, ['single_elimination', 'league', 'group_stage_knockout'], true)) {
+            throw new \InvalidArgumentException('Invalid tournament format');
+        }
+
+        if ($format === 'single_elimination') {
+            if (! in_array($maxTeams, [4, 8, 16, 32, 64], true)) {
+                throw new \InvalidArgumentException('Single-elimination tournaments require max teams in {4, 8, 16, 32, 64}');
+            }
+
+            return;
+        }
+
+        if ($format === 'league') {
+            if ($maxTeams < 2 || $maxTeams > 64) {
+                throw new \InvalidArgumentException('League tournaments require between 2 and 64 teams');
+            }
+
+            return;
+        }
+
+        // group_stage_knockout
+        if (! in_array($groupCount, [2, 4, 8, 16], true)) {
+            throw new \InvalidArgumentException('Group count must be 2, 4, 8 or 16');
+        }
+        if ($groupSize === null || $groupSize < 2 || $groupSize > 16) {
+            throw new \InvalidArgumentException('Group size must be between 2 and 16');
+        }
+        if ($maxTeams !== $groupCount * $groupSize) {
+            throw new \InvalidArgumentException('Max teams must equal group_count × group_size');
+        }
+    }
+
+    /**
+     * Generate a single-elimination bracket.
+     *
+     * When called with no team list, loads approved teams ordered by seed
+     * (assigning seeds to any unseeded entries). When called with an explicit
+     * team list (used by the group→knockout transition), uses that list as-is
+     * and starts numbering rounds from $startingRoundNumber.
+     *
+     * @param  Collection<int, TournamentTeam>|null  $teams
+     */
+    public function generateBracket(Tournament $tournament, ?Collection $teams = null, int $startingRoundNumber = 1): void
+    {
+        if ($teams === null) {
+            $teams = $tournament->tournamentTeams()
+                ->where('status', 'approved')
+                ->with('team')
+                ->orderByRaw('seed IS NULL, seed ASC')
+                ->get();
+
+            $teams = $teams->map(function ($tournamentTeam, $index) {
+                if ($tournamentTeam->seed === null) {
+                    $tournamentTeam->seed = $index + 1;
+                    $tournamentTeam->save();
+                }
+
+                return $tournamentTeam;
+            });
+        }
 
         $teamCount = $teams->count();
 
-        // Validate team count is power of 2
         if (! $this->isPowerOfTwo($teamCount)) {
-            throw new \RuntimeException('Number of approved teams must be a power of 2');
+            throw new \RuntimeException('Number of teams must be a power of 2');
         }
 
-        // Calculate rounds needed
-        $totalRounds = (int) log($teamCount, 2);
+        $totalRoundsForBracket = (int) log($teamCount, 2);
 
-        // Create round records
-        for ($i = 1; $i <= $totalRounds; $i++) {
+        // Create round records (numbering continues from $startingRoundNumber).
+        for ($i = 0; $i < $totalRoundsForBracket; $i++) {
+            $namePosition = $i + 1; // 1-indexed within the bracket for naming
             TournamentRound::create([
                 'tournament_id' => $tournament->id,
-                'round_number' => $i,
-                'name' => $this->getRoundName($i, $totalRounds),
+                'round_number' => $startingRoundNumber + $i,
+                'name' => $this->getRoundName($namePosition, $totalRoundsForBracket),
                 'starts_at' => $tournament->starts_at,
             ]);
         }
 
-        // Get first round
-        $firstRound = $tournament->rounds()->where('round_number', 1)->first();
+        $firstRound = $tournament->rounds()
+            ->where('round_number', $startingRoundNumber)
+            ->first();
 
-        // Create first round matches with seeding
         for ($i = 0; $i < $teamCount; $i += 2) {
             FootballMatch::create([
                 'tournament_id' => $tournament->id,
@@ -289,17 +637,18 @@ final class TournamentService
             ]);
         }
 
-        // Create placeholder matches for subsequent rounds
-        for ($roundNum = 2; $roundNum <= $totalRounds; $roundNum++) {
-            $round = $tournament->rounds()->where('round_number', $roundNum)->first();
-            $matchesInRound = intdiv($teamCount, pow(2, $roundNum));
+        for ($i = 1; $i < $totalRoundsForBracket; $i++) {
+            $round = $tournament->rounds()
+                ->where('round_number', $startingRoundNumber + $i)
+                ->first();
+            $matchesInRound = intdiv($teamCount, pow(2, $i + 1));
 
             for ($matchPos = 0; $matchPos < $matchesInRound; $matchPos++) {
                 FootballMatch::create([
                     'tournament_id' => $tournament->id,
                     'tournament_round_id' => $round->id,
-                    'home_team_id' => null, // TBD
-                    'away_team_id' => null, // TBD
+                    'home_team_id' => null,
+                    'away_team_id' => null,
                     'bracket_position' => $matchPos,
                     'variant' => $tournament->variant,
                     'status' => 'pending',

--- a/app/Support/StandingRow.php
+++ b/app/Support/StandingRow.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Support;
+
+final readonly class StandingRow
+{
+    public function __construct(
+        public int $teamId,
+        public int $played,
+        public int $wins,
+        public int $draws,
+        public int $losses,
+        public int $goalsFor,
+        public int $goalsAgainst,
+        public int $goalDifference,
+        public int $points,
+        public int $position,
+        public bool $tiedWithAbove = false,
+    ) {}
+
+    /**
+     * @return array<string, int|bool>
+     */
+    public function toArray(): array
+    {
+        return [
+            'team_id' => $this->teamId,
+            'played' => $this->played,
+            'wins' => $this->wins,
+            'draws' => $this->draws,
+            'losses' => $this->losses,
+            'goals_for' => $this->goalsFor,
+            'goals_against' => $this->goalsAgainst,
+            'goal_difference' => $this->goalDifference,
+            'points' => $this->points,
+            'position' => $this->position,
+            'tied_with_above' => $this->tiedWithAbove,
+        ];
+    }
+}

--- a/database/migrations/2026_04_25_163750_make_match_schedule_nullable.php
+++ b/database/migrations/2026_04_25_163750_make_match_schedule_nullable.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('matches', function (Blueprint $table) {
+            $table->dateTime('scheduled_at')->nullable()->change();
+            $table->string('location')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('matches', function (Blueprint $table) {
+            $table->dateTime('scheduled_at')->nullable(false)->change();
+            $table->string('location')->nullable(false)->change();
+        });
+    }
+};

--- a/database/migrations/2026_05_10_000001_add_format_and_phase_to_tournaments_table.php
+++ b/database/migrations/2026_05_10_000001_add_format_and_phase_to_tournaments_table.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tournaments', function (Blueprint $table) {
+            $table->enum('format', ['single_elimination', 'league', 'group_stage_knockout'])
+                ->default('single_elimination')
+                ->after('variant');
+
+            $table->enum('phase', ['not_started', 'league', 'group_stage', 'knockout', 'completed'])
+                ->default('not_started')
+                ->after('format');
+
+            $table->unsignedSmallInteger('group_count')->nullable()->after('phase');
+            $table->unsignedSmallInteger('group_size')->nullable()->after('group_count');
+
+            $table->index('format');
+        });
+
+        // Backfill phase for existing tournaments based on status.
+        DB::table('tournaments')->where('status', 'completed')->update(['phase' => 'completed']);
+        DB::table('tournaments')->where('status', 'in_progress')->update(['phase' => 'knockout']);
+    }
+
+    public function down(): void
+    {
+        Schema::table('tournaments', function (Blueprint $table) {
+            $table->dropIndex(['format']);
+            $table->dropColumn(['format', 'phase', 'group_count', 'group_size']);
+        });
+    }
+};

--- a/database/migrations/2026_05_10_000002_create_tournament_groups_table.php
+++ b/database/migrations/2026_05_10_000002_create_tournament_groups_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tournament_groups', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tournament_id')->constrained()->cascadeOnDelete();
+            $table->string('name', 8);
+            $table->unsignedSmallInteger('position');
+            $table->timestamps();
+
+            $table->unique(['tournament_id', 'name']);
+            $table->unique(['tournament_id', 'position']);
+            $table->index('tournament_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tournament_groups');
+    }
+};

--- a/database/migrations/2026_05_10_000003_add_group_to_tournament_teams_table.php
+++ b/database/migrations/2026_05_10_000003_add_group_to_tournament_teams_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tournament_teams', function (Blueprint $table) {
+            $table->foreignId('tournament_group_id')
+                ->nullable()
+                ->after('seed')
+                ->constrained('tournament_groups')
+                ->nullOnDelete();
+
+            $table->index('tournament_group_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tournament_teams', function (Blueprint $table) {
+            $table->dropForeign(['tournament_group_id']);
+            $table->dropIndex(['tournament_group_id']);
+            $table->dropColumn('tournament_group_id');
+        });
+    }
+};

--- a/database/migrations/2026_05_10_000004_add_group_and_matchday_to_matches_table.php
+++ b/database/migrations/2026_05_10_000004_add_group_and_matchday_to_matches_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('matches', function (Blueprint $table) {
+            $table->foreignId('tournament_group_id')
+                ->nullable()
+                ->after('tournament_round_id')
+                ->constrained('tournament_groups')
+                ->nullOnDelete();
+
+            $table->unsignedSmallInteger('matchday')->nullable()->after('bracket_position');
+
+            $table->index('tournament_group_id');
+            $table->index(['tournament_id', 'matchday']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('matches', function (Blueprint $table) {
+            $table->dropForeign(['tournament_group_id']);
+            $table->dropIndex(['tournament_group_id']);
+            $table->dropIndex(['tournament_id', 'matchday']);
+            $table->dropColumn(['tournament_group_id', 'matchday']);
+        });
+    }
+};

--- a/resources/js/components/match-card.tsx
+++ b/resources/js/components/match-card.tsx
@@ -19,8 +19,8 @@ interface Match {
     home_team_id: number;
     away_team_id?: number;
     variant: string;
-    scheduled_at: string;
-    location: string;
+    scheduled_at: string | null;
+    location: string | null;
     match_type: string;
     status: string;
     home_score?: number;
@@ -34,7 +34,8 @@ interface MatchCardProps {
     match: Match;
 }
 
-const formatDate = (dateString: string): string => {
+const formatDate = (dateString: string | null): string => {
+    if (!dateString) return 'Por programar';
     const date = new Date(dateString);
     return date.toLocaleDateString('es-ES', {
         month: 'short',
@@ -43,7 +44,8 @@ const formatDate = (dateString: string): string => {
     });
 };
 
-const formatTime = (dateString: string): string => {
+const formatTime = (dateString: string | null): string => {
+    if (!dateString) return '—';
     const date = new Date(dateString);
     return date.toLocaleTimeString('es-ES', {
         hour: 'numeric',
@@ -179,7 +181,9 @@ export function MatchCard({ match }: MatchCardProps) {
                 <div className="flex items-center justify-between text-sm text-muted-foreground">
                     <div className="flex min-w-0 flex-1 items-center gap-2">
                         <MapPin className="h-4 w-4 flex-shrink-0" />
-                        <span className="line-clamp-1">{match.location}</span>
+                        <span className="line-clamp-1">
+                            {match.location ?? 'Por definir'}
+                        </span>
                     </div>
                     <div className="flex flex-shrink-0 items-center gap-2">
                         <Trophy className="h-4 w-4" />

--- a/resources/js/components/match/match-hero.tsx
+++ b/resources/js/components/match/match-hero.tsx
@@ -316,7 +316,7 @@ export function MatchHero({
                         <div className="flex items-center gap-2">
                             <MapPin className="h-4 w-4 text-muted-foreground" />
                             <span className="font-medium">
-                                {match.location}
+                                {match.location ?? 'Por definir'}
                             </span>
                         </div>
                     </div>

--- a/resources/js/components/match/types.ts
+++ b/resources/js/components/match/types.ts
@@ -60,8 +60,8 @@ export interface MatchPageMatch {
     away_team_id?: number;
     tournament_id?: number;
     variant: string;
-    scheduled_at: string;
-    location: string;
+    scheduled_at: string | null;
+    location: string | null;
     match_type: string;
     status: string;
     home_score?: number;

--- a/resources/js/components/score-tracker.tsx
+++ b/resources/js/components/score-tracker.tsx
@@ -24,7 +24,7 @@ interface Match {
     home_score?: number;
     away_score?: number;
     status: string;
-    scheduled_at: string;
+    scheduled_at: string | null;
     home_team: Team;
     away_team?: Team;
 }
@@ -45,8 +45,10 @@ export function ScoreTracker({ match, isLeader }: Props) {
 
     // Calculate countdown and check if match has started
     useEffect(() => {
+        if (!match.scheduled_at) return;
+        const scheduledAt = match.scheduled_at;
         const updateCountdown = () => {
-            const matchTime = new Date(match.scheduled_at);
+            const matchTime = new Date(scheduledAt);
             const currentTime = new Date();
             const timeDiff = matchTime.getTime() - currentTime.getTime();
 

--- a/resources/js/components/tournament/group-draw.tsx
+++ b/resources/js/components/tournament/group-draw.tsx
@@ -1,0 +1,274 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+import type { Team, TournamentGroup, TournamentTeam } from '@/types';
+import { router } from '@inertiajs/react';
+import { Loader2, RotateCcw, Save } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+interface Props {
+    tournamentId: number;
+    groups: TournamentGroup[];
+    approvedTeams: (TournamentTeam & { team: Team })[];
+    groupSize: number;
+}
+
+const UNASSIGNED = 'unassigned';
+
+export function GroupDraw({
+    tournamentId,
+    groups,
+    approvedTeams,
+    groupSize,
+}: Props) {
+    // Local map of tournamentTeam.id → tournamentGroupId|null. Initialised
+    // from the backend payload so the UI reflects what's already saved.
+    const [assignments, setAssignments] = useState<
+        Record<number, number | null>
+    >(() => {
+        const init: Record<number, number | null> = {};
+        for (const tt of approvedTeams) {
+            init[tt.id] = tt.tournament_group_id ?? null;
+        }
+        return init;
+    });
+    const [saving, setSaving] = useState(false);
+
+    const teamsByGroup = useMemo(() => {
+        const map: Record<number, (TournamentTeam & { team: Team })[]> = {};
+        for (const group of groups) map[group.id] = [];
+        for (const tt of approvedTeams) {
+            const groupId = assignments[tt.id];
+            if (groupId != null && map[groupId]) map[groupId].push(tt);
+        }
+        return map;
+    }, [groups, approvedTeams, assignments]);
+
+    const totalAssigned = approvedTeams.filter(
+        (tt) => assignments[tt.id] != null,
+    ).length;
+    const allAssigned = totalAssigned === approvedTeams.length;
+    const overflow = groups.some(
+        (g) => (teamsByGroup[g.id]?.length ?? 0) > groupSize,
+    );
+
+    const handleAssign = (tournamentTeamId: number, value: string) => {
+        setAssignments((prev) => ({
+            ...prev,
+            [tournamentTeamId]:
+                value === UNASSIGNED ? null : parseInt(value, 10),
+        }));
+    };
+
+    const handleSave = () => {
+        if (overflow) {
+            toast.error(
+                'Algún grupo tiene más equipos que el tamaño permitido.',
+            );
+            return;
+        }
+        setSaving(true);
+        router.post(
+            `/tournaments/${tournamentId}/groups/draw`,
+            {
+                assignments: approvedTeams.map((tt) => ({
+                    tournament_team_id: tt.id,
+                    tournament_group_id: assignments[tt.id],
+                })),
+            },
+            {
+                preserveScroll: true,
+                onSuccess: () => toast.success('Sorteo guardado.'),
+                onError: () => toast.error('No se pudo guardar el sorteo.'),
+                onFinish: () => setSaving(false),
+            },
+        );
+    };
+
+    const handleClear = () => {
+        if (!confirm('¿Borrar todas las asignaciones?')) return;
+        router.delete(`/tournaments/${tournamentId}/groups/draw`, {
+            preserveScroll: true,
+            onSuccess: () => {
+                setAssignments(
+                    Object.fromEntries(
+                        approvedTeams.map((tt) => [tt.id, null]),
+                    ),
+                );
+                toast.success('Sorteo reiniciado.');
+            },
+            onError: () => toast.error('No se pudo reiniciar el sorteo.'),
+        });
+    };
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-start justify-between gap-4">
+                <div>
+                    <CardTitle className="text-base">
+                        Sorteo de Grupos
+                    </CardTitle>
+                    <CardDescription>
+                        Asigná cada equipo a un grupo antes de comenzar el
+                        torneo. {totalAssigned}/{approvedTeams.length}{' '}
+                        asignados.
+                    </CardDescription>
+                </div>
+                <div className="flex gap-2">
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={handleClear}
+                        disabled={saving || totalAssigned === 0}
+                    >
+                        <RotateCcw className="size-4" />
+                        Reiniciar
+                    </Button>
+                    <Button
+                        type="button"
+                        size="sm"
+                        onClick={handleSave}
+                        disabled={saving || overflow}
+                    >
+                        {saving ? (
+                            <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                            <Save className="size-4" />
+                        )}
+                        Guardar
+                    </Button>
+                </div>
+            </CardHeader>
+            <CardContent className="space-y-6">
+                {/* Team list with per-team group selector */}
+                <div className="space-y-2">
+                    <h3 className="text-sm font-medium text-muted-foreground">
+                        Equipos
+                    </h3>
+                    <div className="space-y-2">
+                        {approvedTeams.map((tt) => (
+                            <div
+                                key={tt.id}
+                                className="flex items-center justify-between gap-3 rounded-md border p-2"
+                            >
+                                <div className="flex min-w-0 items-center gap-2">
+                                    <Avatar className="size-7">
+                                        {tt.team?.logo_url && (
+                                            <AvatarImage
+                                                src={tt.team.logo_url}
+                                                alt={tt.team.name}
+                                            />
+                                        )}
+                                        <AvatarFallback className="text-xs">
+                                            {tt.team?.name
+                                                ?.slice(0, 2)
+                                                .toUpperCase() ?? '?'}
+                                        </AvatarFallback>
+                                    </Avatar>
+                                    <span className="truncate text-sm font-medium">
+                                        {tt.team?.name ?? `Team ${tt.team_id}`}
+                                    </span>
+                                </div>
+                                <Select
+                                    value={(
+                                        assignments[tt.id] ?? UNASSIGNED
+                                    ).toString()}
+                                    onValueChange={(value) =>
+                                        handleAssign(tt.id, value)
+                                    }
+                                >
+                                    <SelectTrigger className="w-32">
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value={UNASSIGNED}>
+                                            Sin grupo
+                                        </SelectItem>
+                                        {groups.map((group) => (
+                                            <SelectItem
+                                                key={group.id}
+                                                value={group.id.toString()}
+                                            >
+                                                Grupo {group.name}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Group overview */}
+                <div className="grid gap-3 md:grid-cols-2">
+                    {groups.map((group) => {
+                        const teams = teamsByGroup[group.id] ?? [];
+                        const overCapacity = teams.length > groupSize;
+                        return (
+                            <div
+                                key={group.id}
+                                className={cn(
+                                    'space-y-2 rounded-md border p-3',
+                                    overCapacity &&
+                                        'border-destructive/60 bg-destructive/5',
+                                )}
+                            >
+                                <div className="flex items-center justify-between text-sm font-medium">
+                                    <span>Grupo {group.name}</span>
+                                    <span
+                                        className={cn(
+                                            'text-xs text-muted-foreground tabular-nums',
+                                            overCapacity && 'text-destructive',
+                                        )}
+                                    >
+                                        {teams.length}/{groupSize}
+                                    </span>
+                                </div>
+                                {teams.length === 0 ? (
+                                    <p className="text-xs text-muted-foreground">
+                                        Sin equipos asignados.
+                                    </p>
+                                ) : (
+                                    <ul className="space-y-1">
+                                        {teams.map((tt) => (
+                                            <li
+                                                key={tt.id}
+                                                className="truncate text-xs text-muted-foreground"
+                                            >
+                                                {tt.team?.name ??
+                                                    `Team ${tt.team_id}`}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
+
+                {!allAssigned && (
+                    <p className="text-xs text-muted-foreground">
+                        Faltan {approvedTeams.length - totalAssigned} equipos
+                        por asignar para poder iniciar el torneo.
+                    </p>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/tournament/groups-grid.tsx
+++ b/resources/js/components/tournament/groups-grid.tsx
@@ -1,0 +1,40 @@
+import { StandingsTable } from '@/components/tournament/standings-table';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { StandingRow, TournamentGroup } from '@/types';
+
+interface Props {
+    groups: TournamentGroup[];
+    standingsByGroup: Record<number, StandingRow[]>;
+    highlightTopN?: number;
+}
+
+export function GroupsGrid({
+    groups,
+    standingsByGroup,
+    highlightTopN = 2,
+}: Props) {
+    if (groups.length === 0) return null;
+
+    return (
+        <div className="grid gap-4 md:grid-cols-2">
+            {groups.map((group) => {
+                const rows = standingsByGroup[group.id] ?? [];
+                return (
+                    <Card key={group.id}>
+                        <CardHeader className="pb-3">
+                            <CardTitle className="text-base">
+                                Grupo {group.name}
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <StandingsTable
+                                rows={rows}
+                                highlightTopN={highlightTopN}
+                            />
+                        </CardContent>
+                    </Card>
+                );
+            })}
+        </div>
+    );
+}

--- a/resources/js/components/tournament/standings-table.tsx
+++ b/resources/js/components/tournament/standings-table.tsx
@@ -1,0 +1,143 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { cn } from '@/lib/utils';
+import type { StandingRow } from '@/types';
+
+interface Props {
+    rows: StandingRow[];
+    highlightTopN?: number;
+    title?: string;
+    className?: string;
+}
+
+export function StandingsTable({
+    rows,
+    highlightTopN,
+    title,
+    className,
+}: Props) {
+    return (
+        <div className={cn('overflow-hidden rounded-md border', className)}>
+            {title && (
+                <div className="border-b bg-muted/40 px-4 py-2 text-sm font-semibold">
+                    {title}
+                </div>
+            )}
+            <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                    <thead>
+                        <tr className="bg-muted/40 text-xs text-muted-foreground uppercase">
+                            <th className="px-3 py-2 text-left">#</th>
+                            <th className="px-3 py-2 text-left">Equipo</th>
+                            <th className="px-2 py-2 text-center">PJ</th>
+                            <th className="hidden px-2 py-2 text-center sm:table-cell">
+                                G
+                            </th>
+                            <th className="hidden px-2 py-2 text-center sm:table-cell">
+                                E
+                            </th>
+                            <th className="hidden px-2 py-2 text-center sm:table-cell">
+                                P
+                            </th>
+                            <th className="hidden px-2 py-2 text-center md:table-cell">
+                                GF
+                            </th>
+                            <th className="hidden px-2 py-2 text-center md:table-cell">
+                                GC
+                            </th>
+                            <th className="px-2 py-2 text-center">DG</th>
+                            <th className="px-3 py-2 text-center font-semibold">
+                                Pts
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows.length === 0 && (
+                            <tr>
+                                <td
+                                    colSpan={10}
+                                    className="px-3 py-6 text-center text-muted-foreground"
+                                >
+                                    Aún no hay equipos en la tabla.
+                                </td>
+                            </tr>
+                        )}
+                        {rows.map((row) => {
+                            const highlighted =
+                                highlightTopN !== undefined &&
+                                row.position <= highlightTopN;
+                            return (
+                                <tr
+                                    key={row.team_id}
+                                    className={cn(
+                                        'border-t',
+                                        highlighted && 'bg-emerald-500/5',
+                                        row.tied_with_above && 'border-dashed',
+                                    )}
+                                >
+                                    <td className="px-3 py-2 text-left font-medium tabular-nums">
+                                        {row.position}
+                                    </td>
+                                    <td className="px-3 py-2 text-left">
+                                        <div className="flex items-center gap-2">
+                                            <Avatar className="size-6">
+                                                {row.team?.logo_url && (
+                                                    <AvatarImage
+                                                        src={row.team.logo_url}
+                                                        alt={row.team?.name}
+                                                    />
+                                                )}
+                                                <AvatarFallback className="text-[10px]">
+                                                    {row.team?.name
+                                                        ?.slice(0, 2)
+                                                        .toUpperCase() ?? '?'}
+                                                </AvatarFallback>
+                                            </Avatar>
+                                            <span className="truncate">
+                                                {row.team?.name ??
+                                                    `Team ${row.team_id}`}
+                                            </span>
+                                        </div>
+                                    </td>
+                                    <td className="px-2 py-2 text-center tabular-nums">
+                                        {row.played}
+                                    </td>
+                                    <td className="hidden px-2 py-2 text-center tabular-nums sm:table-cell">
+                                        {row.wins}
+                                    </td>
+                                    <td className="hidden px-2 py-2 text-center tabular-nums sm:table-cell">
+                                        {row.draws}
+                                    </td>
+                                    <td className="hidden px-2 py-2 text-center tabular-nums sm:table-cell">
+                                        {row.losses}
+                                    </td>
+                                    <td className="hidden px-2 py-2 text-center tabular-nums md:table-cell">
+                                        {row.goals_for}
+                                    </td>
+                                    <td className="hidden px-2 py-2 text-center tabular-nums md:table-cell">
+                                        {row.goals_against}
+                                    </td>
+                                    <td
+                                        className={cn(
+                                            'px-2 py-2 text-center tabular-nums',
+                                            row.goal_difference > 0 &&
+                                                'text-emerald-600',
+                                            row.goal_difference < 0 &&
+                                                'text-rose-600',
+                                        )}
+                                    >
+                                        {row.goal_difference > 0
+                                            ? `+${row.goal_difference}`
+                                            : row.goal_difference}
+                                    </td>
+                                    <td className="px-3 py-2 text-center font-semibold tabular-nums">
+                                        {row.points}
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/hooks/use-match-countdown.ts
+++ b/resources/js/hooks/use-match-countdown.ts
@@ -5,11 +5,13 @@ interface CountdownResult {
     hasStarted: boolean;
 }
 
-export function useMatchCountdown(scheduledAt: string): CountdownResult {
+export function useMatchCountdown(scheduledAt: string | null): CountdownResult {
     const [countdown, setCountdown] = useState<string>('');
     const [hasStarted, setHasStarted] = useState(false);
 
     useEffect(() => {
+        if (!scheduledAt) return;
+
         const updateCountdown = () => {
             const matchTime = new Date(scheduledAt);
             const currentTime = new Date();

--- a/resources/js/lib/match-format.ts
+++ b/resources/js/lib/match-format.ts
@@ -32,7 +32,8 @@ export const getMatchStatusText = (status: string): string => {
     }
 };
 
-export const formatMatchDate = (dateString: string): string => {
+export const formatMatchDate = (dateString: string | null): string => {
+    if (!dateString) return 'Por programar';
     const date = new Date(dateString);
     return date.toLocaleDateString('es-ES', {
         weekday: 'long',
@@ -42,7 +43,8 @@ export const formatMatchDate = (dateString: string): string => {
     });
 };
 
-export const formatMatchTime = (dateString: string): string => {
+export const formatMatchTime = (dateString: string | null): string => {
+    if (!dateString) return '—';
     const date = new Date(dateString);
     return date.toLocaleTimeString('es-ES', {
         hour: 'numeric',

--- a/resources/js/pages/matches/edit.tsx
+++ b/resources/js/pages/matches/edit.tsx
@@ -29,8 +29,8 @@ interface Team {
 
 interface Match {
     id: number;
-    scheduled_at: string;
-    location: string;
+    scheduled_at: string | null;
+    location: string | null;
     location_coords?: string;
     match_type: string;
     notes?: string;
@@ -58,8 +58,8 @@ export default function Edit({ match }: Props) {
     ];
 
     const { data, setData, put, processing, errors } = useForm({
-        scheduled_at: match.scheduled_at.slice(0, 16), // Format for datetime-local input
-        location: match.location,
+        scheduled_at: match.scheduled_at?.slice(0, 16) ?? '',
+        location: match.location ?? '',
         location_coords: match.location_coords || '',
         match_type: match.match_type,
         notes: match.notes || '',

--- a/resources/js/pages/matches/index.tsx
+++ b/resources/js/pages/matches/index.tsx
@@ -30,8 +30,8 @@ interface Match {
     home_team_id: number;
     away_team_id?: number;
     variant: string;
-    scheduled_at: string;
-    location: string;
+    scheduled_at: string | null;
+    location: string | null;
     match_type: string;
     status: string;
     home_score?: number;
@@ -69,12 +69,14 @@ export default function Index({
         const past: Match[] = [];
 
         for (const match of myMatches) {
-            const matchDate = new Date(match.scheduled_at);
+            const matchDate = match.scheduled_at
+                ? new Date(match.scheduled_at)
+                : null;
             // Consider a match as "past" if it's completed OR if the scheduled time has passed
             if (
                 match.status === 'completed' ||
                 match.status === 'cancelled' ||
-                matchDate < now
+                (matchDate && matchDate < now)
             ) {
                 past.push(match);
             } else {
@@ -82,17 +84,16 @@ export default function Index({
             }
         }
 
-        // Sort upcoming by date ascending (soonest first)
-        upcoming.sort(
-            (a, b) =>
-                new Date(a.scheduled_at).getTime() -
-                new Date(b.scheduled_at).getTime(),
-        );
+        const dateValue = (m: Match) =>
+            m.scheduled_at ? new Date(m.scheduled_at).getTime() : Infinity;
+
+        // Sort upcoming by date ascending (soonest first; unscheduled at the end)
+        upcoming.sort((a, b) => dateValue(a) - dateValue(b));
         // Sort past by date descending (most recent first)
         past.sort(
             (a, b) =>
-                new Date(b.scheduled_at).getTime() -
-                new Date(a.scheduled_at).getTime(),
+                (b.scheduled_at ? new Date(b.scheduled_at).getTime() : 0) -
+                (a.scheduled_at ? new Date(a.scheduled_at).getTime() : 0),
         );
 
         return { upcomingMatches: upcoming, pastMatches: past };
@@ -104,7 +105,9 @@ export default function Index({
                 match.home_team.name
                     .toLowerCase()
                     .includes(searchQuery.toLowerCase()) ||
-                match.location.toLowerCase().includes(searchQuery.toLowerCase())
+                (match.location ?? '')
+                    .toLowerCase()
+                    .includes(searchQuery.toLowerCase())
             );
         });
     }, [availableMatches, searchQuery]);

--- a/resources/js/pages/tournaments/create.tsx
+++ b/resources/js/pages/tournaments/create.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import AppLayout from '@/layouts/app-layout';
-import type { BreadcrumbItem } from '@/types';
+import type { BreadcrumbItem, TournamentFormat } from '@/types';
 import { Head, router } from '@inertiajs/react';
 import { AlertCircle, ArrowLeft, ImagePlus, Save, X } from 'lucide-react';
 import { useRef, useState } from 'react';
@@ -33,6 +33,9 @@ interface FormData {
     description: string;
     visibility: 'public' | 'invite_only';
     variant: string;
+    format: TournamentFormat;
+    group_count: number;
+    group_size: number;
     max_teams: number;
     min_teams: number;
     registration_deadline: string;
@@ -46,6 +49,9 @@ export default function TournamentCreate() {
         description: '',
         visibility: 'public',
         variant: '',
+        format: 'single_elimination',
+        group_count: 4,
+        group_size: 4,
         max_teams: 8,
         min_teams: 4,
         registration_deadline: '',
@@ -103,12 +109,37 @@ export default function TournamentCreate() {
         if (fileInputRef.current) fileInputRef.current.value = '';
     };
 
+    const derivedMaxTeams =
+        data.format === 'group_stage_knockout'
+            ? data.group_count * data.group_size
+            : data.max_teams;
+
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         setProcessing(true);
 
         const formData = new FormData();
-        Object.entries(data).forEach(([key, value]) => {
+        const payload: Record<string, string | number> = {
+            name: data.name,
+            description: data.description,
+            visibility: data.visibility,
+            variant: data.variant,
+            format: data.format,
+            min_teams: data.min_teams,
+            registration_deadline: data.registration_deadline,
+            starts_at: data.starts_at,
+            ends_at: data.ends_at,
+        };
+
+        if (data.format === 'group_stage_knockout') {
+            payload.group_count = data.group_count;
+            payload.group_size = data.group_size;
+            payload.max_teams = derivedMaxTeams;
+        } else {
+            payload.max_teams = data.max_teams;
+        }
+
+        Object.entries(payload).forEach(([key, value]) => {
             formData.append(key, String(value));
         });
         if (selectedLogo) {
@@ -338,55 +369,227 @@ export default function TournamentCreate() {
                                     )}
                                 </div>
 
-                                {/* Max Teams */}
+                                {/* Format */}
                                 <div className="space-y-2">
-                                    <Label htmlFor="max_teams">
-                                        Número Máximo de Equipos{' '}
+                                    <Label htmlFor="format">
+                                        Formato del Torneo{' '}
                                         <span className="text-destructive">
                                             *
                                         </span>
                                     </Label>
                                     <Select
-                                        value={data.max_teams.toString()}
-                                        onValueChange={(value) =>
-                                            setData(
-                                                'max_teams',
-                                                parseInt(value),
-                                            )
-                                        }
+                                        value={data.format}
+                                        onValueChange={(
+                                            value: TournamentFormat,
+                                        ) => setData('format', value)}
                                     >
                                         <SelectTrigger>
                                             <SelectValue />
                                         </SelectTrigger>
                                         <SelectContent>
-                                            <SelectItem value="4">
-                                                4 equipos
+                                            <SelectItem value="single_elimination">
+                                                Eliminación directa - Brackets,
+                                                un partido por ronda
                                             </SelectItem>
-                                            <SelectItem value="8">
-                                                8 equipos
+                                            <SelectItem value="league">
+                                                Liga - Todos contra todos, gana
+                                                el de más puntos
                                             </SelectItem>
-                                            <SelectItem value="16">
-                                                16 equipos
-                                            </SelectItem>
-                                            <SelectItem value="32">
-                                                32 equipos
-                                            </SelectItem>
-                                            <SelectItem value="64">
-                                                64 equipos
+                                            <SelectItem value="group_stage_knockout">
+                                                Fase de grupos + eliminación -
+                                                Grupos primero, luego bracket
                                             </SelectItem>
                                         </SelectContent>
                                     </Select>
-                                    <p className="text-xs text-muted-foreground">
-                                        Debe ser una potencia de 2 para el
-                                        bracket de eliminación
-                                    </p>
-                                    {errors.max_teams && (
+                                    {errors.format && (
                                         <p className="flex items-center gap-1 text-sm text-destructive">
                                             <AlertCircle className="size-3" />
-                                            {errors.max_teams}
+                                            {errors.format}
                                         </p>
                                     )}
                                 </div>
+
+                                {/* Max Teams (single_elimination) */}
+                                {data.format === 'single_elimination' && (
+                                    <div className="space-y-2">
+                                        <Label htmlFor="max_teams">
+                                            Número Máximo de Equipos{' '}
+                                            <span className="text-destructive">
+                                                *
+                                            </span>
+                                        </Label>
+                                        <Select
+                                            value={data.max_teams.toString()}
+                                            onValueChange={(value) =>
+                                                setData(
+                                                    'max_teams',
+                                                    parseInt(value),
+                                                )
+                                            }
+                                        >
+                                            <SelectTrigger>
+                                                <SelectValue />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                <SelectItem value="4">
+                                                    4 equipos
+                                                </SelectItem>
+                                                <SelectItem value="8">
+                                                    8 equipos
+                                                </SelectItem>
+                                                <SelectItem value="16">
+                                                    16 equipos
+                                                </SelectItem>
+                                                <SelectItem value="32">
+                                                    32 equipos
+                                                </SelectItem>
+                                                <SelectItem value="64">
+                                                    64 equipos
+                                                </SelectItem>
+                                            </SelectContent>
+                                        </Select>
+                                        <p className="text-xs text-muted-foreground">
+                                            Debe ser una potencia de 2 para el
+                                            bracket
+                                        </p>
+                                        {errors.max_teams && (
+                                            <p className="flex items-center gap-1 text-sm text-destructive">
+                                                <AlertCircle className="size-3" />
+                                                {errors.max_teams}
+                                            </p>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* Max Teams (league) */}
+                                {data.format === 'league' && (
+                                    <div className="space-y-2">
+                                        <Label htmlFor="max_teams">
+                                            Número Máximo de Equipos{' '}
+                                            <span className="text-destructive">
+                                                *
+                                            </span>
+                                        </Label>
+                                        <Input
+                                            id="max_teams"
+                                            type="number"
+                                            value={data.max_teams}
+                                            onChange={(e) =>
+                                                setData(
+                                                    'max_teams',
+                                                    parseInt(e.target.value) ||
+                                                        2,
+                                                )
+                                            }
+                                            min={2}
+                                            max={64}
+                                        />
+                                        <p className="text-xs text-muted-foreground">
+                                            Cualquier número de 2 a 64. Cada
+                                            equipo jugará{' '}
+                                            {Math.max(0, data.max_teams - 1)}{' '}
+                                            partidos.
+                                        </p>
+                                        {errors.max_teams && (
+                                            <p className="flex items-center gap-1 text-sm text-destructive">
+                                                <AlertCircle className="size-3" />
+                                                {errors.max_teams}
+                                            </p>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* Group config (group_stage_knockout) */}
+                                {data.format === 'group_stage_knockout' && (
+                                    <>
+                                        <div className="space-y-2">
+                                            <Label htmlFor="group_count">
+                                                Cantidad de Grupos{' '}
+                                                <span className="text-destructive">
+                                                    *
+                                                </span>
+                                            </Label>
+                                            <Select
+                                                value={data.group_count.toString()}
+                                                onValueChange={(value) =>
+                                                    setData(
+                                                        'group_count',
+                                                        parseInt(value),
+                                                    )
+                                                }
+                                            >
+                                                <SelectTrigger>
+                                                    <SelectValue />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    <SelectItem value="2">
+                                                        2 grupos
+                                                    </SelectItem>
+                                                    <SelectItem value="4">
+                                                        4 grupos
+                                                    </SelectItem>
+                                                    <SelectItem value="8">
+                                                        8 grupos
+                                                    </SelectItem>
+                                                    <SelectItem value="16">
+                                                        16 grupos
+                                                    </SelectItem>
+                                                </SelectContent>
+                                            </Select>
+                                            <p className="text-xs text-muted-foreground">
+                                                Debe ser potencia de 2 para que
+                                                los 2 mejores de cada grupo
+                                                formen un bracket limpio.
+                                            </p>
+                                            {errors.group_count && (
+                                                <p className="flex items-center gap-1 text-sm text-destructive">
+                                                    <AlertCircle className="size-3" />
+                                                    {errors.group_count}
+                                                </p>
+                                            )}
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label htmlFor="group_size">
+                                                Equipos por Grupo{' '}
+                                                <span className="text-destructive">
+                                                    *
+                                                </span>
+                                            </Label>
+                                            <Input
+                                                id="group_size"
+                                                type="number"
+                                                value={data.group_size}
+                                                onChange={(e) =>
+                                                    setData(
+                                                        'group_size',
+                                                        parseInt(
+                                                            e.target.value,
+                                                        ) || 2,
+                                                    )
+                                                }
+                                                min={2}
+                                                max={16}
+                                            />
+                                            <p className="text-xs text-muted-foreground">
+                                                Total: {derivedMaxTeams} equipos
+                                                ({data.group_count} ×{' '}
+                                                {data.group_size}). Cada equipo
+                                                jugará{' '}
+                                                {Math.max(
+                                                    0,
+                                                    data.group_size - 1,
+                                                )}{' '}
+                                                partidos en su grupo.
+                                            </p>
+                                            {errors.group_size && (
+                                                <p className="flex items-center gap-1 text-sm text-destructive">
+                                                    <AlertCircle className="size-3" />
+                                                    {errors.group_size}
+                                                </p>
+                                            )}
+                                        </div>
+                                    </>
+                                )}
 
                                 {/* Min Teams */}
                                 <div className="space-y-2">

--- a/resources/js/pages/tournaments/edit.tsx
+++ b/resources/js/pages/tournaments/edit.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import AppLayout from '@/layouts/app-layout';
-import type { BreadcrumbItem, Tournament } from '@/types';
+import type { BreadcrumbItem, Tournament, TournamentFormat } from '@/types';
 import { Head, router } from '@inertiajs/react';
 import { AlertCircle, ArrowLeft, ImagePlus, Save, Trash2 } from 'lucide-react';
 import { useRef, useState } from 'react';
@@ -39,6 +39,9 @@ interface FormData {
     description: string;
     visibility: 'public' | 'invite_only';
     variant: string;
+    format: TournamentFormat;
+    group_count: number;
+    group_size: number;
     max_teams: number;
     min_teams: number;
     registration_deadline: string;
@@ -47,11 +50,15 @@ interface FormData {
 }
 
 export default function TournamentEdit({ tournament }: PageProps) {
+    const formatLocked = (tournament.registered_teams_count ?? 0) > 0;
     const [data, setDataState] = useState<FormData>({
         name: tournament.name,
         description: tournament.description || '',
         visibility: tournament.visibility,
         variant: tournament.variant,
+        format: tournament.format,
+        group_count: tournament.group_count ?? 4,
+        group_size: tournament.group_size ?? 4,
         max_teams: tournament.max_teams,
         min_teams: tournament.min_teams,
         registration_deadline: tournament.registration_deadline
@@ -124,13 +131,39 @@ export default function TournamentEdit({ tournament }: PageProps) {
         if (fileInputRef.current) fileInputRef.current.value = '';
     };
 
+    const derivedMaxTeams =
+        data.format === 'group_stage_knockout'
+            ? data.group_count * data.group_size
+            : data.max_teams;
+
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         setProcessing(true);
 
         const formData = new FormData();
         formData.append('_method', 'PUT');
-        Object.entries(data).forEach(([key, value]) => {
+
+        const payload: Record<string, string | number> = {
+            name: data.name,
+            description: data.description,
+            visibility: data.visibility,
+            variant: data.variant,
+            format: data.format,
+            min_teams: data.min_teams,
+            registration_deadline: data.registration_deadline,
+            starts_at: data.starts_at,
+            ends_at: data.ends_at,
+        };
+
+        if (data.format === 'group_stage_knockout') {
+            payload.group_count = data.group_count;
+            payload.group_size = data.group_size;
+            payload.max_teams = derivedMaxTeams;
+        } else {
+            payload.max_teams = data.max_teams;
+        }
+
+        Object.entries(payload).forEach(([key, value]) => {
             formData.append(key, String(value));
         });
         if (selectedLogo) {
@@ -372,51 +405,211 @@ export default function TournamentEdit({ tournament }: PageProps) {
                                     )}
                                 </div>
 
-                                {/* Max Teams */}
+                                {/* Format */}
                                 <div className="space-y-2">
-                                    <Label htmlFor="max_teams">
-                                        Número Máximo de Equipos{' '}
+                                    <Label htmlFor="format">
+                                        Formato del Torneo{' '}
                                         <span className="text-destructive">
                                             *
                                         </span>
                                     </Label>
                                     <Select
-                                        value={data.max_teams.toString()}
-                                        onValueChange={(value) =>
-                                            setData(
-                                                'max_teams',
-                                                parseInt(value),
-                                            )
-                                        }
+                                        value={data.format}
+                                        disabled={formatLocked}
+                                        onValueChange={(
+                                            value: TournamentFormat,
+                                        ) => setData('format', value)}
                                     >
                                         <SelectTrigger>
                                             <SelectValue />
                                         </SelectTrigger>
                                         <SelectContent>
-                                            <SelectItem value="4">
-                                                4 equipos
+                                            <SelectItem value="single_elimination">
+                                                Eliminación directa
                                             </SelectItem>
-                                            <SelectItem value="8">
-                                                8 equipos
+                                            <SelectItem value="league">
+                                                Liga
                                             </SelectItem>
-                                            <SelectItem value="16">
-                                                16 equipos
-                                            </SelectItem>
-                                            <SelectItem value="32">
-                                                32 equipos
-                                            </SelectItem>
-                                            <SelectItem value="64">
-                                                64 equipos
+                                            <SelectItem value="group_stage_knockout">
+                                                Fase de grupos + eliminación
                                             </SelectItem>
                                         </SelectContent>
                                     </Select>
-                                    {errors.max_teams && (
+                                    {formatLocked && (
+                                        <p className="text-xs text-muted-foreground">
+                                            El formato no se puede cambiar
+                                            después de que se hayan registrado
+                                            equipos.
+                                        </p>
+                                    )}
+                                    {errors.format && (
                                         <p className="flex items-center gap-1 text-sm text-destructive">
                                             <AlertCircle className="size-3" />
-                                            {errors.max_teams}
+                                            {errors.format}
                                         </p>
                                     )}
                                 </div>
+
+                                {/* Max Teams (single_elimination) */}
+                                {data.format === 'single_elimination' && (
+                                    <div className="space-y-2">
+                                        <Label htmlFor="max_teams">
+                                            Número Máximo de Equipos{' '}
+                                            <span className="text-destructive">
+                                                *
+                                            </span>
+                                        </Label>
+                                        <Select
+                                            value={data.max_teams.toString()}
+                                            onValueChange={(value) =>
+                                                setData(
+                                                    'max_teams',
+                                                    parseInt(value),
+                                                )
+                                            }
+                                        >
+                                            <SelectTrigger>
+                                                <SelectValue />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                <SelectItem value="4">
+                                                    4 equipos
+                                                </SelectItem>
+                                                <SelectItem value="8">
+                                                    8 equipos
+                                                </SelectItem>
+                                                <SelectItem value="16">
+                                                    16 equipos
+                                                </SelectItem>
+                                                <SelectItem value="32">
+                                                    32 equipos
+                                                </SelectItem>
+                                                <SelectItem value="64">
+                                                    64 equipos
+                                                </SelectItem>
+                                            </SelectContent>
+                                        </Select>
+                                        {errors.max_teams && (
+                                            <p className="flex items-center gap-1 text-sm text-destructive">
+                                                <AlertCircle className="size-3" />
+                                                {errors.max_teams}
+                                            </p>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* Max Teams (league) */}
+                                {data.format === 'league' && (
+                                    <div className="space-y-2">
+                                        <Label htmlFor="max_teams">
+                                            Número Máximo de Equipos{' '}
+                                            <span className="text-destructive">
+                                                *
+                                            </span>
+                                        </Label>
+                                        <Input
+                                            id="max_teams"
+                                            type="number"
+                                            value={data.max_teams}
+                                            onChange={(e) =>
+                                                setData(
+                                                    'max_teams',
+                                                    parseInt(e.target.value) ||
+                                                        2,
+                                                )
+                                            }
+                                            min={2}
+                                            max={64}
+                                        />
+                                        {errors.max_teams && (
+                                            <p className="flex items-center gap-1 text-sm text-destructive">
+                                                <AlertCircle className="size-3" />
+                                                {errors.max_teams}
+                                            </p>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* Group config (group_stage_knockout) */}
+                                {data.format === 'group_stage_knockout' && (
+                                    <>
+                                        <div className="space-y-2">
+                                            <Label htmlFor="group_count">
+                                                Cantidad de Grupos{' '}
+                                                <span className="text-destructive">
+                                                    *
+                                                </span>
+                                            </Label>
+                                            <Select
+                                                value={data.group_count.toString()}
+                                                onValueChange={(value) =>
+                                                    setData(
+                                                        'group_count',
+                                                        parseInt(value),
+                                                    )
+                                                }
+                                            >
+                                                <SelectTrigger>
+                                                    <SelectValue />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    <SelectItem value="2">
+                                                        2 grupos
+                                                    </SelectItem>
+                                                    <SelectItem value="4">
+                                                        4 grupos
+                                                    </SelectItem>
+                                                    <SelectItem value="8">
+                                                        8 grupos
+                                                    </SelectItem>
+                                                    <SelectItem value="16">
+                                                        16 grupos
+                                                    </SelectItem>
+                                                </SelectContent>
+                                            </Select>
+                                            {errors.group_count && (
+                                                <p className="flex items-center gap-1 text-sm text-destructive">
+                                                    <AlertCircle className="size-3" />
+                                                    {errors.group_count}
+                                                </p>
+                                            )}
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label htmlFor="group_size">
+                                                Equipos por Grupo{' '}
+                                                <span className="text-destructive">
+                                                    *
+                                                </span>
+                                            </Label>
+                                            <Input
+                                                id="group_size"
+                                                type="number"
+                                                value={data.group_size}
+                                                onChange={(e) =>
+                                                    setData(
+                                                        'group_size',
+                                                        parseInt(
+                                                            e.target.value,
+                                                        ) || 2,
+                                                    )
+                                                }
+                                                min={2}
+                                                max={16}
+                                            />
+                                            <p className="text-xs text-muted-foreground">
+                                                Total: {derivedMaxTeams} equipos
+                                                ({data.group_count} ×{' '}
+                                                {data.group_size}).
+                                            </p>
+                                            {errors.group_size && (
+                                                <p className="flex items-center gap-1 text-sm text-destructive">
+                                                    <AlertCircle className="size-3" />
+                                                    {errors.group_size}
+                                                </p>
+                                            )}
+                                        </div>
+                                    </>
+                                )}
 
                                 {/* Min Teams */}
                                 <div className="space-y-2">

--- a/resources/js/pages/tournaments/edit.tsx
+++ b/resources/js/pages/tournaments/edit.tsx
@@ -22,6 +22,7 @@ import type { BreadcrumbItem, Tournament } from '@/types';
 import { Head, router } from '@inertiajs/react';
 import { AlertCircle, ArrowLeft, ImagePlus, Save, Trash2 } from 'lucide-react';
 import { useRef, useState } from 'react';
+import { toast } from 'sonner';
 
 interface PageProps {
     tournament: Tournament;
@@ -143,6 +144,9 @@ export default function TournamentEdit({ tournament }: PageProps) {
             onError: (errs) => {
                 setProcessing(false);
                 setErrors(errs as Record<string, string>);
+                if (errs.error) {
+                    toast.error(errs.error as string);
+                }
             },
         });
     };
@@ -173,6 +177,13 @@ export default function TournamentEdit({ tournament }: PageProps) {
                                 </CardDescription>
                             </CardHeader>
                             <CardContent className="space-y-6">
+                                {errors.error && (
+                                    <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+                                        <AlertCircle className="mt-0.5 size-4 shrink-0" />
+                                        <span>{errors.error}</span>
+                                    </div>
+                                )}
+
                                 {/* Name */}
                                 <div className="space-y-2">
                                     <Label htmlFor="name">

--- a/resources/js/pages/tournaments/show.tsx
+++ b/resources/js/pages/tournaments/show.tsx
@@ -20,6 +20,16 @@ import {
     CardHeader,
     CardTitle,
 } from '@/components/ui/card';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Progress } from '@/components/ui/progress';
 import {
     Select,
@@ -32,6 +42,7 @@ import { Separator } from '@/components/ui/separator';
 import { UserAvatar } from '@/components/user-avatar';
 import { VariantBadge } from '@/components/variant-badge';
 import AppLayout from '@/layouts/app-layout';
+import tournamentMatches from '@/routes/tournaments/matches';
 import type {
     BreadcrumbItem,
     FootballMatch,
@@ -42,11 +53,14 @@ import type {
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import {
     Calendar,
+    CalendarClock,
     Check,
     Clock,
     Edit,
     Info,
     Loader2,
+    MapPin,
+    Pencil,
     Play,
     Trash2,
     Trophy,
@@ -73,7 +87,156 @@ interface PageProps {
         canStart: boolean;
         canCancel: boolean;
         canApprove: boolean;
+        canScheduleMatches: boolean;
     };
+}
+
+function formatScheduledAt(value: string | null): string {
+    if (!value) return 'Sin programar';
+    const date = new Date(value);
+    return date.toLocaleString('es-UY', {
+        day: 'numeric',
+        month: 'short',
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+}
+
+function toLocalDatetimeInputValue(value: string | null): string {
+    if (!value) return '';
+    const date = new Date(value);
+    const offsetMs = date.getTimezoneOffset() * 60_000;
+    return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
+function ScheduleMatchDialog({
+    match,
+    tournamentId,
+    open,
+    onOpenChange,
+}: {
+    match: FootballMatch | null;
+    tournamentId: number;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}) {
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                {match && (
+                    <ScheduleMatchForm
+                        key={match.id}
+                        match={match}
+                        tournamentId={tournamentId}
+                        onClose={() => onOpenChange(false)}
+                    />
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function ScheduleMatchForm({
+    match,
+    tournamentId,
+    onClose,
+}: {
+    match: FootballMatch;
+    tournamentId: number;
+    onClose: () => void;
+}) {
+    const [scheduledAt, setScheduledAt] = useState(() =>
+        toLocalDatetimeInputValue(match.scheduled_at),
+    );
+    const [location, setLocation] = useState(() => match.location ?? '');
+    const [submitting, setSubmitting] = useState(false);
+    const [errors, setErrors] = useState<Record<string, string>>({});
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        setSubmitting(true);
+        router.patch(
+            tournamentMatches.update([tournamentId, match.id]).url,
+            {
+                scheduled_at: scheduledAt || null,
+                location: location.trim() || null,
+            },
+            {
+                preserveScroll: true,
+                onSuccess: () => {
+                    onClose();
+                },
+                onError: (errs) => {
+                    setErrors(errs as Record<string, string>);
+                    toast.error('Revisá los datos del partido.');
+                },
+                onFinish: () => setSubmitting(false),
+            },
+        );
+    };
+
+    const homeName = match.home_team?.name ?? 'Por definir';
+    const awayName = match.away_team?.name ?? 'Por definir';
+
+    return (
+        <>
+            <DialogHeader>
+                <DialogTitle>Programar partido</DialogTitle>
+                <DialogDescription>
+                    {homeName} vs {awayName}
+                </DialogDescription>
+            </DialogHeader>
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="space-y-2">
+                    <Label htmlFor="scheduled_at">Fecha y hora</Label>
+                    <Input
+                        id="scheduled_at"
+                        type="datetime-local"
+                        value={scheduledAt}
+                        onChange={(e) => setScheduledAt(e.target.value)}
+                    />
+                    {errors.scheduled_at && (
+                        <p className="text-sm text-destructive">
+                            {errors.scheduled_at}
+                        </p>
+                    )}
+                </div>
+                <div className="space-y-2">
+                    <Label htmlFor="location">Cancha</Label>
+                    <Input
+                        id="location"
+                        type="text"
+                        placeholder="Ej: Cancha 3 — Complejo Norte"
+                        value={location}
+                        onChange={(e) => setLocation(e.target.value)}
+                        maxLength={255}
+                    />
+                    {errors.location && (
+                        <p className="text-sm text-destructive">
+                            {errors.location}
+                        </p>
+                    )}
+                </div>
+                <DialogFooter>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={onClose}
+                        disabled={submitting}
+                    >
+                        Cancelar
+                    </Button>
+                    <Button type="submit" disabled={submitting}>
+                        {submitting ? (
+                            <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                            'Guardar'
+                        )}
+                    </Button>
+                </DialogFooter>
+            </form>
+        </>
+    );
 }
 
 const statusConfig = {
@@ -152,6 +315,9 @@ export default function TournamentShow({
     const [showCancelDialog, setShowCancelDialog] = useState(false);
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
     const [withdrawId, setWithdrawId] = useState<number | null>(null);
+    const [scheduleMatch, setScheduleMatch] = useState<FootballMatch | null>(
+        null,
+    );
 
     const [processing, setProcessing] = useState(false);
     const { flash } = usePage<{
@@ -471,12 +637,134 @@ export default function TournamentShow({
                     <div className="space-y-6 lg:col-span-2">
                         {/* Bracket */}
                         {hasBracket ? (
-                            <section className="space-y-4">
-                                <h2 className="text-lg font-semibold">
-                                    Bracket
-                                </h2>
-                                <TournamentBracket rounds={tournament.rounds} />
-                            </section>
+                            <>
+                                <section className="space-y-4">
+                                    <h2 className="text-lg font-semibold">
+                                        Bracket
+                                    </h2>
+                                    <TournamentBracket
+                                        rounds={tournament.rounds}
+                                    />
+                                </section>
+
+                                <Card>
+                                    <CardHeader>
+                                        <CardTitle className="text-base">
+                                            Programación de partidos
+                                        </CardTitle>
+                                        <CardDescription>
+                                            {permissions.canScheduleMatches
+                                                ? 'Definí la fecha, hora y cancha de cada partido.'
+                                                : 'Fechas y canchas confirmadas por el organizador.'}
+                                        </CardDescription>
+                                    </CardHeader>
+                                    <CardContent className="space-y-6">
+                                        {tournament.rounds.map((round) => (
+                                            <div
+                                                key={round.id}
+                                                className="space-y-2"
+                                            >
+                                                <h3 className="text-sm font-medium text-muted-foreground">
+                                                    {round.name}
+                                                </h3>
+                                                <div className="space-y-2">
+                                                    {(round.matches?.length ??
+                                                        0) === 0 ? (
+                                                        <p className="text-sm text-muted-foreground">
+                                                            Sin partidos
+                                                        </p>
+                                                    ) : (
+                                                        round.matches!.map(
+                                                            (match) => {
+                                                                const home =
+                                                                    match
+                                                                        .home_team
+                                                                        ?.name ??
+                                                                    'Por definir';
+                                                                const away =
+                                                                    match
+                                                                        .away_team
+                                                                        ?.name ??
+                                                                    'Por definir';
+                                                                const isLocked =
+                                                                    match.status ===
+                                                                        'in_progress' ||
+                                                                    match.status ===
+                                                                        'completed';
+                                                                const canEditMatch =
+                                                                    permissions.canScheduleMatches &&
+                                                                    !isLocked;
+                                                                return (
+                                                                    <div
+                                                                        key={
+                                                                            match.id
+                                                                        }
+                                                                        className="flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+                                                                    >
+                                                                        <div className="min-w-0 flex-1">
+                                                                            <p className="truncate text-sm font-medium">
+                                                                                {
+                                                                                    home
+                                                                                }{' '}
+                                                                                <span className="text-muted-foreground">
+                                                                                    vs
+                                                                                </span>{' '}
+                                                                                {
+                                                                                    away
+                                                                                }
+                                                                            </p>
+                                                                            <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                                                                                <span className="flex items-center gap-1">
+                                                                                    <CalendarClock className="size-3.5" />
+                                                                                    {match.scheduled_at ? (
+                                                                                        formatScheduledAt(
+                                                                                            match.scheduled_at,
+                                                                                        )
+                                                                                    ) : (
+                                                                                        <Badge
+                                                                                            variant="outline"
+                                                                                            className="font-normal"
+                                                                                        >
+                                                                                            Sin
+                                                                                            programar
+                                                                                        </Badge>
+                                                                                    )}
+                                                                                </span>
+                                                                                <span className="flex items-center gap-1">
+                                                                                    <MapPin className="size-3.5" />
+                                                                                    {match.location ??
+                                                                                        'Por definir'}
+                                                                                </span>
+                                                                            </div>
+                                                                        </div>
+                                                                        {canEditMatch && (
+                                                                            <Button
+                                                                                size="sm"
+                                                                                variant="outline"
+                                                                                onClick={() =>
+                                                                                    setScheduleMatch(
+                                                                                        match,
+                                                                                    )
+                                                                                }
+                                                                                className="gap-1.5"
+                                                                            >
+                                                                                <Pencil className="size-3.5" />
+                                                                                {match.scheduled_at
+                                                                                    ? 'Editar'
+                                                                                    : 'Programar'}
+                                                                            </Button>
+                                                                        )}
+                                                                    </div>
+                                                                );
+                                                            },
+                                                        )
+                                                    )}
+                                                </div>
+                                            </div>
+                                        ))}
+                                    </CardContent>
+                                </Card>
+                            </>
                         ) : (
                             (tournament.status === 'draft' ||
                                 tournament.status === 'registration_open') && (
@@ -1025,6 +1313,13 @@ export default function TournamentShow({
                     </AlertDialogFooter>
                 </AlertDialogContent>
             </AlertDialog>
+
+            <ScheduleMatchDialog
+                tournamentId={tournament.id}
+                match={scheduleMatch}
+                open={scheduleMatch !== null}
+                onOpenChange={(open) => !open && setScheduleMatch(null)}
+            />
 
             <AlertDialog
                 open={withdrawId !== null}

--- a/resources/js/pages/tournaments/show.tsx
+++ b/resources/js/pages/tournaments/show.tsx
@@ -1,4 +1,7 @@
 import { TeamAvatar } from '@/components/team-avatar';
+import { GroupDraw } from '@/components/tournament/group-draw';
+import { GroupsGrid } from '@/components/tournament/groups-grid';
+import { StandingsTable } from '@/components/tournament/standings-table';
 import { TournamentBracket } from '@/components/tournament/tournament-bracket';
 import {
     AlertDialog,
@@ -46,8 +49,10 @@ import tournamentMatches from '@/routes/tournaments/matches';
 import type {
     BreadcrumbItem,
     FootballMatch,
+    StandingRow,
     Team,
     Tournament,
+    TournamentGroup,
     TournamentTeam,
 } from '@/types';
 import { Head, Link, router, usePage } from '@inertiajs/react';
@@ -79,7 +84,10 @@ interface PageProps {
             name: string;
             matches: FootballMatch[];
         }>;
+        groups?: TournamentGroup[];
     };
+    standings: StandingRow[] | null;
+    groupStandings: Record<number, StandingRow[]> | null;
     userTeams: Team[];
     permissions: {
         canEdit: boolean;
@@ -88,6 +96,7 @@ interface PageProps {
         canCancel: boolean;
         canApprove: boolean;
         canScheduleMatches: boolean;
+        canDrawGroups: boolean;
     };
 }
 
@@ -299,6 +308,8 @@ const breadcrumbs = (tournament: Tournament): BreadcrumbItem[] => [
 
 export default function TournamentShow({
     tournament,
+    standings,
+    groupStandings,
     userTeams,
     permissions,
 }: PageProps) {
@@ -635,17 +646,93 @@ export default function TournamentShow({
                 <div className="grid gap-6 lg:grid-cols-3">
                     {/* Left column — main content */}
                     <div className="space-y-6 lg:col-span-2">
-                        {/* Bracket */}
+                        {/* Group draw (group_stage_knockout, pre-start) */}
+                        {tournament.format === 'group_stage_knockout' &&
+                            permissions.canDrawGroups &&
+                            tournament.groups &&
+                            tournament.groups.length > 0 &&
+                            (tournament.status === 'draft' ||
+                                tournament.status === 'registration_open') && (
+                                <GroupDraw
+                                    tournamentId={tournament.id}
+                                    groups={tournament.groups}
+                                    approvedTeams={
+                                        approvedTeams as (TournamentTeam & {
+                                            team: Team;
+                                        })[]
+                                    }
+                                    groupSize={tournament.group_size ?? 4}
+                                />
+                            )}
+
+                        {/* Bracket / Standings / Groups */}
                         {hasBracket ? (
                             <>
-                                <section className="space-y-4">
-                                    <h2 className="text-lg font-semibold">
-                                        Bracket
-                                    </h2>
-                                    <TournamentBracket
-                                        rounds={tournament.rounds}
-                                    />
-                                </section>
+                                {tournament.format === 'league' && standings ? (
+                                    <section className="space-y-4">
+                                        <h2 className="text-lg font-semibold">
+                                            Tabla de Posiciones
+                                        </h2>
+                                        <StandingsTable
+                                            rows={standings}
+                                            highlightTopN={1}
+                                        />
+                                    </section>
+                                ) : tournament.format ===
+                                  'group_stage_knockout' ? (
+                                    <>
+                                        {tournament.groups &&
+                                            groupStandings && (
+                                                <section className="space-y-4">
+                                                    <h2 className="text-lg font-semibold">
+                                                        {tournament.phase ===
+                                                            'knockout' ||
+                                                        tournament.phase ===
+                                                            'completed'
+                                                            ? 'Tablas Finales de Grupos'
+                                                            : 'Fase de Grupos'}
+                                                    </h2>
+                                                    <GroupsGrid
+                                                        groups={
+                                                            tournament.groups
+                                                        }
+                                                        standingsByGroup={
+                                                            groupStandings
+                                                        }
+                                                        highlightTopN={2}
+                                                    />
+                                                </section>
+                                            )}
+                                        {(tournament.phase === 'knockout' ||
+                                            tournament.phase ===
+                                                'completed') && (
+                                            <section className="space-y-4">
+                                                <h2 className="text-lg font-semibold">
+                                                    Bracket
+                                                </h2>
+                                                <TournamentBracket
+                                                    rounds={tournament.rounds.filter(
+                                                        (r) =>
+                                                            !r.matches?.some(
+                                                                (m) =>
+                                                                    m.tournament_group_id !=
+                                                                    null,
+                                                            ),
+                                                    )}
+                                                />
+                                            </section>
+                                        )}
+                                    </>
+                                ) : (
+                                    <section className="space-y-4">
+                                        <h2 className="text-lg font-semibold">
+                                            Bracket
+                                        </h2>
+                                        <TournamentBracket
+                                            rounds={tournament.rounds}
+                                        />
+                                    </section>
+                                )}
 
                                 <Card>
                                     <CardHeader>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -314,8 +314,8 @@ export interface FootballMatch {
     tournament_round?: TournamentRound;
     bracket_position?: number;
     variant: string;
-    scheduled_at: string;
-    location: string;
+    scheduled_at: string | null;
+    location: string | null;
     location_coords?: string;
     match_type: string;
     status: string;

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -255,6 +255,42 @@ export type TournamentTeamStatus =
     | 'rejected'
     | 'withdrawn';
 
+export type TournamentFormat =
+    | 'single_elimination'
+    | 'league'
+    | 'group_stage_knockout';
+
+export type TournamentPhase =
+    | 'not_started'
+    | 'league'
+    | 'group_stage'
+    | 'knockout'
+    | 'completed';
+
+export interface StandingRow {
+    team_id: number;
+    team?: Team;
+    played: number;
+    wins: number;
+    draws: number;
+    losses: number;
+    goals_for: number;
+    goals_against: number;
+    goal_difference: number;
+    points: number;
+    position: number;
+    tied_with_above: boolean;
+}
+
+export interface TournamentGroup {
+    id: number;
+    tournament_id: number;
+    name: string;
+    position: number;
+    teams?: TournamentTeam[];
+    standings?: StandingRow[];
+}
+
 export interface Tournament {
     id: number;
     name: string;
@@ -266,6 +302,10 @@ export interface Tournament {
     visibility: TournamentVisibility;
     status: TournamentStatus;
     variant: string;
+    format: TournamentFormat;
+    phase: TournamentPhase;
+    group_count?: number | null;
+    group_size?: number | null;
     max_teams: number;
     min_teams: number;
     registered_teams_count?: number;
@@ -276,6 +316,7 @@ export interface Tournament {
     updated_at: string;
     tournament_teams?: TournamentTeam[];
     rounds?: TournamentRound[];
+    groups?: TournamentGroup[];
     [key: string]: unknown;
 }
 
@@ -286,6 +327,7 @@ export interface TournamentTeam {
     team?: Team;
     status: TournamentTeamStatus;
     seed?: number;
+    tournament_group_id?: number | null;
     registered_by: number;
     registered_at: string;
     approved_at?: string;
@@ -312,7 +354,10 @@ export interface FootballMatch {
     tournament?: Tournament;
     tournament_round_id?: number;
     tournament_round?: TournamentRound;
+    tournament_group_id?: number | null;
+    tournament_group?: TournamentGroup;
     bracket_position?: number;
+    matchday?: number | null;
     variant: string;
     scheduled_at: string | null;
     location: string | null;

--- a/routes/tournaments.php
+++ b/routes/tournaments.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\TournamentController;
 use App\Http\Controllers\TournamentLogoController;
+use App\Http\Controllers\TournamentMatchController;
 use App\Http\Controllers\TournamentRegistrationController;
 use Illuminate\Support\Facades\Route;
 
@@ -19,6 +20,9 @@ Route::middleware(['auth', 'verified', 'throttle:tournaments', 'onboarding'])->g
     Route::post('/tournaments/{id}/open-registration', [TournamentController::class, 'openRegistration'])->name('tournaments.open-registration');
     Route::post('/tournaments/{id}/start', [TournamentController::class, 'start'])->name('tournaments.start');
     Route::post('/tournaments/{id}/cancel', [TournamentController::class, 'cancel'])->name('tournaments.cancel');
+
+    // Tournament Match Scheduling
+    Route::patch('/tournaments/{tournament}/matches/{match}', [TournamentMatchController::class, 'update'])->name('tournaments.matches.update');
 
     // Tournament Logo
     Route::post('/tournaments/{id}/logo', [TournamentLogoController::class, 'store'])->name('tournaments.logo.store');

--- a/routes/tournaments.php
+++ b/routes/tournaments.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\TournamentController;
+use App\Http\Controllers\TournamentGroupController;
 use App\Http\Controllers\TournamentLogoController;
 use App\Http\Controllers\TournamentMatchController;
 use App\Http\Controllers\TournamentRegistrationController;
@@ -23,6 +24,10 @@ Route::middleware(['auth', 'verified', 'throttle:tournaments', 'onboarding'])->g
 
     // Tournament Match Scheduling
     Route::patch('/tournaments/{tournament}/matches/{match}', [TournamentMatchController::class, 'update'])->name('tournaments.matches.update');
+
+    // Tournament Groups (group_stage_knockout draw)
+    Route::post('/tournaments/{id}/groups/draw', [TournamentGroupController::class, 'assign'])->name('tournaments.groups.assign');
+    Route::delete('/tournaments/{id}/groups/draw', [TournamentGroupController::class, 'clear'])->name('tournaments.groups.clear');
 
     // Tournament Logo
     Route::post('/tournaments/{id}/logo', [TournamentLogoController::class, 'store'])->name('tournaments.logo.store');

--- a/tests/Feature/Tournament/GroupStageKnockoutTest.php
+++ b/tests/Feature/Tournament/GroupStageKnockoutTest.php
@@ -1,0 +1,264 @@
+<?php
+
+use App\Models\Team;
+use App\Models\Tournament;
+use App\Models\TournamentGroup;
+use App\Models\TournamentTeam;
+use App\Models\User;
+use App\Services\MatchService;
+use App\Services\TournamentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Build a group_stage_knockout tournament with `groupCount * groupSize`
+ * approved teams. Returns the tournament with eager-loaded groups.
+ */
+function makeGroupTournament(int $groupCount, int $groupSize, User $organizer): Tournament
+{
+    $maxTeams = $groupCount * $groupSize;
+    $tournament = Tournament::factory()->create([
+        'organizer_id' => $organizer->id,
+        'status' => 'registration_open',
+        'variant' => 'football_11',
+        'format' => 'group_stage_knockout',
+        'phase' => 'not_started',
+        'group_count' => $groupCount,
+        'group_size' => $groupSize,
+        'max_teams' => $maxTeams,
+        'min_teams' => $maxTeams,
+    ]);
+
+    // Auto-create groups (mirrors what the service does on real creation).
+    for ($i = 0; $i < $groupCount; $i++) {
+        TournamentGroup::create([
+            'tournament_id' => $tournament->id,
+            'name' => chr(ord('A') + $i),
+            'position' => $i,
+        ]);
+    }
+
+    for ($i = 0; $i < $maxTeams; $i++) {
+        $team = Team::factory()->create(['variant' => 'football_11']);
+        TournamentTeam::factory()->create([
+            'tournament_id' => $tournament->id,
+            'team_id' => $team->id,
+            'status' => 'approved',
+            'seed' => $i + 1,
+            'registered_by' => $organizer->id,
+        ]);
+    }
+
+    return $tournament->fresh(['groups']);
+}
+
+test('creating a group_stage_knockout tournament auto-creates groups', function () {
+    $user = User::factory()->create(['email_verified_at' => now()]);
+    $this->actingAs($user);
+
+    $response = $this->post('/tournaments', [
+        'name' => 'Mundialito',
+        'visibility' => 'public',
+        'variant' => 'football_11',
+        'format' => 'group_stage_knockout',
+        'group_count' => 4,
+        'group_size' => 4,
+        'min_teams' => 16,
+        'starts_at' => now()->addDays(3)->toDateTimeString(),
+    ]);
+
+    $response->assertRedirect();
+    $tournament = Tournament::where('name', 'Mundialito')->first();
+    expect($tournament->format)->toBe('group_stage_knockout')
+        ->and($tournament->group_count)->toBe(4)
+        ->and($tournament->group_size)->toBe(4)
+        ->and($tournament->max_teams)->toBe(16)
+        ->and($tournament->groups()->count())->toBe(4);
+
+    $names = $tournament->groups()->orderBy('position')->pluck('name')->all();
+    expect($names)->toBe(['A', 'B', 'C', 'D']);
+});
+
+test('cannot start group_stage_knockout until every team is assigned to a group', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeGroupTournament(2, 4, $organizer); // 8 teams, 2 groups
+
+    // Assign only 4 teams (one full group, one empty)
+    $teams = $tournament->tournamentTeams()->orderBy('id')->get();
+    $groupA = $tournament->groups->first();
+    foreach ($teams->take(4) as $tt) {
+        $tt->update(['tournament_group_id' => $groupA->id]);
+    }
+
+    $this->actingAs($organizer);
+    $response = $this->post("/tournaments/{$tournament->id}/start");
+    $response->assertSessionHasErrors();
+
+    expect($tournament->fresh()->status)->toBe('registration_open');
+});
+
+test('group draw endpoint enforces capacity', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeGroupTournament(2, 4, $organizer); // 8 teams, 2 groups of 4
+    $teams = $tournament->tournamentTeams()->orderBy('id')->get();
+    $groupA = $tournament->groups->first();
+
+    $this->actingAs($organizer);
+
+    // Try to put 5 teams into a 4-team group
+    $assignments = $teams->take(5)->map(fn ($tt) => [
+        'tournament_team_id' => $tt->id,
+        'tournament_group_id' => $groupA->id,
+    ])->all();
+
+    $response = $this->post("/tournaments/{$tournament->id}/groups/draw", [
+        'assignments' => $assignments,
+    ]);
+
+    $response->assertSessionHasErrors();
+
+    // No assignments persisted.
+    expect($tournament->fresh()->tournamentTeams()->whereNotNull('tournament_group_id')->count())->toBe(0);
+});
+
+test('starting a group_stage_knockout generates round-robin matches across all groups', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeGroupTournament(2, 4, $organizer); // 8 teams, 2 groups of 4 → 6 matches/group, 3 matchdays
+
+    // Manually distribute teams: first 4 → group A, last 4 → group B
+    $teams = $tournament->tournamentTeams()->orderBy('id')->get();
+    $groupA = $tournament->groups->where('position', 0)->first();
+    $groupB = $tournament->groups->where('position', 1)->first();
+    foreach ($teams->take(4) as $tt) {
+        $tt->update(['tournament_group_id' => $groupA->id]);
+    }
+    foreach ($teams->skip(4) as $tt) {
+        $tt->update(['tournament_group_id' => $groupB->id]);
+    }
+
+    app(TournamentService::class)->startTournament($tournament);
+
+    $tournament = $tournament->fresh();
+    expect($tournament->status)->toBe('in_progress')
+        ->and($tournament->phase)->toBe('group_stage');
+
+    // Each group has n*(n-1)/2 = 6 matches
+    expect($tournament->matches()->where('tournament_group_id', $groupA->id)->count())->toBe(6);
+    expect($tournament->matches()->where('tournament_group_id', $groupB->id)->count())->toBe(6);
+
+    // 3 shared matchdays, each with 4 matches (2 per group × 2 groups)
+    expect($tournament->rounds()->count())->toBe(3);
+    for ($md = 1; $md <= 3; $md++) {
+        expect($tournament->matches()->where('matchday', $md)->count())->toBe(4);
+    }
+});
+
+test('completing all group matches transitions to knockout with cross-bracket pairings', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeGroupTournament(2, 4, $organizer);
+
+    // Distribute teams into groups deterministically by seed
+    $teams = $tournament->tournamentTeams()->orderBy('seed')->get();
+    $groupA = $tournament->groups->where('position', 0)->first();
+    $groupB = $tournament->groups->where('position', 1)->first();
+    foreach ($teams->take(4) as $tt) {
+        $tt->update(['tournament_group_id' => $groupA->id]);
+    }
+    foreach ($teams->skip(4) as $tt) {
+        $tt->update(['tournament_group_id' => $groupB->id]);
+    }
+
+    app(TournamentService::class)->startTournament($tournament);
+
+    // Complete every group match. Use scoring that produces a clean ordering:
+    // home team always wins by 2-0. Inside each group the team that plays home
+    // most often wins; we just verify the transition fires, not the exact order.
+    $tournament->fresh()->matches()->whereNotNull('tournament_group_id')->get()->each(function ($match) {
+        $match->update([
+            'status' => 'in_progress',
+            'started_at' => now()->subHours(2),
+            'scheduled_at' => now()->subHours(3),
+            'home_score' => 2,
+            'away_score' => 0,
+        ]);
+        app(MatchService::class)->completeMatch($match->fresh());
+    });
+
+    $tournament = $tournament->fresh();
+
+    // Phase advanced to knockout
+    expect($tournament->phase)->toBe('knockout');
+
+    // 4-team bracket = 2 rounds (Semifinal, Final). Group stage had 3 rounds, so
+    // bracket rounds continue at 4 and 5.
+    $bracketRounds = $tournament->rounds()->where('round_number', '>=', 4)->orderBy('round_number')->get();
+    expect($bracketRounds)->toHaveCount(2);
+    expect($bracketRounds[0]->name)->toBe('Semifinal');
+    expect($bracketRounds[1]->name)->toBe('Final');
+
+    // First bracket round (semifinals) should have 2 matches with both teams set
+    $semifinals = $tournament->matches()->where('tournament_round_id', $bracketRounds[0]->id)->get();
+    expect($semifinals)->toHaveCount(2);
+    foreach ($semifinals as $sf) {
+        expect($sf->home_team_id)->not->toBeNull();
+        expect($sf->away_team_id)->not->toBeNull();
+        expect($sf->status)->toBe('confirmed');
+    }
+});
+
+test('completing group matches with all groups incomplete does not transition', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeGroupTournament(2, 4, $organizer);
+
+    $teams = $tournament->tournamentTeams()->orderBy('seed')->get();
+    foreach ($teams->take(4) as $tt) {
+        $tt->update(['tournament_group_id' => $tournament->groups->where('position', 0)->first()->id]);
+    }
+    foreach ($teams->skip(4) as $tt) {
+        $tt->update(['tournament_group_id' => $tournament->groups->where('position', 1)->first()->id]);
+    }
+
+    app(TournamentService::class)->startTournament($tournament);
+
+    // Complete only the FIRST group match
+    $first = $tournament->fresh()->matches()->whereNotNull('tournament_group_id')->orderBy('id')->first();
+    $first->update([
+        'status' => 'in_progress',
+        'started_at' => now()->subHours(2),
+        'scheduled_at' => now()->subHours(3),
+        'home_score' => 1,
+        'away_score' => 0,
+    ]);
+    app(MatchService::class)->completeMatch($first->fresh());
+
+    expect($tournament->fresh()->phase)->toBe('group_stage');
+});
+
+test('group standings appear in show endpoint props', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeGroupTournament(2, 4, $organizer);
+
+    // Don't start; just request the page.
+    $this->actingAs($organizer);
+    $response = $this->get("/tournaments/{$tournament->id}");
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->component('tournaments/show')
+        ->has('groupStandings', 2)
+    );
+});
+
+test('non-organizer cannot draw groups', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $stranger = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeGroupTournament(2, 4, $organizer);
+
+    $this->actingAs($stranger);
+    $response = $this->post("/tournaments/{$tournament->id}/groups/draw", [
+        'assignments' => [],
+    ]);
+
+    $response->assertForbidden();
+});

--- a/tests/Feature/Tournament/LeagueFormatTest.php
+++ b/tests/Feature/Tournament/LeagueFormatTest.php
@@ -1,0 +1,256 @@
+<?php
+
+use App\Models\Team;
+use App\Models\Tournament;
+use App\Models\TournamentTeam;
+use App\Models\User;
+use App\Services\MatchService;
+use App\Services\TournamentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function makeLeagueTournament(int $teamCount, User $organizer): Tournament
+{
+    $tournament = Tournament::factory()->create([
+        'organizer_id' => $organizer->id,
+        'status' => 'registration_open',
+        'variant' => 'football_11',
+        'format' => 'league',
+        'phase' => 'not_started',
+        'max_teams' => $teamCount,
+        'min_teams' => 2,
+    ]);
+
+    for ($i = 0; $i < $teamCount; $i++) {
+        $team = Team::factory()->create(['variant' => 'football_11']);
+        TournamentTeam::factory()->create([
+            'tournament_id' => $tournament->id,
+            'team_id' => $team->id,
+            'status' => 'approved',
+            'seed' => $i + 1,
+            'registered_by' => $organizer->id,
+        ]);
+    }
+
+    return $tournament->fresh();
+}
+
+test('user can create a league tournament with a non-power-of-2 team count', function () {
+    $user = User::factory()->create(['email_verified_at' => now()]);
+    $this->actingAs($user);
+
+    $response = $this->post('/tournaments', [
+        'name' => 'Liga de Prueba',
+        'visibility' => 'public',
+        'variant' => 'football_11',
+        'format' => 'league',
+        'max_teams' => 6,
+        'min_teams' => 2,
+        'starts_at' => now()->addDays(3)->toDateTimeString(),
+    ]);
+
+    $response->assertRedirect();
+    $this->assertDatabaseHas('tournaments', [
+        'name' => 'Liga de Prueba',
+        'format' => 'league',
+        'phase' => 'not_started',
+        'max_teams' => 6,
+    ]);
+});
+
+test('league tournament requires max_teams between 2 and 64', function () {
+    $user = User::factory()->create(['email_verified_at' => now()]);
+    $this->actingAs($user);
+
+    $response = $this->post('/tournaments', [
+        'name' => 'Liga',
+        'visibility' => 'public',
+        'variant' => 'football_11',
+        'format' => 'league',
+        'max_teams' => 1,
+        'min_teams' => 2,
+    ]);
+
+    $response->assertSessionHasErrors('max_teams');
+});
+
+test('starting a league with fewer than min_teams fails', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = Tournament::factory()->create([
+        'organizer_id' => $organizer->id,
+        'status' => 'registration_open',
+        'format' => 'league',
+        'phase' => 'not_started',
+        'max_teams' => 6,
+        'min_teams' => 4,
+    ]);
+
+    // Only register 2 teams
+    for ($i = 0; $i < 2; $i++) {
+        $team = Team::factory()->create(['variant' => $tournament->variant]);
+        TournamentTeam::factory()->create([
+            'tournament_id' => $tournament->id,
+            'team_id' => $team->id,
+            'status' => 'approved',
+            'registered_by' => $organizer->id,
+        ]);
+    }
+
+    $this->actingAs($organizer);
+    $response = $this->post("/tournaments/{$tournament->id}/start");
+    $response->assertSessionHasErrors();
+
+    $this->assertDatabaseHas('tournaments', [
+        'id' => $tournament->id,
+        'status' => 'registration_open',
+    ]);
+});
+
+test('starting a league generates a full round-robin schedule', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeLeagueTournament(6, $organizer);
+
+    $this->actingAs($organizer);
+    $this->post("/tournaments/{$tournament->id}/start")->assertRedirect();
+
+    $tournament = $tournament->fresh();
+    expect($tournament->status)->toBe('in_progress')
+        ->and($tournament->phase)->toBe('league');
+
+    // n*(n-1)/2 = 15 matches across n-1 = 5 matchdays
+    expect($tournament->matches()->count())->toBe(15);
+    expect($tournament->rounds()->count())->toBe(5);
+
+    // Each matchday has exactly 3 matches (6 teams / 2)
+    for ($md = 1; $md <= 5; $md++) {
+        expect($tournament->matches()->where('matchday', $md)->count())->toBe(3);
+    }
+
+    // Every team plays every other team exactly once.
+    $teamIds = $tournament->approvedTeams()->pluck('team_id')->all();
+    foreach ($teamIds as $teamId) {
+        $opponents = $tournament->matches()
+            ->where(function ($q) use ($teamId) {
+                $q->where('home_team_id', $teamId)->orWhere('away_team_id', $teamId);
+            })
+            ->get()
+            ->map(fn ($m) => $m->home_team_id === $teamId ? $m->away_team_id : $m->home_team_id)
+            ->unique()
+            ->sort()
+            ->values()
+            ->all();
+
+        $expected = collect($teamIds)->reject(fn ($id) => $id === $teamId)->sort()->values()->all();
+        expect($opponents)->toBe($expected, "team {$teamId} should play every other team exactly once");
+    }
+});
+
+test('league matches accept draws without throwing', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeLeagueTournament(4, $organizer);
+    app(TournamentService::class)->startTournament($tournament);
+
+    $match = $tournament->fresh()->matches()->first();
+    $match->update([
+        'status' => 'in_progress',
+        'started_at' => now()->subMinutes(90),
+        'scheduled_at' => now()->subHours(2),
+        'home_score' => 1,
+        'away_score' => 1,
+    ]);
+
+    app(MatchService::class)->completeMatch($match->fresh());
+
+    expect($match->fresh()->status)->toBe('completed');
+});
+
+test('completing the last league match marks the tournament completed', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeLeagueTournament(4, $organizer);
+    app(TournamentService::class)->startTournament($tournament);
+
+    $matches = $tournament->fresh()->matches;
+    expect($matches)->toHaveCount(6); // 4 teams → 6 matches
+
+    foreach ($matches as $i => $match) {
+        $match->update([
+            'status' => 'in_progress',
+            'started_at' => now()->subMinutes(90),
+            'scheduled_at' => now()->subHours(2),
+            'home_score' => 2,
+            'away_score' => $i,
+        ]);
+        app(MatchService::class)->completeMatch($match->fresh());
+    }
+
+    $tournament = $tournament->fresh();
+    expect($tournament->status)->toBe('completed')
+        ->and($tournament->phase)->toBe('completed')
+        ->and($tournament->ends_at)->not->toBeNull();
+});
+
+test('tournament show endpoint includes standings for league format', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeLeagueTournament(4, $organizer);
+    app(TournamentService::class)->startTournament($tournament);
+
+    // Complete two matches with deterministic results.
+    $tournament->fresh()->matches->each(function ($match, $i) {
+        if ($i >= 2) {
+            return;
+        }
+        $match->update([
+            'status' => 'in_progress',
+            'started_at' => now()->subMinutes(90),
+            'scheduled_at' => now()->subHours(2),
+            'home_score' => 3,
+            'away_score' => 0,
+        ]);
+        app(MatchService::class)->completeMatch($match->fresh());
+    });
+
+    $this->actingAs($organizer);
+    $response = $this->get("/tournaments/{$tournament->id}");
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->component('tournaments/show')
+        ->has('standings', 4)
+        ->where('standings.0.position', 1)
+    );
+});
+
+test('single-elimination regression: existing flow still works', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = Tournament::factory()->create([
+        'organizer_id' => $organizer->id,
+        'status' => 'registration_open',
+        'variant' => 'football_11',
+        'max_teams' => 4,
+        'min_teams' => 4,
+    ]);
+
+    for ($i = 0; $i < 4; $i++) {
+        $team = Team::factory()->create(['variant' => 'football_11']);
+        TournamentTeam::factory()->create([
+            'tournament_id' => $tournament->id,
+            'team_id' => $team->id,
+            'status' => 'approved',
+            'seed' => $i + 1,
+            'registered_by' => $organizer->id,
+        ]);
+    }
+
+    $this->actingAs($organizer);
+    $this->post("/tournaments/{$tournament->id}/start")->assertRedirect();
+
+    $tournament = $tournament->fresh();
+    expect($tournament->status)->toBe('in_progress')
+        ->and($tournament->phase)->toBe('knockout')
+        ->and($tournament->format)->toBe('single_elimination');
+
+    // 4 teams → 2 rounds (Semifinal, Final), 3 matches total (2 in first round + 1 placeholder)
+    expect($tournament->rounds()->count())->toBe(2);
+    expect($tournament->matches()->count())->toBe(3);
+});

--- a/tests/Feature/TournamentMatchScheduleTest.php
+++ b/tests/Feature/TournamentMatchScheduleTest.php
@@ -1,0 +1,161 @@
+<?php
+
+use App\Models\FootballMatch;
+use App\Models\Team;
+use App\Models\Tournament;
+use App\Models\TournamentTeam;
+use App\Models\User;
+use App\Services\TournamentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function startTournamentWithMatches(User $organizer, int $teamCount = 4): Tournament
+{
+    $tournament = Tournament::factory()->create([
+        'organizer_id' => $organizer->id,
+        'status' => 'registration_open',
+        'variant' => 'football_11',
+        'starts_at' => now()->addDays(3),
+    ]);
+
+    for ($i = 0; $i < $teamCount; $i++) {
+        $team = Team::factory()->create(['variant' => 'football_11']);
+        TournamentTeam::factory()->create([
+            'tournament_id' => $tournament->id,
+            'team_id' => $team->id,
+            'status' => 'approved',
+            'registered_by' => $organizer->id,
+        ]);
+    }
+
+    app(TournamentService::class)->startTournament($tournament);
+
+    return $tournament->fresh();
+}
+
+test('bracket generation leaves matches unscheduled', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = startTournamentWithMatches($organizer);
+
+    $matches = FootballMatch::where('tournament_id', $tournament->id)->get();
+
+    expect($matches)->not->toBeEmpty();
+    foreach ($matches as $match) {
+        expect($match->scheduled_at)->toBeNull();
+        expect($match->location)->toBeNull();
+    }
+});
+
+test('organizer can schedule a tournament match', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = startTournamentWithMatches($organizer);
+    $match = FootballMatch::where('tournament_id', $tournament->id)
+        ->whereNotNull('home_team_id')
+        ->first();
+
+    $this->actingAs($organizer);
+
+    $scheduledAt = now()->addDays(5)->setTime(18, 30);
+
+    $response = $this->patch(
+        "/tournaments/{$tournament->id}/matches/{$match->id}",
+        [
+            'scheduled_at' => $scheduledAt->toDateTimeString(),
+            'location' => 'Cancha 3 — Complejo Norte',
+        ],
+    );
+
+    $response->assertRedirect();
+
+    $match->refresh();
+    expect($match->scheduled_at->format('Y-m-d H:i'))
+        ->toBe($scheduledAt->format('Y-m-d H:i'));
+    expect($match->location)->toBe('Cancha 3 — Complejo Norte');
+});
+
+test('non-organizer cannot schedule a tournament match', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $intruder = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = startTournamentWithMatches($organizer);
+    $match = FootballMatch::where('tournament_id', $tournament->id)
+        ->whereNotNull('home_team_id')
+        ->first();
+
+    $this->actingAs($intruder);
+
+    $response = $this->patch(
+        "/tournaments/{$tournament->id}/matches/{$match->id}",
+        [
+            'scheduled_at' => now()->addDays(5)->toDateTimeString(),
+            'location' => 'Hack',
+        ],
+    );
+
+    $response->assertForbidden();
+    expect($match->fresh()->scheduled_at)->toBeNull();
+});
+
+test('cannot schedule a match for a date in the past', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = startTournamentWithMatches($organizer);
+    $match = FootballMatch::where('tournament_id', $tournament->id)
+        ->whereNotNull('home_team_id')
+        ->first();
+
+    $this->actingAs($organizer);
+
+    $response = $this->patch(
+        "/tournaments/{$tournament->id}/matches/{$match->id}",
+        [
+            'scheduled_at' => now()->subDays(1)->toDateTimeString(),
+            'location' => 'Cancha 1',
+        ],
+    );
+
+    $response->assertSessionHasErrors('scheduled_at');
+    expect($match->fresh()->scheduled_at)->toBeNull();
+});
+
+test('cannot edit a completed match', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = startTournamentWithMatches($organizer);
+    $match = FootballMatch::where('tournament_id', $tournament->id)
+        ->whereNotNull('home_team_id')
+        ->first();
+    $match->update(['status' => 'completed']);
+
+    $this->actingAs($organizer);
+
+    $response = $this->patch(
+        "/tournaments/{$tournament->id}/matches/{$match->id}",
+        [
+            'scheduled_at' => now()->addDays(2)->toDateTimeString(),
+            'location' => 'Otra cancha',
+        ],
+    );
+
+    $response->assertForbidden();
+});
+
+test('match must belong to the given tournament', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournamentA = startTournamentWithMatches($organizer);
+    $tournamentB = startTournamentWithMatches($organizer);
+
+    $matchFromB = FootballMatch::where('tournament_id', $tournamentB->id)
+        ->whereNotNull('home_team_id')
+        ->first();
+
+    $this->actingAs($organizer);
+
+    $response = $this->patch(
+        "/tournaments/{$tournamentA->id}/matches/{$matchFromB->id}",
+        [
+            'scheduled_at' => now()->addDays(2)->toDateTimeString(),
+            'location' => 'Cancha 1',
+        ],
+    );
+
+    $response->assertNotFound();
+});

--- a/tests/Unit/Services/StandingsServiceTest.php
+++ b/tests/Unit/Services/StandingsServiceTest.php
@@ -1,0 +1,194 @@
+<?php
+
+use App\Models\FootballMatch;
+use App\Services\StandingsService;
+
+function standingsMatch(int $home, int $away, int $homeScore, int $awayScore, string $status = 'completed'): FootballMatch
+{
+    $match = new FootballMatch;
+    $match->home_team_id = $home;
+    $match->away_team_id = $away;
+    $match->home_score = $homeScore;
+    $match->away_score = $awayScore;
+    $match->status = $status;
+
+    return $match;
+}
+
+it('returns one row per team with zeros when no matches exist', function () {
+    $rows = (new StandingsService)->compute(collect(), collect([1, 2, 3]));
+
+    expect($rows)->toHaveCount(3);
+    foreach ($rows as $row) {
+        expect($row->played)->toBe(0)
+            ->and($row->wins)->toBe(0)
+            ->and($row->draws)->toBe(0)
+            ->and($row->losses)->toBe(0)
+            ->and($row->points)->toBe(0)
+            ->and($row->goalDifference)->toBe(0)
+            ->and($row->tiedWithAbove)->toBeFalse();
+    }
+    // Input order preserved when no matches have been played.
+    expect(array_map(fn ($r) => $r->teamId, $rows))->toBe([1, 2, 3]);
+});
+
+it('aggregates wins, draws, losses, goals, and points correctly', function () {
+    $matches = collect([
+        standingsMatch(1, 2, 3, 1),  // 1 beats 2
+        standingsMatch(2, 3, 2, 2),  // draw
+        standingsMatch(1, 3, 1, 0),  // 1 beats 3
+    ]);
+
+    $rows = (new StandingsService)->compute($matches, collect([1, 2, 3]));
+
+    // Team 1: 2W = 6 pts, GF 4 GA 1 GD +3
+    expect($rows[0]->teamId)->toBe(1)
+        ->and($rows[0]->wins)->toBe(2)
+        ->and($rows[0]->draws)->toBe(0)
+        ->and($rows[0]->losses)->toBe(0)
+        ->and($rows[0]->goalsFor)->toBe(4)
+        ->and($rows[0]->goalsAgainst)->toBe(1)
+        ->and($rows[0]->goalDifference)->toBe(3)
+        ->and($rows[0]->points)->toBe(6)
+        ->and($rows[0]->position)->toBe(1);
+
+    // Team 3: 0W 1D 1L = 1 pt, GF 2 GA 3 GD -1 (better than team 2's GD -2)
+    expect($rows[1]->teamId)->toBe(3)
+        ->and($rows[1]->points)->toBe(1)
+        ->and($rows[1]->goalDifference)->toBe(-1)
+        ->and($rows[1]->position)->toBe(2);
+
+    // Team 2: 0W 1D 1L = 1 pt, GF 3 GA 5 GD -2
+    expect($rows[2]->teamId)->toBe(2)
+        ->and($rows[2]->points)->toBe(1)
+        ->and($rows[2]->goalDifference)->toBe(-2)
+        ->and($rows[2]->position)->toBe(3);
+});
+
+it('breaks ties by goal difference', function () {
+    $matches = collect([
+        standingsMatch(1, 3, 3, 0),  // 1 beats 3 by 3
+        standingsMatch(2, 3, 1, 0),  // 2 beats 3 by 1
+    ]);
+
+    $rows = (new StandingsService)->compute($matches, collect([1, 2, 3]));
+
+    // Teams 1 and 2 both have 3 pts; team 1 has GD +3, team 2 has GD +1.
+    expect($rows[0]->teamId)->toBe(1)->and($rows[0]->goalDifference)->toBe(3);
+    expect($rows[1]->teamId)->toBe(2)->and($rows[1]->goalDifference)->toBe(1);
+    expect($rows[2]->teamId)->toBe(3);
+});
+
+it('breaks ties by goals scored when GD is equal', function () {
+    $matches = collect([
+        standingsMatch(1, 3, 4, 2),  // 1 beats 3
+        standingsMatch(4, 1, 3, 1),  // 4 beats 1 — team 1 GD: +2 -2 = 0
+        standingsMatch(2, 3, 1, 0),  // 2 beats 3
+        standingsMatch(4, 2, 1, 0),  // 4 beats 2 — team 2 GD: +1 -1 = 0
+    ]);
+
+    $rows = (new StandingsService)->compute($matches, collect([1, 2, 3, 4]));
+
+    // Team 4: 2W = 6 pts (top)
+    // Team 1: 1W 1L = 3 pts, GD 0, GF 5
+    // Team 2: 1W 1L = 3 pts, GD 0, GF 1 — same pts/GD, less GF
+    // Team 3: 0W 2L = 0 pts (bottom)
+    expect($rows[0]->teamId)->toBe(4)->and($rows[0]->points)->toBe(6);
+    expect($rows[1]->teamId)->toBe(1)->and($rows[1]->goalsFor)->toBe(5);
+    expect($rows[2]->teamId)->toBe(2)->and($rows[2]->goalsFor)->toBe(1);
+    expect($rows[3]->teamId)->toBe(3);
+});
+
+it('breaks ties by head-to-head when primary stats are identical', function () {
+    // 4 teams. A=1, B=2, C=3, D=4. All play each other once.
+    $matches = collect([
+        standingsMatch(1, 4, 5, 0),  // A beats D 5-0
+        standingsMatch(1, 2, 1, 0),  // A beats B 1-0
+        standingsMatch(3, 1, 1, 0),  // C beats A 1-0
+        standingsMatch(4, 2, 5, 0),  // D beats B 5-0
+        standingsMatch(3, 4, 5, 0),  // C beats D 5-0
+        standingsMatch(2, 3, 1, 0),  // B beats C 1-0
+    ]);
+
+    $rows = (new StandingsService)->compute($matches, collect([1, 2, 3, 4]));
+
+    // A: 6 pts, GF 6 GA 1 GD +5
+    // C: 6 pts, GF 6 GA 1 GD +5  ← tied with A on (pts, GD, GF); H2H: C beat A, so C first
+    // D: 3 pts, GF 5 GA 10 GD -5
+    // B: 3 pts, GF 1 GA 6  GD -5  ← tied with D on (pts, GD); GF tiebreak: D ahead (5 > 1)
+    expect($rows[0]->teamId)->toBe(3); // C
+    expect($rows[1]->teamId)->toBe(1); // A
+    expect($rows[2]->teamId)->toBe(4); // D
+    expect($rows[3]->teamId)->toBe(2); // B
+});
+
+it('uses seeded RNG to break truly unbreakable ties deterministically', function () {
+    // Rock-paper-scissors: each team beats one and loses to the other.
+    // All 3 teams: 1W 1L = 3 pts, GF 1 GA 1 GD 0. H2H mini-table is identical.
+    $matches = collect([
+        standingsMatch(1, 2, 1, 0),
+        standingsMatch(2, 3, 1, 0),
+        standingsMatch(3, 1, 1, 0),
+    ]);
+
+    $svc = new StandingsService;
+    $rows1 = $svc->compute($matches, collect([1, 2, 3]), rngSeed: 42);
+    $rows2 = $svc->compute($matches, collect([1, 2, 3]), rngSeed: 42);
+
+    $ids1 = array_map(fn ($r) => $r->teamId, $rows1);
+    $ids2 = array_map(fn ($r) => $r->teamId, $rows2);
+
+    // Same seed → identical order.
+    expect($ids1)->toBe($ids2);
+
+    // The 2nd and 3rd teams are flagged as tied with above.
+    expect($rows1[1]->tiedWithAbove)->toBeTrue();
+    expect($rows1[2]->tiedWithAbove)->toBeTrue();
+    expect($rows1[0]->tiedWithAbove)->toBeFalse();
+});
+
+it('preserves input order when tied teams have not yet played each other', function () {
+    // Mid-stage standings: teams 1, 2, 3 are all at zero having only played team 4.
+    // No actual H2H between 1/2/3 — should NOT shuffle them via RNG.
+    $matches = collect([
+        standingsMatch(4, 1, 1, 0),  // team 1 lost to 4
+        standingsMatch(4, 2, 1, 0),  // team 2 lost to 4
+        standingsMatch(4, 3, 1, 0),  // team 3 lost to 4
+    ]);
+
+    $rows = (new StandingsService)->compute($matches, collect([1, 2, 3, 4]));
+
+    expect($rows[0]->teamId)->toBe(4);
+    // Teams 1, 2, 3 all tied (0 pts, GD -1, GF 0) and have NOT played each
+    // other → input order preserved, no _tied_with_above markers.
+    expect($rows[1]->teamId)->toBe(1)->and($rows[1]->tiedWithAbove)->toBeFalse();
+    expect($rows[2]->teamId)->toBe(2)->and($rows[2]->tiedWithAbove)->toBeFalse();
+    expect($rows[3]->teamId)->toBe(3)->and($rows[3]->tiedWithAbove)->toBeFalse();
+});
+
+it('ignores matches involving teams outside the team set', function () {
+    $matches = collect([
+        standingsMatch(1, 2, 3, 1),
+        standingsMatch(99, 1, 5, 0), // team 99 not in the set
+    ]);
+
+    $rows = (new StandingsService)->compute($matches, collect([1, 2]));
+
+    expect($rows[0]->teamId)->toBe(1)
+        ->and($rows[0]->played)->toBe(1)
+        ->and($rows[0]->goalsFor)->toBe(3);
+});
+
+it('ignores non-completed matches', function () {
+    $matches = collect([
+        standingsMatch(1, 2, 3, 1, 'completed'),
+        standingsMatch(1, 2, 0, 0, 'in_progress'),
+        standingsMatch(1, 2, 0, 0, 'confirmed'),
+    ]);
+
+    $rows = (new StandingsService)->compute($matches, collect([1, 2]));
+
+    expect($rows[0]->played)->toBe(1)
+        ->and($rows[0]->teamId)->toBe(1)
+        ->and($rows[0]->wins)->toBe(1);
+});


### PR DESCRIPTION
## Summary

Bundles four related tournament improvements:

1. **Per-match scheduling** (`d018be4`) — Organizers can set a specific date and venue for each generated tournament match.
2. **Flash messages on Inertia pages** (`024513c`) — Session flash (`success`/`error`) is now exposed as a shared Inertia prop, so existing toast handlers (e.g. on `tournaments/show.tsx`) actually fire on redirect.
3. **Edit guard for in-flight tournaments** (`e85c40c`) — Hides the edit button and redirects the edit route once a tournament leaves `draft`/`registration_open`.
4. **League and group-stage tournament formats** (`2c28e1c`) — The marquee feature. Tournaments can now be created in three formats:
   - **`single_elimination`** (existing) — power-of-2 bracket
   - **`league`** — round-robin, points table decides champion. Any team count from 2 to 64. Draws allowed.
   - **`group_stage_knockout`** — groups (2/4/8/16) play round-robin, top 2 of each group auto-advance to a single-elim bracket. Manual click-to-assign group draw before start.

### Multi-format design highlights

- **Reusable standings engine** (`StandingsService`) with full tiebreaker chain: Points → Goal Difference → Goals Scored → Head-to-Head → seeded RNG (only when tied teams have actually played each other; otherwise input order is preserved). Fully unit-tested.
- **Hard-coded scoring**: W=3, D=1, L=0.
- **Group draw**: click-to-assign UI per team (no drag-and-drop, no auto-balance). Save button disabled until all teams placed; per-group capacity counter highlights overflow.
- **Knockout transition**: when the last group match completes, the system computes top-2 per group and slots them into a cross-bracket via deterministic pairings (group winners can only meet at later rounds).
- **Round numbering continues** from the last group matchday into the knockout phase — preserves the existing `unique(tournament_id, round_number)` schema constraint.

### Schema

Four additive migrations under `database/migrations/2026_05_10_*`:
- `tournaments`: `format` enum, `phase` enum, `group_count`, `group_size`. Existing rows backfilled inline (single-elim default, phase mirrors status).
- New `tournament_groups` table.
- `tournament_teams.tournament_group_id` (nullable FK).
- `matches.tournament_group_id` (nullable FK) + `matches.matchday`.

All nullable/defaulted — existing single-elim tournaments unchanged. A regression test in `LeagueFormatTest` pins single-elim behavior.

## Test plan

- [x] `php artisan test` — 328 passed (1465 assertions). Includes 9 new unit tests for `StandingsService`, 8 new feature tests for league format, 8 new feature tests for group → knockout.
- [x] Single-elim regression test asserts the existing flow generates the same rounds/matches/seeding as before.
- [x] `bun run types` — no new TS errors (pre-existing `.form()` errors on auth/settings pages are unrelated to this work).
- [x] `bun run lint` + `bun run format` clean.
- [x] `./vendor/bin/pint` clean.
- [ ] Manual end-to-end: create a 6-team league, register/approve teams, start, complete matches with mixed results (incl. draws), verify standings + auto-completion.
- [ ] Manual end-to-end: create a 4-group × 4-team `group_stage_knockout`, draw teams via click-to-assign UI, start, complete all group matches, verify auto-transition to a 4-team semifinal bracket with correct cross-pairings, complete bracket through final.
- [ ] Manual smoke: existing single-elimination tournament create + start + advance + complete flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)