### PR TITLE
Improve tournaments index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+Veltro is a Laravel 12 + React 19 + Inertia.js application. Backend code lives in `app/`, with controllers under `app/Http/Controllers`, models in `app/Models`, services in `app/Services`, policies in `app/Policies`, and notifications in `app/Notifications`. Routes are split across `routes/web.php`, `routes/teams.php`, `routes/matches.php`, `routes/tournaments.php`, and related route files. Frontend source is in `resources/js`: pages in `pages/`, shared components in `components/`, layouts in `layouts/`, hooks in `hooks/`, and types in `types/`. Styles are in `resources/css/app.css`. Tests are in `tests/Feature` and `tests/Unit`.
+
+## Build, Test, and Development Commands
+
+- Do not run `composer dev`: the user keeps the local Laravel, queue, and Vite stack running in another terminal.
+- `composer dev:ssr`: run the local stack with Inertia SSR.
+- `bun run build`: build production frontend assets.
+- `bun run build:ssr`: build client and SSR bundles.
+- `bun run types`: run TypeScript checks.
+- `bun run format` / `bun run format:check`: format or verify `resources/` with Prettier.
+- `bun run lint`: run ESLint with fixes.
+- `composer test` or `php artisan test`: run the PHP test suite.
+- `./vendor/bin/pint`: format PHP code.
+
+After adding or changing Laravel routes, regenerate Wayfinder output with `php artisan wayfinder:generate`.
+
+## Coding Style & Naming Conventions
+
+Use Prettier for frontend formatting and Pint for PHP formatting. Follow existing TypeScript patterns: React components use PascalCase, hooks use `use-*` naming, and page files use lowercase route-oriented names such as `resources/js/pages/teams/show.tsx`. Keep controllers thin and place business logic in service classes. Prefer Wayfinder route helpers from `resources/js/routes` over hardcoded app URLs.
+
+## Testing Guidelines
+
+The backend test suite uses Pest. Put integration and HTTP behavior tests in `tests/Feature`, and isolated service or utility tests in `tests/Unit`. Name tests after the feature or behavior, for example `TournamentRegistrationTest.php` or `StandingsServiceTest.php`. Run targeted tests with `php artisan test tests/Feature/TeamTest.php`; run the full suite before merging with `composer test`.
+
+## Commit & Pull Request Guidelines
+
+Recent history uses conventional prefixes such as `feat:`, `fix:`, and `chore:`. Keep commit subjects imperative and scoped to one change. Pull requests should include a short summary, linked issue or ticket when available, test results, and screenshots for user-facing UI changes.
+
+## Security & Configuration Tips
+
+Do not commit `.env` or secrets. Keep generated frontend route files in sync with backend routes. For auth, authorization, and team-role changes, verify both server-side policy/model checks and frontend permission flags.

--- a/app/Http/Controllers/MatchController.php
+++ b/app/Http/Controllers/MatchController.php
@@ -469,8 +469,9 @@ final class MatchController extends Controller
             abort(403, 'No autorizado');
         }
 
-        // Check if match time has been reached
-        if ($match->scheduled_at->isFuture()) {
+        // Check if match time has been reached (skip when no schedule is set,
+        // e.g. league matches without a fixed kickoff time)
+        if ($match->scheduled_at !== null && $match->scheduled_at->isFuture()) {
             return back()->with('error', 'No se puede completar el partido antes de que comience');
         }
 

--- a/app/Http/Controllers/TournamentController.php
+++ b/app/Http/Controllers/TournamentController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Team;
 use App\Models\Tournament;
+use App\Services\StandingsService;
 use App\Services\TournamentService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -92,18 +93,7 @@ final class TournamentController extends Controller
     {
         $this->authorize('create', Tournament::class);
 
-        $validated = $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'description' => ['nullable', 'string', 'max:5000'],
-            'logo' => ['nullable', 'image', 'mimes:jpg,jpeg,png,webp', 'max:2048'],
-            'visibility' => ['required', 'in:public,invite_only'],
-            'variant' => ['required', 'in:football_11,football_7,football_5,futsal'],
-            'max_teams' => ['required', 'integer', 'in:4,8,16,32,64'],
-            'min_teams' => ['required', 'integer', 'min:2'],
-            'registration_deadline' => array_filter(['nullable', 'date', 'after:now', $request->starts_at ? 'before:starts_at' : null]),
-            'starts_at' => array_filter(['nullable', 'date', 'after_or_equal:now', $request->ends_at ? 'before:ends_at' : null]),
-            'ends_at' => array_filter(['nullable', 'date', $request->starts_at ? 'after:starts_at' : null]),
-        ]);
+        $validated = $request->validate($this->tournamentRules($request));
 
         try {
             $user = Auth::user();
@@ -133,6 +123,8 @@ final class TournamentController extends Controller
             'tournamentTeams.registeredBy:id,name',
             'rounds.matches.homeTeam',
             'rounds.matches.awayTeam',
+            'groups.teams.team',
+            'groups.matches',
         ])
             ->withCount(['tournamentTeams as registered_teams_count' => function ($query) {
                 $query->whereIn('status', ['pending', 'approved']);
@@ -161,8 +153,23 @@ final class TournamentController extends Controller
         $canApprove = $user && $user->can('approveTeam', $tournament);
         $canScheduleMatches = $user && $user->can('scheduleMatches', $tournament);
 
+        $standings = null;
+        $groupStandings = null;
+        $canDrawGroups = false;
+
+        if ($tournament->isLeague()) {
+            $standings = $this->buildLeagueStandings($tournament);
+        }
+
+        if ($tournament->isGroupStageKnockout()) {
+            $groupStandings = $this->buildGroupStandings($tournament);
+            $canDrawGroups = $user && $user->can('drawGroups', $tournament);
+        }
+
         return Inertia::render('tournaments/show', [
             'tournament' => $tournament,
+            'standings' => $standings,
+            'groupStandings' => $groupStandings,
             'userTeams' => $userTeams,
             'permissions' => [
                 'canEdit' => $canEdit,
@@ -171,8 +178,112 @@ final class TournamentController extends Controller
                 'canCancel' => $canCancel,
                 'canApprove' => $canApprove,
                 'canScheduleMatches' => $canScheduleMatches,
+                'canDrawGroups' => $canDrawGroups,
             ],
         ]);
+    }
+
+    /**
+     * Build the league standings rows enriched with team data for Inertia.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildLeagueStandings(Tournament $tournament): array
+    {
+        $teamIds = $tournament->approvedTeams()->pluck('team_id');
+        $matches = $tournament->matches()->get();
+
+        $rows = app(StandingsService::class)->compute($matches, $teamIds, $tournament->id);
+
+        return $this->attachTeamsToRows($rows, $tournament);
+    }
+
+    /**
+     * Build per-group standings keyed by tournament_group_id.
+     *
+     * @return array<int, array<int, array<string, mixed>>>
+     */
+    private function buildGroupStandings(Tournament $tournament): array
+    {
+        $service = app(StandingsService::class);
+        $byGroup = [];
+
+        foreach ($tournament->groups as $group) {
+            $rows = $service->forGroup($group);
+            $byGroup[$group->id] = $this->attachTeamsToRows($rows, $tournament);
+        }
+
+        return $byGroup;
+    }
+
+    /**
+     * @param  array<int, \App\Support\StandingRow>  $rows
+     * @return array<int, array<string, mixed>>
+     */
+    private function attachTeamsToRows(array $rows, Tournament $tournament): array
+    {
+        $teamMap = [];
+        foreach ($tournament->tournamentTeams as $tt) {
+            if ($tt->team) {
+                $teamMap[$tt->team_id] = $tt->team;
+            }
+        }
+
+        $out = [];
+        foreach ($rows as $row) {
+            $out[] = $row->toArray() + [
+                'team' => $teamMap[$row->teamId] ?? null,
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Build validation rules for tournament create/update, branching on format.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    private function tournamentRules(Request $request, bool $isUpdate = false): array
+    {
+        $format = $request->input('format', 'single_elimination');
+
+        $rules = [
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:5000'],
+            'logo' => ['nullable', 'image', 'mimes:jpg,jpeg,png,webp', 'max:2048'],
+            'visibility' => ['required', 'in:public,invite_only'],
+            'variant' => ['required', 'in:football_11,football_7,football_5,futsal'],
+            'format' => ['nullable', 'in:single_elimination,league,group_stage_knockout'],
+            'min_teams' => ['required', 'integer', 'min:2'],
+            'registration_deadline' => array_filter([
+                'nullable', 'date',
+                $isUpdate ? null : 'after:now',
+                $request->starts_at ? 'before:starts_at' : null,
+            ]),
+            'starts_at' => array_filter([
+                'nullable', 'date',
+                $isUpdate ? null : 'after_or_equal:now',
+                $request->ends_at ? 'before:ends_at' : null,
+            ]),
+            'ends_at' => array_filter([
+                'nullable', 'date',
+                $request->starts_at ? 'after:starts_at' : null,
+            ]),
+        ];
+
+        if ($format === 'group_stage_knockout') {
+            $rules['group_count'] = ['required', 'integer', 'in:2,4,8,16'];
+            $rules['group_size'] = ['required', 'integer', 'min:2', 'max:16'];
+            // max_teams is derived from group_count × group_size in the service.
+            $rules['max_teams'] = ['nullable', 'integer'];
+        } elseif ($format === 'league') {
+            $rules['max_teams'] = ['required', 'integer', 'min:2', 'max:64'];
+        } else {
+            $rules['max_teams'] = ['required', 'integer', 'in:4,8,16,32,64'];
+        }
+
+        return $rules;
     }
 
     /**
@@ -204,18 +315,7 @@ final class TournamentController extends Controller
 
         $this->authorize('update', $tournament);
 
-        $validated = $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'description' => ['nullable', 'string', 'max:5000'],
-            'logo' => ['nullable', 'image', 'mimes:jpg,jpeg,png,webp', 'max:2048'],
-            'visibility' => ['required', 'in:public,invite_only'],
-            'variant' => ['required', 'in:football_11,football_7,football_5,futsal'],
-            'max_teams' => ['required', 'integer', 'in:4,8,16,32,64'],
-            'min_teams' => ['required', 'integer', 'min:2'],
-            'registration_deadline' => array_filter(['nullable', 'date', $request->starts_at ? 'before:starts_at' : null]),
-            'starts_at' => array_filter(['nullable', 'date', $request->ends_at ? 'before:ends_at' : null]),
-            'ends_at' => array_filter(['nullable', 'date', $request->starts_at ? 'after:starts_at' : null]),
-        ]);
+        $validated = $request->validate($this->tournamentRules($request, isUpdate: true));
 
         try {
             unset($validated['logo']);

--- a/app/Http/Controllers/TournamentController.php
+++ b/app/Http/Controllers/TournamentController.php
@@ -28,21 +28,21 @@ final class TournamentController extends Controller
     public function index(Request $request): Response
     {
         $user = Auth::user();
+        $status = $request->string('status')->toString();
+        $variant = $request->string('variant')->toString();
+        $sort = $request->string('sort')->toString();
+
+        $filters = [
+            'status' => in_array($status, ['draft', 'registration_open', 'in_progress', 'completed', 'cancelled'], true) ? $status : 'all',
+            'variant' => in_array($variant, ['football_11', 'football_7', 'football_5', 'futsal'], true) ? $variant : 'all',
+            'search' => trim($request->string('search')->toString()),
+            'sort' => in_array($sort, ['newest', 'start_soon', 'name'], true) ? $sort : 'newest',
+        ];
 
         $query = Tournament::with(['organizer:id,name,avatar_path,google_avatar_url'])
             ->withCount(['tournamentTeams as registered_teams_count' => function ($query) {
                 $query->whereIn('status', ['pending', 'approved']);
             }]);
-
-        // Filter by status if provided
-        if ($request->has('status') && $request->status !== 'all') {
-            $query->where('status', $request->status);
-        }
-
-        // Filter by variant if provided
-        if ($request->has('variant') && $request->variant !== 'all') {
-            $query->where('variant', $request->variant);
-        }
 
         // Only show public tournaments or tournaments user is involved in
         $query->where(function ($q) use ($user) {
@@ -57,7 +57,34 @@ final class TournamentController extends Controller
             }
         });
 
-        $tournaments = $query->orderByDesc('created_at')->paginate(12);
+        if ($filters['variant'] !== 'all') {
+            $query->where('variant', $filters['variant']);
+        }
+
+        if ($filters['search'] !== '') {
+            $query->where(function ($q) use ($filters) {
+                $q->where('name', 'like', "%{$filters['search']}%")
+                    ->orWhere('description', 'like', "%{$filters['search']}%");
+            });
+        }
+
+        $statusCounts = (clone $query)
+            ->select('status')
+            ->selectRaw('count(*) as aggregate')
+            ->groupBy('status')
+            ->pluck('aggregate', 'status');
+
+        if ($filters['status'] !== 'all') {
+            $query->where('status', $filters['status']);
+        }
+
+        match ($filters['sort']) {
+            'start_soon' => $query->orderByRaw('starts_at is null, starts_at asc')->orderByDesc('created_at'),
+            'name' => $query->orderBy('name')->orderByDesc('created_at'),
+            default => $query->orderByDesc('created_at'),
+        };
+
+        $tournaments = $query->paginate(12)->withQueryString();
 
         // Get user's teams where they are a leader (for creating tournaments)
         $userTeams = $user ? Team::whereHas('teamMembers', function ($query) use ($user) {
@@ -68,11 +95,16 @@ final class TournamentController extends Controller
 
         return Inertia::render('tournaments/index', [
             'tournaments' => $tournaments,
-            'userTeams' => $userTeams,
-            'filters' => [
-                'status' => $request->status ?? 'all',
-                'variant' => $request->variant ?? 'all',
+            'statusCounts' => [
+                'all' => $statusCounts->sum(),
+                'draft' => (int) ($statusCounts['draft'] ?? 0),
+                'registration_open' => (int) ($statusCounts['registration_open'] ?? 0),
+                'in_progress' => (int) ($statusCounts['in_progress'] ?? 0),
+                'completed' => (int) ($statusCounts['completed'] ?? 0),
+                'cancelled' => (int) ($statusCounts['cancelled'] ?? 0),
             ],
+            'userTeams' => $userTeams,
+            'filters' => $filters,
         ]);
     }
 

--- a/app/Http/Controllers/TournamentController.php
+++ b/app/Http/Controllers/TournamentController.php
@@ -151,7 +151,7 @@ final class TournamentController extends Controller
         })->where('variant', $tournament->variant)->get(['id', 'name', 'variant']) : collect();
 
         // Check if user can perform various actions
-        $canEdit = $user && $user->can('update', $tournament);
+        $canEdit = $user && $user->can('update', $tournament) && $tournament->canBeEdited();
         $canDelete = $user && $user->can('delete', $tournament);
         // canStart combines the policy check (organizer + valid status) with the
         // model's runtime readiness check (enough approved teams, power of 2)
@@ -178,11 +178,17 @@ final class TournamentController extends Controller
     /**
      * Show the form for editing the specified tournament.
      */
-    public function edit(int $id): Response
+    public function edit(int $id): Response|\Illuminate\Http\RedirectResponse
     {
         $tournament = Tournament::findOrFail($id);
 
         $this->authorize('update', $tournament);
+
+        if (! $tournament->canBeEdited()) {
+            return redirect()
+                ->route('tournaments.show', $tournament->id)
+                ->with('error', 'Este torneo ya no se puede editar.');
+        }
 
         return Inertia::render('tournaments/edit', [
             'tournament' => $tournament,

--- a/app/Http/Controllers/TournamentGroupController.php
+++ b/app/Http/Controllers/TournamentGroupController.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\Tournament;
+use App\Models\TournamentTeam;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+final class TournamentGroupController extends Controller
+{
+    /**
+     * Save the organizer's group draw. Accepts an `assignments` array of
+     * { tournament_team_id, tournament_group_id } and writes them in a
+     * single transaction. Group-id may be null to "unassign" a team.
+     */
+    public function assign(Request $request, int $tournamentId)
+    {
+        $tournament = Tournament::with('groups')->findOrFail($tournamentId);
+        $this->authorize('drawGroups', $tournament);
+
+        $validated = $request->validate([
+            'assignments' => ['required', 'array', 'min:1'],
+            'assignments.*.tournament_team_id' => ['required', 'integer'],
+            'assignments.*.tournament_group_id' => ['nullable', 'integer'],
+        ]);
+
+        $groupIdsForTournament = $tournament->groups->pluck('id')->all();
+        $teamIdsForTournament = TournamentTeam::where('tournament_id', $tournament->id)
+            ->where('status', 'approved')
+            ->pluck('id')
+            ->all();
+
+        // Validate every team and group belong to this tournament.
+        foreach ($validated['assignments'] as $assignment) {
+            if (! in_array($assignment['tournament_team_id'], $teamIdsForTournament, true)) {
+                throw ValidationException::withMessages([
+                    'error' => 'Una o más asignaciones referencian un equipo que no pertenece a este torneo.',
+                ]);
+            }
+            if ($assignment['tournament_group_id'] !== null
+                && ! in_array($assignment['tournament_group_id'], $groupIdsForTournament, true)) {
+                throw ValidationException::withMessages([
+                    'error' => 'Una o más asignaciones referencian un grupo que no pertenece a este torneo.',
+                ]);
+            }
+        }
+
+        // Validate group capacity.
+        $assignmentsByGroup = [];
+        foreach ($validated['assignments'] as $assignment) {
+            if ($assignment['tournament_group_id'] !== null) {
+                $assignmentsByGroup[$assignment['tournament_group_id']] = ($assignmentsByGroup[$assignment['tournament_group_id']] ?? 0) + 1;
+            }
+        }
+        $capacity = (int) $tournament->group_size;
+        foreach ($assignmentsByGroup as $groupId => $count) {
+            if ($count > $capacity) {
+                throw ValidationException::withMessages([
+                    'error' => "Un grupo no puede tener más de {$capacity} equipos.",
+                ]);
+            }
+        }
+
+        DB::transaction(function () use ($validated) {
+            foreach ($validated['assignments'] as $assignment) {
+                TournamentTeam::where('id', $assignment['tournament_team_id'])
+                    ->update(['tournament_group_id' => $assignment['tournament_group_id']]);
+            }
+        });
+
+        return redirect()->route('tournaments.show', $tournament->id)
+            ->with('success', 'Sorteo guardado.');
+    }
+
+    /**
+     * Clear all group assignments for this tournament's approved teams.
+     */
+    public function clear(int $tournamentId)
+    {
+        $tournament = Tournament::findOrFail($tournamentId);
+        $this->authorize('drawGroups', $tournament);
+
+        TournamentTeam::where('tournament_id', $tournament->id)
+            ->update(['tournament_group_id' => null]);
+
+        return redirect()->route('tournaments.show', $tournament->id)
+            ->with('success', 'Sorteo reiniciado.');
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -46,6 +46,10 @@ class HandleInertiaRequests extends Middleware
                 'user' => $request->user(),
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
+            'flash' => [
+                'success' => fn () => $request->session()->get('success'),
+                'error' => fn () => $request->session()->get('error'),
+            ],
         ];
     }
 }

--- a/app/Models/FootballMatch.php
+++ b/app/Models/FootballMatch.php
@@ -30,7 +30,9 @@ final class FootballMatch extends Model
         'away_team_id',
         'tournament_id',
         'tournament_round_id',
+        'tournament_group_id',
         'bracket_position',
+        'matchday',
         'variant',
         'scheduled_at',
         'location',
@@ -101,6 +103,27 @@ final class FootballMatch extends Model
     public function tournamentRound(): BelongsTo
     {
         return $this->belongsTo(TournamentRound::class);
+    }
+
+    /**
+     * Get the tournament group this match belongs to (group_stage_knockout only).
+     */
+    public function tournamentGroup(): BelongsTo
+    {
+        return $this->belongsTo(TournamentGroup::class, 'tournament_group_id');
+    }
+
+    public function isGroupMatch(): bool
+    {
+        return $this->tournament_group_id !== null;
+    }
+
+    public function isLeagueMatch(): bool
+    {
+        return $this->tournament_id !== null
+            && $this->matchday !== null
+            && $this->tournament_group_id === null
+            && $this->bracket_position === null;
     }
 
     /**

--- a/app/Models/Tournament.php
+++ b/app/Models/Tournament.php
@@ -28,6 +28,10 @@ final class Tournament extends Model
         'visibility',
         'status',
         'variant',
+        'format',
+        'phase',
+        'group_count',
+        'group_size',
         'max_teams',
         'min_teams',
         'registration_deadline',
@@ -55,6 +59,8 @@ final class Tournament extends Model
             'registration_deadline' => 'datetime',
             'starts_at' => 'datetime',
             'ends_at' => 'datetime',
+            'group_count' => 'integer',
+            'group_size' => 'integer',
         ];
     }
 
@@ -134,6 +140,39 @@ final class Tournament extends Model
     public function matches(): HasMany
     {
         return $this->hasMany(FootballMatch::class);
+    }
+
+    /**
+     * Get the groups (only populated for group_stage_knockout format).
+     */
+    public function groups(): HasMany
+    {
+        return $this->hasMany(TournamentGroup::class)->orderBy('position');
+    }
+
+    public function isSingleElimination(): bool
+    {
+        return $this->format === 'single_elimination';
+    }
+
+    public function isLeague(): bool
+    {
+        return $this->format === 'league';
+    }
+
+    public function isGroupStageKnockout(): bool
+    {
+        return $this->format === 'group_stage_knockout';
+    }
+
+    public function inGroupStage(): bool
+    {
+        return $this->phase === 'group_stage';
+    }
+
+    public function inKnockout(): bool
+    {
+        return $this->phase === 'knockout';
     }
 
     /**
@@ -225,13 +264,16 @@ final class Tournament extends Model
 
         $approvedCount = $this->getApprovedTeamsCount();
 
-        // Must have at least min_teams
         if ($approvedCount < $this->min_teams) {
             return false;
         }
 
-        // Must be a power of 2
-        return $this->isPowerOfTwo($approvedCount);
+        return match ($this->format) {
+            'league' => $approvedCount >= 2,
+            'group_stage_knockout' => $approvedCount === ($this->group_count * $this->group_size)
+                && $this->approvedTeams()->whereNull('tournament_group_id')->doesntExist(),
+            default => $this->isPowerOfTwo($approvedCount),
+        };
     }
 
     /**

--- a/app/Models/TournamentGroup.php
+++ b/app/Models/TournamentGroup.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+final class TournamentGroup extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'tournament_id',
+        'name',
+        'position',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'position' => 'integer',
+        ];
+    }
+
+    public function tournament(): BelongsTo
+    {
+        return $this->belongsTo(Tournament::class);
+    }
+
+    /**
+     * Teams assigned to this group (via tournament_teams pivot).
+     */
+    public function teams(): HasMany
+    {
+        return $this->hasMany(TournamentTeam::class);
+    }
+
+    /**
+     * Matches played within this group.
+     */
+    public function matches(): HasMany
+    {
+        return $this->hasMany(FootballMatch::class);
+    }
+}

--- a/app/Models/TournamentTeam.php
+++ b/app/Models/TournamentTeam.php
@@ -22,6 +22,7 @@ final class TournamentTeam extends Model
         'team_id',
         'status',
         'seed',
+        'tournament_group_id',
         'registered_by',
         'registered_at',
         'approved_at',
@@ -62,6 +63,14 @@ final class TournamentTeam extends Model
     public function registeredBy(): BelongsTo
     {
         return $this->belongsTo(User::class, 'registered_by');
+    }
+
+    /**
+     * Get the group this team has been drawn into (group_stage_knockout only).
+     */
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(TournamentGroup::class, 'tournament_group_id');
     }
 
     /**

--- a/app/Policies/TournamentPolicy.php
+++ b/app/Policies/TournamentPolicy.php
@@ -113,6 +113,16 @@ final class TournamentPolicy
     }
 
     /**
+     * Determine whether the user can draw teams into groups (pre-start only).
+     */
+    public function drawGroups(User $user, Tournament $tournament): bool
+    {
+        return $tournament->isOrganizer($user->id)
+            && $tournament->isGroupStageKnockout()
+            && in_array($tournament->status, ['draft', 'registration_open'], true);
+    }
+
+    /**
      * Determine whether the user can register a team for the tournament.
      */
     public function register(User $user, Tournament $tournament, Team $team): bool

--- a/app/Services/MatchService.php
+++ b/app/Services/MatchService.php
@@ -397,19 +397,22 @@ final class MatchService
      */
     public function completeMatch(FootballMatch $match): FootballMatch
     {
-        // Verify match is in progress
         if (! $match->isInProgress()) {
             throw new \Exception('Can only complete in-progress matches');
         }
 
-        // Verify match time has been reached
-        if ($match->scheduled_at->isFuture()) {
+        if ($match->scheduled_at !== null && $match->scheduled_at->isFuture()) {
             throw new \Exception('Cannot complete match before it has started');
         }
 
-        // Tournament matches cannot end in a draw
+        // Draws are forbidden only for knockout matches (single-elim or the
+        // knockout phase of group_stage_knockout). League and group-stage
+        // matches accept draws as valid results.
         if ($match->isTournamentMatch() && $match->home_score === $match->away_score) {
-            throw new \Exception('Tournament matches cannot end in a draw. Please update the score to reflect a winner.');
+            $tournament = $match->tournament;
+            if ($tournament->isSingleElimination() || $tournament->inKnockout()) {
+                throw new \Exception('Tournament matches cannot end in a draw. Please update the score to reflect a winner.');
+            }
         }
 
         $match->update([
@@ -417,10 +420,17 @@ final class MatchService
             'completed_at' => now(),
         ]);
 
-        // If this is a tournament match, advance the winner
         if ($match->isTournamentMatch()) {
             $tournamentService = app(TournamentService::class);
-            $tournamentService->advanceWinner($match);
+            $tournament = $match->tournament;
+
+            if ($tournament->isSingleElimination() || $tournament->inKnockout()) {
+                $tournamentService->advanceWinner($match);
+            } elseif ($tournament->isLeague()) {
+                $tournamentService->completeLeagueIfDone($tournament);
+            } elseif ($tournament->inGroupStage()) {
+                $tournamentService->maybeTransitionToKnockout($tournament);
+            }
         }
 
         return $match->fresh();

--- a/app/Services/StandingsService.php
+++ b/app/Services/StandingsService.php
@@ -1,0 +1,338 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\FootballMatch;
+use App\Models\Tournament;
+use App\Models\TournamentGroup;
+use App\Support\StandingRow;
+use Illuminate\Support\Collection;
+
+class StandingsService
+{
+    public const WIN_POINTS = 3;
+
+    public const DRAW_POINTS = 1;
+
+    public const LOSS_POINTS = 0;
+
+    /**
+     * Compute a standings table from a set of matches over a fixed team set.
+     *
+     * Tiebreakers applied in order: points → goal difference → goals scored →
+     * head-to-head (mini-table over only matches between the tied teams) →
+     * seeded random shuffle (only when teams in the tied subgroup have actually
+     * played each other; otherwise input order is preserved).
+     *
+     * @param  Collection<int, FootballMatch>  $matches
+     * @param  Collection<int, int>  $teamIds
+     * @return array<int, StandingRow>
+     */
+    public function compute(Collection $matches, Collection $teamIds, ?int $rngSeed = null): array
+    {
+        $teamIdList = $teamIds->values()->all();
+
+        $aggregates = [];
+        foreach ($teamIdList as $teamId) {
+            $aggregates[$teamId] = $this->emptyAggregate($teamId);
+        }
+
+        $completed = $matches->filter(fn (FootballMatch $m) => $m->status === 'completed'
+            && $m->home_score !== null
+            && $m->away_score !== null
+            && in_array($m->home_team_id, $teamIdList, true)
+            && in_array($m->away_team_id, $teamIdList, true)
+        )->values();
+
+        foreach ($completed as $match) {
+            $this->applyMatch($aggregates, $match);
+        }
+
+        // Preserve registration/input order as the stable starting order.
+        $ordered = array_values(array_map(fn (int $id) => $aggregates[$id], $teamIdList));
+
+        // Stable sort by primary stats (points → GD → GF).
+        $this->stableSort($ordered, fn (array $a, array $b) => [$b['points'], $b['goal_difference'], $b['goals_for']]
+            <=> [$a['points'], $a['goal_difference'], $a['goals_for']]);
+
+        $ordered = $this->resolveTies($ordered, $completed, $rngSeed);
+
+        return $this->toStandingRows($ordered);
+    }
+
+    /**
+     * Compute league standings (all approved teams over all tournament matches).
+     *
+     * @return array<int, StandingRow>
+     */
+    public function forLeague(Tournament $tournament): array
+    {
+        $teamIds = $tournament->approvedTeams()->pluck('team_id');
+        $matches = $tournament->matches()->get();
+
+        return $this->compute($matches, $teamIds, $tournament->id);
+    }
+
+    /**
+     * Compute standings for a single group.
+     *
+     * @return array<int, StandingRow>
+     */
+    public function forGroup(TournamentGroup $group): array
+    {
+        $group->loadMissing(['teams', 'matches']);
+        $teamIds = $group->teams->pluck('team_id');
+
+        return $this->compute($group->matches, $teamIds, $group->tournament_id);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function emptyAggregate(int $teamId): array
+    {
+        return [
+            'team_id' => $teamId,
+            'played' => 0,
+            'wins' => 0,
+            'draws' => 0,
+            'losses' => 0,
+            'goals_for' => 0,
+            'goals_against' => 0,
+            'goal_difference' => 0,
+            'points' => 0,
+        ];
+    }
+
+    /**
+     * @param  array<int, array<string, int>>  $aggregates
+     */
+    private function applyMatch(array &$aggregates, FootballMatch $match): void
+    {
+        $home = &$aggregates[$match->home_team_id];
+        $away = &$aggregates[$match->away_team_id];
+
+        $home['played']++;
+        $away['played']++;
+        $home['goals_for'] += $match->home_score;
+        $home['goals_against'] += $match->away_score;
+        $away['goals_for'] += $match->away_score;
+        $away['goals_against'] += $match->home_score;
+
+        if ($match->home_score > $match->away_score) {
+            $home['wins']++;
+            $away['losses']++;
+            $home['points'] += self::WIN_POINTS;
+            $away['points'] += self::LOSS_POINTS;
+        } elseif ($match->away_score > $match->home_score) {
+            $away['wins']++;
+            $home['losses']++;
+            $away['points'] += self::WIN_POINTS;
+            $home['points'] += self::LOSS_POINTS;
+        } else {
+            $home['draws']++;
+            $away['draws']++;
+            $home['points'] += self::DRAW_POINTS;
+            $away['points'] += self::DRAW_POINTS;
+        }
+
+        $home['goal_difference'] = $home['goals_for'] - $home['goals_against'];
+        $away['goal_difference'] = $away['goals_for'] - $away['goals_against'];
+    }
+
+    /**
+     * Walk the ordered list, find adjacent runs that tie on (points, GD, GF),
+     * and resolve each run via head-to-head + RNG (only when actually played).
+     *
+     * @param  array<int, array<string, int>>  $ordered
+     * @param  Collection<int, FootballMatch>  $matches
+     * @return array<int, array<string, int|bool>>
+     */
+    private function resolveTies(array $ordered, Collection $matches, ?int $rngSeed): array
+    {
+        $resolved = [];
+        $i = 0;
+        $n = count($ordered);
+
+        while ($i < $n) {
+            $group = [$ordered[$i]];
+            $j = $i + 1;
+            while ($j < $n && $this->primaryEqual($ordered[$i], $ordered[$j])) {
+                $group[] = $ordered[$j];
+                $j++;
+            }
+
+            if (count($group) > 1) {
+                $group = $this->resolveTiedGroup($group, $matches, $rngSeed);
+            }
+
+            foreach ($group as $row) {
+                $resolved[] = $row;
+            }
+            $i = $j;
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<int, array<string, int>>  $group
+     * @param  Collection<int, FootballMatch>  $matches
+     * @return array<int, array<string, int|bool>>
+     */
+    private function resolveTiedGroup(array $group, Collection $matches, ?int $rngSeed): array
+    {
+        $tiedIds = array_column($group, 'team_id');
+
+        $h2hMatches = $matches->filter(fn (FootballMatch $m) => in_array($m->home_team_id, $tiedIds, true)
+            && in_array($m->away_team_id, $tiedIds, true)
+        )->values();
+
+        $miniAggregates = [];
+        foreach ($tiedIds as $teamId) {
+            $miniAggregates[$teamId] = $this->emptyAggregate($teamId);
+        }
+        foreach ($h2hMatches as $match) {
+            $this->applyMatch($miniAggregates, $match);
+        }
+
+        // Stable sort by H2H mini-table.
+        $this->stableSort($group, function (array $a, array $b) use ($miniAggregates) {
+            $ma = $miniAggregates[$a['team_id']];
+            $mb = $miniAggregates[$b['team_id']];
+
+            return [$mb['points'], $mb['goal_difference'], $mb['goals_for']]
+                <=> [$ma['points'], $ma['goal_difference'], $ma['goals_for']];
+        });
+
+        // Find runs that are still tied in the mini-table; only RNG-shuffle if
+        // the subgroup has actually played each other.
+        $resolved = [];
+        $i = 0;
+        $n = count($group);
+        while ($i < $n) {
+            $sub = [$group[$i]];
+            $j = $i + 1;
+            $miniA = $miniAggregates[$group[$i]['team_id']];
+            while ($j < $n) {
+                $miniB = $miniAggregates[$group[$j]['team_id']];
+                if ($this->aggregatesEqual($miniA, $miniB)) {
+                    $sub[] = $group[$j];
+                    $j++;
+                } else {
+                    break;
+                }
+            }
+
+            if (count($sub) > 1) {
+                $subTeamIds = array_column($sub, 'team_id');
+                if ($this->subgroupHasPlayed($h2hMatches, $subTeamIds)) {
+                    $sub = $this->shuffleDeterministic($sub, $rngSeed);
+                    for ($k = 1; $k < count($sub); $k++) {
+                        $sub[$k]['_tied_with_above'] = true;
+                    }
+                }
+            }
+
+            foreach ($sub as $row) {
+                $resolved[] = $row;
+            }
+            $i = $j;
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<string, int>  $a
+     * @param  array<string, int>  $b
+     */
+    private function primaryEqual(array $a, array $b): bool
+    {
+        return $this->aggregatesEqual($a, $b);
+    }
+
+    /**
+     * @param  array<string, int>  $a
+     * @param  array<string, int>  $b
+     */
+    private function aggregatesEqual(array $a, array $b): bool
+    {
+        return $a['points'] === $b['points']
+            && $a['goal_difference'] === $b['goal_difference']
+            && $a['goals_for'] === $b['goals_for'];
+    }
+
+    /**
+     * @param  Collection<int, FootballMatch>  $matches
+     * @param  array<int, int>  $teamIds
+     */
+    private function subgroupHasPlayed(Collection $matches, array $teamIds): bool
+    {
+        foreach ($matches as $match) {
+            if (in_array($match->home_team_id, $teamIds, true)
+                && in_array($match->away_team_id, $teamIds, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<int, array<string, int>>  $items
+     * @return array<int, array<string, int>>
+     */
+    private function shuffleDeterministic(array $items, ?int $rngSeed): array
+    {
+        $seed = ($rngSeed ?? 0) + array_sum(array_column($items, 'team_id'));
+        mt_srand($seed);
+        for ($k = count($items) - 1; $k > 0; $k--) {
+            $r = mt_rand(0, $k);
+            [$items[$k], $items[$r]] = [$items[$r], $items[$k]];
+        }
+        // Restore non-deterministic state so unrelated callers aren't affected.
+        mt_srand();
+
+        return $items;
+    }
+
+    /**
+     * Stable sort (preserves input order for equal elements). PHP's usort is
+     * stable since 8.0 but we wrap it for clarity.
+     *
+     * @param  array<int, mixed>  $items
+     */
+    private function stableSort(array &$items, callable $comparator): void
+    {
+        usort($items, $comparator);
+    }
+
+    /**
+     * @param  array<int, array<string, int|bool>>  $ordered
+     * @return array<int, StandingRow>
+     */
+    private function toStandingRows(array $ordered): array
+    {
+        $rows = [];
+        $position = 1;
+        foreach ($ordered as $aggregate) {
+            $rows[] = new StandingRow(
+                teamId: $aggregate['team_id'],
+                played: $aggregate['played'],
+                wins: $aggregate['wins'],
+                draws: $aggregate['draws'],
+                losses: $aggregate['losses'],
+                goalsFor: $aggregate['goals_for'],
+                goalsAgainst: $aggregate['goals_against'],
+                goalDifference: $aggregate['goal_difference'],
+                points: $aggregate['points'],
+                position: $position,
+                tiedWithAbove: $aggregate['_tied_with_above'] ?? false,
+            );
+            $position++;
+        }
+
+        return $rows;
+    }
+}

--- a/app/Services/Tournament/RoundRobinScheduler.php
+++ b/app/Services/Tournament/RoundRobinScheduler.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Tournament;
+
+final class RoundRobinScheduler
+{
+    /**
+     * Generate a single round-robin schedule using the circle method.
+     *
+     * Returns one fixture per pair of teams across `n - 1` matchdays (n/2
+     * matches per matchday). If team count is odd, a phantom BYE is added and
+     * fixtures involving it are skipped. Home/away alternates per round so the
+     * fixed-position team gets a balanced split.
+     *
+     * @param  array<int, int>  $teamIds
+     * @return array<int, array{matchday: int, home: int, away: int}>
+     */
+    public function generate(array $teamIds): array
+    {
+        $teams = array_values($teamIds);
+        if (count($teams) < 2) {
+            return [];
+        }
+
+        if (count($teams) % 2 === 1) {
+            $teams[] = -1; // BYE sentinel
+        }
+
+        $n = count($teams);
+        $rounds = $n - 1;
+        $half = intdiv($n, 2);
+
+        // We rotate indices into $teams instead of the array itself so the
+        // fixed team (position 0) is always the original first team.
+        $positions = range(0, $n - 1);
+        $fixtures = [];
+
+        for ($r = 0; $r < $rounds; $r++) {
+            $matchday = $r + 1;
+
+            for ($i = 0; $i < $half; $i++) {
+                $home = $teams[$positions[$i]];
+                $away = $teams[$positions[$n - 1 - $i]];
+
+                if ($home === -1 || $away === -1) {
+                    continue;
+                }
+
+                if ($r % 2 === 1) {
+                    $fixtures[] = ['matchday' => $matchday, 'home' => $away, 'away' => $home];
+                } else {
+                    $fixtures[] = ['matchday' => $matchday, 'home' => $home, 'away' => $away];
+                }
+            }
+
+            // Rotate: keep position[0] fixed, move last index to position 1,
+            // shift the rest right by one.
+            $last = $positions[$n - 1];
+            for ($k = $n - 1; $k > 1; $k--) {
+                $positions[$k] = $positions[$k - 1];
+            }
+            $positions[1] = $last;
+        }
+
+        return $fixtures;
+    }
+}

--- a/app/Services/TournamentService.php
+++ b/app/Services/TournamentService.php
@@ -7,9 +7,12 @@ namespace App\Services;
 use App\Models\FootballMatch;
 use App\Models\Team;
 use App\Models\Tournament;
+use App\Models\TournamentGroup;
 use App\Models\TournamentRound;
 use App\Models\TournamentTeam;
 use App\Models\User;
+use App\Services\Tournament\RoundRobinScheduler;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 final class TournamentService
@@ -19,11 +22,12 @@ final class TournamentService
      */
     public function createTournament(User $user, array $data): Tournament
     {
-        // Validate max_teams is power of 2
-        $maxTeams = (int) ($data['max_teams'] ?? 8);
-        if (! $this->isPowerOfTwo($maxTeams)) {
-            throw new \InvalidArgumentException('Max teams must be a power of 2 (4, 8, 16, 32, 64)');
-        }
+        $format = $data['format'] ?? 'single_elimination';
+        $groupCount = isset($data['group_count']) ? (int) $data['group_count'] : null;
+        $groupSize = isset($data['group_size']) ? (int) $data['group_size'] : null;
+
+        $maxTeams = $this->resolveMaxTeams($format, $data, $groupCount, $groupSize);
+        $this->validateFormatConfig($format, $maxTeams, $groupCount, $groupSize);
 
         $tournament = Tournament::create([
             'name' => $data['name'],
@@ -33,12 +37,20 @@ final class TournamentService
             'visibility' => $data['visibility'] ?? 'public',
             'status' => $data['status'] ?? 'draft',
             'variant' => $data['variant'],
+            'format' => $format,
+            'phase' => 'not_started',
+            'group_count' => $format === 'group_stage_knockout' ? $groupCount : null,
+            'group_size' => $format === 'group_stage_knockout' ? $groupSize : null,
             'max_teams' => $maxTeams,
             'min_teams' => $data['min_teams'] ?? 4,
             'registration_deadline' => $data['registration_deadline'] ?? null,
             'starts_at' => $data['starts_at'] ?? null,
             'ends_at' => $data['ends_at'] ?? null,
         ]);
+
+        if ($format === 'group_stage_knockout') {
+            $this->createGroups($tournament);
+        }
 
         return $tournament;
     }
@@ -52,16 +64,22 @@ final class TournamentService
             throw new \RuntimeException('Tournament cannot be edited in its current status');
         }
 
-        // Validate max_teams is power of 2 if being changed
-        if (isset($data['max_teams'])) {
-            if (! $this->isPowerOfTwo((int) $data['max_teams'])) {
-                throw new \InvalidArgumentException('Max teams must be a power of 2 (4, 8, 16, 32, 64)');
+        // Format cannot change once any team has registered.
+        if (isset($data['format']) && $data['format'] !== $tournament->format) {
+            if ($tournament->getRegisteredTeamsCount() > 0) {
+                throw new \InvalidArgumentException('Cannot change tournament format after teams have registered');
             }
+        }
 
-            // Check if reducing max_teams would exclude already registered teams
-            if ($data['max_teams'] < $tournament->getRegisteredTeamsCount()) {
-                throw new \InvalidArgumentException('Cannot reduce max teams below current registered count');
-            }
+        $format = $data['format'] ?? $tournament->format;
+        $groupCount = $data['group_count'] ?? $tournament->group_count;
+        $groupSize = $data['group_size'] ?? $tournament->group_size;
+
+        $maxTeams = $this->resolveMaxTeams($format, $data, $groupCount, $groupSize, fallback: $tournament->max_teams);
+        $this->validateFormatConfig($format, $maxTeams, $groupCount, $groupSize);
+
+        if ($maxTeams < $tournament->getRegisteredTeamsCount()) {
+            throw new \InvalidArgumentException('Cannot reduce max teams below current registered count');
         }
 
         $tournament->update([
@@ -70,7 +88,10 @@ final class TournamentService
             'logo_path' => $data['logo_path'] ?? $tournament->logo_path,
             'visibility' => $data['visibility'] ?? $tournament->visibility,
             'variant' => $data['variant'] ?? $tournament->variant,
-            'max_teams' => $data['max_teams'] ?? $tournament->max_teams,
+            'format' => $format,
+            'group_count' => $format === 'group_stage_knockout' ? $groupCount : null,
+            'group_size' => $format === 'group_stage_knockout' ? $groupSize : null,
+            'max_teams' => $maxTeams,
             'min_teams' => $data['min_teams'] ?? $tournament->min_teams,
             'registration_deadline' => $data['registration_deadline'] ?? $tournament->registration_deadline,
             'starts_at' => $data['starts_at'] ?? $tournament->starts_at,
@@ -202,7 +223,7 @@ final class TournamentService
     }
 
     /**
-     * Start the tournament and generate bracket.
+     * Start the tournament and generate the schedule for its format.
      */
     public function startTournament(Tournament $tournament): void
     {
@@ -216,62 +237,389 @@ final class TournamentService
             throw new \RuntimeException("Tournament needs at least {$tournament->min_teams} teams to start");
         }
 
-        if (! $this->isPowerOfTwo($approvedCount)) {
-            throw new \RuntimeException('Number of approved teams must be a power of 2 (4, 8, 16, 32, 64)');
-        }
+        DB::transaction(function () use ($tournament, $approvedCount) {
+            if ($tournament->isLeague()) {
+                if ($approvedCount < 2) {
+                    throw new \RuntimeException('League tournaments need at least 2 teams to start');
+                }
+                $tournament->update(['status' => 'in_progress', 'phase' => 'league']);
+                $this->generateLeagueSchedule($tournament);
 
-        DB::transaction(function () use ($tournament) {
-            $tournament->update(['status' => 'in_progress']);
+                return;
+            }
+
+            if ($tournament->isGroupStageKnockout()) {
+                $expected = (int) $tournament->group_count * (int) $tournament->group_size;
+                if ($approvedCount !== $expected) {
+                    throw new \RuntimeException("Tournament needs exactly {$expected} approved teams to start");
+                }
+                if ($tournament->approvedTeams()->whereNull('tournament_group_id')->exists()) {
+                    throw new \RuntimeException('All approved teams must be assigned to a group before starting');
+                }
+                $tournament->update(['status' => 'in_progress', 'phase' => 'group_stage']);
+                $this->generateGroupStageMatches($tournament);
+
+                return;
+            }
+
+            // Default: single-elimination
+            if (! $this->isPowerOfTwo($approvedCount)) {
+                throw new \RuntimeException('Number of approved teams must be a power of 2 (4, 8, 16, 32, 64)');
+            }
+            $tournament->update(['status' => 'in_progress', 'phase' => 'knockout']);
             $this->generateBracket($tournament);
         });
     }
 
     /**
-     * Generate tournament bracket.
+     * Generate the league schedule (round-robin, one matchday per round).
      */
-    public function generateBracket(Tournament $tournament): void
+    public function generateLeagueSchedule(Tournament $tournament): void
     {
-        // Get approved teams ordered by seed (nulls last)
-        $teams = $tournament->tournamentTeams()
-            ->where('status', 'approved')
-            ->with('team')
+        $teamIds = $tournament->approvedTeams()
             ->orderByRaw('seed IS NULL, seed ASC')
-            ->get();
+            ->pluck('team_id')
+            ->all();
 
-        // Assign seeds if not set
-        $teams = $teams->map(function ($tournamentTeam, $index) {
-            if ($tournamentTeam->seed === null) {
-                $tournamentTeam->seed = $index + 1;
-                $tournamentTeam->save();
+        $fixtures = (new RoundRobinScheduler)->generate($teamIds);
+
+        $matchdays = [];
+        foreach ($fixtures as $fixture) {
+            $matchdays[$fixture['matchday']][] = $fixture;
+        }
+
+        foreach ($matchdays as $matchdayNum => $matches) {
+            $round = TournamentRound::create([
+                'tournament_id' => $tournament->id,
+                'round_number' => $matchdayNum,
+                'name' => "Jornada {$matchdayNum}",
+                'starts_at' => $tournament->starts_at,
+            ]);
+
+            foreach ($matches as $fixture) {
+                FootballMatch::create([
+                    'tournament_id' => $tournament->id,
+                    'tournament_round_id' => $round->id,
+                    'matchday' => $matchdayNum,
+                    'home_team_id' => $fixture['home'],
+                    'away_team_id' => $fixture['away'],
+                    'bracket_position' => null,
+                    'variant' => $tournament->variant,
+                    'status' => 'confirmed',
+                    'match_type' => 'competitive',
+                    'scheduled_at' => null,
+                    'location' => null,
+                    'created_by' => $tournament->organizer_id,
+                    'confirmed_at' => now(),
+                ]);
+            }
+        }
+    }
+
+    /**
+     * If every league match is completed, mark the tournament completed.
+     */
+    public function completeLeagueIfDone(Tournament $tournament): void
+    {
+        if (! $tournament->isLeague()) {
+            return;
+        }
+
+        $hasIncomplete = $tournament->matches()
+            ->where('status', '!=', 'completed')
+            ->exists();
+
+        if (! $hasIncomplete) {
+            $tournament->update([
+                'status' => 'completed',
+                'phase' => 'completed',
+                'ends_at' => now(),
+            ]);
+        }
+    }
+
+    /**
+     * Generate group-stage round-robin matches for every group, sharing one
+     * `tournament_round` per matchday across all groups.
+     */
+    public function generateGroupStageMatches(Tournament $tournament): void
+    {
+        $groups = $tournament->groups()->with('teams')->get();
+
+        if ($groups->isEmpty()) {
+            throw new \RuntimeException('Tournament has no groups defined');
+        }
+
+        $scheduler = new RoundRobinScheduler;
+        $byMatchday = [];
+
+        foreach ($groups as $group) {
+            $teamIds = $group->teams->pluck('team_id')->all();
+            $fixtures = $scheduler->generate($teamIds);
+            foreach ($fixtures as $fixture) {
+                $byMatchday[$fixture['matchday']][] = [
+                    'group_id' => $group->id,
+                    'home' => $fixture['home'],
+                    'away' => $fixture['away'],
+                ];
+            }
+        }
+
+        ksort($byMatchday);
+
+        foreach ($byMatchday as $matchdayNum => $matches) {
+            $round = TournamentRound::create([
+                'tournament_id' => $tournament->id,
+                'round_number' => $matchdayNum,
+                'name' => "Jornada {$matchdayNum} - Fase de grupos",
+                'starts_at' => $tournament->starts_at,
+            ]);
+
+            foreach ($matches as $fixture) {
+                FootballMatch::create([
+                    'tournament_id' => $tournament->id,
+                    'tournament_round_id' => $round->id,
+                    'tournament_group_id' => $fixture['group_id'],
+                    'matchday' => $matchdayNum,
+                    'home_team_id' => $fixture['home'],
+                    'away_team_id' => $fixture['away'],
+                    'bracket_position' => null,
+                    'variant' => $tournament->variant,
+                    'status' => 'confirmed',
+                    'match_type' => 'competitive',
+                    'scheduled_at' => null,
+                    'location' => null,
+                    'created_by' => $tournament->organizer_id,
+                    'confirmed_at' => now(),
+                ]);
+            }
+        }
+    }
+
+    /**
+     * If every group-stage match is completed, compute advancers, generate the
+     * knockout bracket, and flip the tournament into the knockout phase.
+     */
+    public function maybeTransitionToKnockout(Tournament $tournament): void
+    {
+        if (! $tournament->isGroupStageKnockout() || ! $tournament->inGroupStage()) {
+            return;
+        }
+
+        $hasIncomplete = $tournament->matches()
+            ->whereNotNull('tournament_group_id')
+            ->where('status', '!=', 'completed')
+            ->exists();
+
+        if ($hasIncomplete) {
+            return;
+        }
+
+        DB::transaction(function () use ($tournament) {
+            $lastMatchday = (int) $tournament->matches()
+                ->whereNotNull('matchday')
+                ->max('matchday');
+
+            $standingsService = app(StandingsService::class);
+            $advancers = []; // group_position => [rank => team_id]
+
+            $tournament->load('groups.teams', 'groups.matches');
+            $groups = $tournament->groups->sortBy('position')->values();
+
+            foreach ($groups as $group) {
+                $rows = $standingsService->forGroup($group);
+                $advancers[$group->position] = [
+                    0 => $rows[0]->teamId,
+                    1 => $rows[1]->teamId,
+                ];
             }
 
-            return $tournamentTeam;
+            $pairings = $this->groupKnockoutPairings((int) $tournament->group_count);
+
+            // Flatten pairings into bracket-ordered team_ids: pos 0 home, pos 0 away, pos 1 home, ...
+            $orderedTeamIds = [];
+            foreach ($pairings as $pairing) {
+                $orderedTeamIds[] = $advancers[$pairing['home_group_pos']][$pairing['home_rank']];
+                $orderedTeamIds[] = $advancers[$pairing['away_group_pos']][$pairing['away_rank']];
+            }
+
+            $tournamentTeams = TournamentTeam::where('tournament_id', $tournament->id)
+                ->whereIn('team_id', $orderedTeamIds)
+                ->get()
+                ->keyBy('team_id');
+
+            $teamsOrdered = collect($orderedTeamIds)
+                ->map(fn (int $teamId) => $tournamentTeams[$teamId])
+                ->values();
+
+            $this->generateBracket($tournament, $teamsOrdered, $lastMatchday + 1);
+            $tournament->update(['phase' => 'knockout']);
         });
+    }
+
+    /**
+     * Cross-bracket pairings for the knockout phase of a group_stage_knockout
+     * tournament. Returns one entry per first-round bracket position, keyed by
+     * bracket_position, mapping to the (home_group_pos, home_rank, away_group_pos,
+     * away_rank) of the advancers to slot into that match.
+     *
+     * Pairs adjacent groups (0,1) (2,3) ... and mirrors them across the bracket
+     * so group winners can only meet at later rounds.
+     *
+     * @return array<int, array{home_group_pos: int, home_rank: int, away_group_pos: int, away_rank: int}>
+     */
+    private function groupKnockoutPairings(int $groupCount): array
+    {
+        if (! $this->isPowerOfTwo($groupCount) || $groupCount < 2) {
+            throw new \RuntimeException('Group count must be a power of 2 ≥ 2');
+        }
+
+        $pairings = [];
+        $half = intdiv($groupCount, 2);
+
+        for ($i = 0; $i < $groupCount; $i += 2) {
+            $primaryPos = intdiv($i, 2);
+            $mirrorPos = $primaryPos + $half;
+
+            $pairings[$primaryPos] = [
+                'home_group_pos' => $i,
+                'home_rank' => 0,
+                'away_group_pos' => $i + 1,
+                'away_rank' => 1,
+            ];
+
+            $pairings[$mirrorPos] = [
+                'home_group_pos' => $i + 1,
+                'home_rank' => 0,
+                'away_group_pos' => $i,
+                'away_rank' => 1,
+            ];
+        }
+
+        ksort($pairings);
+
+        return $pairings;
+    }
+
+    /**
+     * Auto-create groups when a group_stage_knockout tournament is created.
+     */
+    private function createGroups(Tournament $tournament): void
+    {
+        $count = (int) $tournament->group_count;
+        for ($i = 0; $i < $count; $i++) {
+            TournamentGroup::create([
+                'tournament_id' => $tournament->id,
+                'name' => chr(ord('A') + $i),
+                'position' => $i,
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function resolveMaxTeams(string $format, array $data, ?int $groupCount, ?int $groupSize, ?int $fallback = null): int
+    {
+        if ($format === 'group_stage_knockout') {
+            if ($groupCount && $groupSize) {
+                return $groupCount * $groupSize;
+            }
+        }
+
+        if (isset($data['max_teams'])) {
+            return (int) $data['max_teams'];
+        }
+
+        return $fallback ?? 8;
+    }
+
+    private function validateFormatConfig(string $format, int $maxTeams, ?int $groupCount, ?int $groupSize): void
+    {
+        if (! in_array($format, ['single_elimination', 'league', 'group_stage_knockout'], true)) {
+            throw new \InvalidArgumentException('Invalid tournament format');
+        }
+
+        if ($format === 'single_elimination') {
+            if (! in_array($maxTeams, [4, 8, 16, 32, 64], true)) {
+                throw new \InvalidArgumentException('Single-elimination tournaments require max teams in {4, 8, 16, 32, 64}');
+            }
+
+            return;
+        }
+
+        if ($format === 'league') {
+            if ($maxTeams < 2 || $maxTeams > 64) {
+                throw new \InvalidArgumentException('League tournaments require between 2 and 64 teams');
+            }
+
+            return;
+        }
+
+        // group_stage_knockout
+        if (! in_array($groupCount, [2, 4, 8, 16], true)) {
+            throw new \InvalidArgumentException('Group count must be 2, 4, 8 or 16');
+        }
+        if ($groupSize === null || $groupSize < 2 || $groupSize > 16) {
+            throw new \InvalidArgumentException('Group size must be between 2 and 16');
+        }
+        if ($maxTeams !== $groupCount * $groupSize) {
+            throw new \InvalidArgumentException('Max teams must equal group_count × group_size');
+        }
+    }
+
+    /**
+     * Generate a single-elimination bracket.
+     *
+     * When called with no team list, loads approved teams ordered by seed
+     * (assigning seeds to any unseeded entries). When called with an explicit
+     * team list (used by the group→knockout transition), uses that list as-is
+     * and starts numbering rounds from $startingRoundNumber.
+     *
+     * @param  Collection<int, TournamentTeam>|null  $teams
+     */
+    public function generateBracket(Tournament $tournament, ?Collection $teams = null, int $startingRoundNumber = 1): void
+    {
+        if ($teams === null) {
+            $teams = $tournament->tournamentTeams()
+                ->where('status', 'approved')
+                ->with('team')
+                ->orderByRaw('seed IS NULL, seed ASC')
+                ->get();
+
+            $teams = $teams->map(function ($tournamentTeam, $index) {
+                if ($tournamentTeam->seed === null) {
+                    $tournamentTeam->seed = $index + 1;
+                    $tournamentTeam->save();
+                }
+
+                return $tournamentTeam;
+            });
+        }
 
         $teamCount = $teams->count();
 
-        // Validate team count is power of 2
         if (! $this->isPowerOfTwo($teamCount)) {
-            throw new \RuntimeException('Number of approved teams must be a power of 2');
+            throw new \RuntimeException('Number of teams must be a power of 2');
         }
 
-        // Calculate rounds needed
-        $totalRounds = (int) log($teamCount, 2);
+        $totalRoundsForBracket = (int) log($teamCount, 2);
 
-        // Create round records
-        for ($i = 1; $i <= $totalRounds; $i++) {
+        // Create round records (numbering continues from $startingRoundNumber).
+        for ($i = 0; $i < $totalRoundsForBracket; $i++) {
+            $namePosition = $i + 1; // 1-indexed within the bracket for naming
             TournamentRound::create([
                 'tournament_id' => $tournament->id,
-                'round_number' => $i,
-                'name' => $this->getRoundName($i, $totalRounds),
+                'round_number' => $startingRoundNumber + $i,
+                'name' => $this->getRoundName($namePosition, $totalRoundsForBracket),
                 'starts_at' => $tournament->starts_at,
             ]);
         }
 
-        // Get first round
-        $firstRound = $tournament->rounds()->where('round_number', 1)->first();
+        $firstRound = $tournament->rounds()
+            ->where('round_number', $startingRoundNumber)
+            ->first();
 
-        // Create first round matches with seeding
         for ($i = 0; $i < $teamCount; $i += 2) {
             FootballMatch::create([
                 'tournament_id' => $tournament->id,
@@ -289,17 +637,18 @@ final class TournamentService
             ]);
         }
 
-        // Create placeholder matches for subsequent rounds
-        for ($roundNum = 2; $roundNum <= $totalRounds; $roundNum++) {
-            $round = $tournament->rounds()->where('round_number', $roundNum)->first();
-            $matchesInRound = intdiv($teamCount, pow(2, $roundNum));
+        for ($i = 1; $i < $totalRoundsForBracket; $i++) {
+            $round = $tournament->rounds()
+                ->where('round_number', $startingRoundNumber + $i)
+                ->first();
+            $matchesInRound = intdiv($teamCount, pow(2, $i + 1));
 
             for ($matchPos = 0; $matchPos < $matchesInRound; $matchPos++) {
                 FootballMatch::create([
                     'tournament_id' => $tournament->id,
                     'tournament_round_id' => $round->id,
-                    'home_team_id' => null, // TBD
-                    'away_team_id' => null, // TBD
+                    'home_team_id' => null,
+                    'away_team_id' => null,
                     'bracket_position' => $matchPos,
                     'variant' => $tournament->variant,
                     'status' => 'pending',

--- a/app/Support/StandingRow.php
+++ b/app/Support/StandingRow.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Support;
+
+final readonly class StandingRow
+{
+    public function __construct(
+        public int $teamId,
+        public int $played,
+        public int $wins,
+        public int $draws,
+        public int $losses,
+        public int $goalsFor,
+        public int $goalsAgainst,
+        public int $goalDifference,
+        public int $points,
+        public int $position,
+        public bool $tiedWithAbove = false,
+    ) {}
+
+    /**
+     * @return array<string, int|bool>
+     */
+    public function toArray(): array
+    {
+        return [
+            'team_id' => $this->teamId,
+            'played' => $this->played,
+            'wins' => $this->wins,
+            'draws' => $this->draws,
+            'losses' => $this->losses,
+            'goals_for' => $this->goalsFor,
+            'goals_against' => $this->goalsAgainst,
+            'goal_difference' => $this->goalDifference,
+            'points' => $this->points,
+            'position' => $this->position,
+            'tied_with_above' => $this->tiedWithAbove,
+        ];
+    }
+}

--- a/database/migrations/2026_05_10_000001_add_format_and_phase_to_tournaments_table.php
+++ b/database/migrations/2026_05_10_000001_add_format_and_phase_to_tournaments_table.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tournaments', function (Blueprint $table) {
+            $table->enum('format', ['single_elimination', 'league', 'group_stage_knockout'])
+                ->default('single_elimination')
+                ->after('variant');
+
+            $table->enum('phase', ['not_started', 'league', 'group_stage', 'knockout', 'completed'])
+                ->default('not_started')
+                ->after('format');
+
+            $table->unsignedSmallInteger('group_count')->nullable()->after('phase');
+            $table->unsignedSmallInteger('group_size')->nullable()->after('group_count');
+
+            $table->index('format');
+        });
+
+        // Backfill phase for existing tournaments based on status.
+        DB::table('tournaments')->where('status', 'completed')->update(['phase' => 'completed']);
+        DB::table('tournaments')->where('status', 'in_progress')->update(['phase' => 'knockout']);
+    }
+
+    public function down(): void
+    {
+        Schema::table('tournaments', function (Blueprint $table) {
+            $table->dropIndex(['format']);
+            $table->dropColumn(['format', 'phase', 'group_count', 'group_size']);
+        });
+    }
+};

--- a/database/migrations/2026_05_10_000002_create_tournament_groups_table.php
+++ b/database/migrations/2026_05_10_000002_create_tournament_groups_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tournament_groups', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tournament_id')->constrained()->cascadeOnDelete();
+            $table->string('name', 8);
+            $table->unsignedSmallInteger('position');
+            $table->timestamps();
+
+            $table->unique(['tournament_id', 'name']);
+            $table->unique(['tournament_id', 'position']);
+            $table->index('tournament_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tournament_groups');
+    }
+};

--- a/database/migrations/2026_05_10_000003_add_group_to_tournament_teams_table.php
+++ b/database/migrations/2026_05_10_000003_add_group_to_tournament_teams_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tournament_teams', function (Blueprint $table) {
+            $table->foreignId('tournament_group_id')
+                ->nullable()
+                ->after('seed')
+                ->constrained('tournament_groups')
+                ->nullOnDelete();
+
+            $table->index('tournament_group_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tournament_teams', function (Blueprint $table) {
+            $table->dropForeign(['tournament_group_id']);
+            $table->dropIndex(['tournament_group_id']);
+            $table->dropColumn('tournament_group_id');
+        });
+    }
+};

--- a/database/migrations/2026_05_10_000004_add_group_and_matchday_to_matches_table.php
+++ b/database/migrations/2026_05_10_000004_add_group_and_matchday_to_matches_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('matches', function (Blueprint $table) {
+            $table->foreignId('tournament_group_id')
+                ->nullable()
+                ->after('tournament_round_id')
+                ->constrained('tournament_groups')
+                ->nullOnDelete();
+
+            $table->unsignedSmallInteger('matchday')->nullable()->after('bracket_position');
+
+            $table->index('tournament_group_id');
+            $table->index(['tournament_id', 'matchday']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('matches', function (Blueprint $table) {
+            $table->dropForeign(['tournament_group_id']);
+            $table->dropIndex(['tournament_group_id']);
+            $table->dropIndex(['tournament_id', 'matchday']);
+            $table->dropColumn(['tournament_group_id', 'matchday']);
+        });
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -12,7 +12,10 @@
     font-weight: 700;
     font-display: optional;
     src: url('/fonts/barlow-condensed-700-latin-ext.woff2') format('woff2');
-    unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+    unicode-range:
+        U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304,
+        U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
+        U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 @font-face {
@@ -21,7 +24,10 @@
     font-weight: 700;
     font-display: optional;
     src: url('/fonts/barlow-condensed-700-latin.woff2') format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    unicode-range:
+        U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+        U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
+        U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 @font-face {
@@ -30,7 +36,10 @@
     font-weight: 800;
     font-display: optional;
     src: url('/fonts/barlow-condensed-800-latin-ext.woff2') format('woff2');
-    unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+    unicode-range:
+        U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304,
+        U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020,
+        U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 @font-face {
@@ -39,7 +48,10 @@
     font-weight: 800;
     font-display: optional;
     src: url('/fonts/barlow-condensed-800-latin.woff2') format('woff2');
-    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+    unicode-range:
+        U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC,
+        U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,
+        U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 @source '../views';
@@ -91,74 +103,74 @@
 }
 
 :root {
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.145 0 0);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.145 0 0);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.145 0 0);
-    --primary: oklch(0.205 0 0);
-    --primary-foreground: oklch(0.985 0 0);
-    --secondary: oklch(0.97 0 0);
-    --secondary-foreground: oklch(0.205 0 0);
-    --muted: oklch(0.97 0 0);
-    --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(0.97 0 0);
-    --accent-foreground: oklch(0.205 0 0);
+    --background: #101312;
+    --foreground: #f4f7f5;
+    --card: #171b19;
+    --card-foreground: #f4f7f5;
+    --popover: #171b19;
+    --popover-foreground: #f4f7f5;
+    --primary: #48d17a;
+    --primary-foreground: #07110b;
+    --secondary: #202622;
+    --secondary-foreground: #edf5ef;
+    --muted: #202622;
+    --muted-foreground: #9aa59d;
+    --accent: #23332a;
+    --accent-foreground: #b2f7c8;
     --destructive: oklch(0.577 0.245 27.325);
     --destructive-foreground: oklch(0.577 0.245 27.325);
-    --border: oklch(0.922 0 0);
-    --input: oklch(0.922 0 0);
-    --ring: oklch(0.708 0 0);
-    --chart-1: oklch(0.87 0 0);
-    --chart-2: oklch(0.556 0 0);
-    --chart-3: oklch(0.439 0 0);
-    --chart-4: oklch(0.371 0 0);
-    --chart-5: oklch(0.269 0 0);
+    --border: rgba(255, 255, 255, 0.1);
+    --input: rgba(255, 255, 255, 0.14);
+    --ring: rgba(72, 209, 122, 0.55);
+    --chart-1: #48d17a;
+    --chart-2: #8df0ad;
+    --chart-3: #9aa59d;
+    --chart-4: #d6b85f;
+    --chart-5: #ef7777;
     --radius: 0.625rem;
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.145 0 0);
-    --sidebar-primary: oklch(0.205 0 0);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.97 0 0);
-    --sidebar-accent-foreground: oklch(0.205 0 0);
-    --sidebar-border: oklch(0.922 0 0);
-    --sidebar-ring: oklch(0.708 0 0);
+    --sidebar: #0c0f0d;
+    --sidebar-foreground: #edf5ef;
+    --sidebar-primary: #48d17a;
+    --sidebar-primary-foreground: #07110b;
+    --sidebar-accent: rgba(72, 209, 122, 0.1);
+    --sidebar-accent-foreground: #b2f7c8;
+    --sidebar-border: rgba(255, 255, 255, 0.1);
+    --sidebar-ring: rgba(72, 209, 122, 0.55);
 }
 
 .dark {
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.205 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.205 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.922 0 0);
-    --primary-foreground: oklch(0.205 0 0);
-    --secondary: oklch(0.269 0 0);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.269 0 0);
-    --accent-foreground: oklch(0.985 0 0);
+    --background: #101312;
+    --foreground: #f4f7f5;
+    --card: #171b19;
+    --card-foreground: #f4f7f5;
+    --popover: #171b19;
+    --popover-foreground: #f4f7f5;
+    --primary: #48d17a;
+    --primary-foreground: #07110b;
+    --secondary: #202622;
+    --secondary-foreground: #edf5ef;
+    --muted: #202622;
+    --muted-foreground: #9aa59d;
+    --accent: #23332a;
+    --accent-foreground: #b2f7c8;
     --destructive: oklch(0.704 0.191 22.216);
     --destructive-foreground: oklch(0.637 0.237 25.331);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.556 0 0);
-    --chart-1: oklch(0.87 0 0);
-    --chart-2: oklch(0.556 0 0);
-    --chart-3: oklch(0.439 0 0);
-    --chart-4: oklch(0.371 0 0);
-    --chart-5: oklch(0.269 0 0);
-    --sidebar: oklch(0.205 0 0);
-    --sidebar-foreground: oklch(0.985 0 0);
-    --sidebar-primary: oklch(0.488 0.243 264.376);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.269 0 0);
-    --sidebar-accent-foreground: oklch(0.985 0 0);
-    --sidebar-border: oklch(1 0 0 / 10%);
-    --sidebar-ring: oklch(0.556 0 0);
+    --border: rgba(255, 255, 255, 0.1);
+    --input: rgba(255, 255, 255, 0.14);
+    --ring: rgba(72, 209, 122, 0.55);
+    --chart-1: #48d17a;
+    --chart-2: #8df0ad;
+    --chart-3: #9aa59d;
+    --chart-4: #d6b85f;
+    --chart-5: #ef7777;
+    --sidebar: #0c0f0d;
+    --sidebar-foreground: #edf5ef;
+    --sidebar-primary: #48d17a;
+    --sidebar-primary-foreground: #07110b;
+    --sidebar-accent: rgba(72, 209, 122, 0.1);
+    --sidebar-accent-foreground: #b2f7c8;
+    --sidebar-border: rgba(255, 255, 255, 0.1);
+    --sidebar-ring: rgba(72, 209, 122, 0.55);
 }
 
 @layer base {
@@ -177,11 +189,86 @@
 
     html {
         @apply font-sans;
+        color-scheme: dark;
     }
 }
 
 @layer utilities {
     .font-display {
         font-family: 'Barlow Condensed', sans-serif;
+    }
+
+    .auth-form-surface label {
+        color: rgba(255, 255, 255, 0.72);
+    }
+
+    .auth-form-surface input {
+        min-height: 2.75rem;
+        border-radius: 0.375rem;
+        border-color: rgba(255, 255, 255, 0.12);
+        background: rgba(16, 19, 18, 0.92);
+        color: #ffffff;
+    }
+
+    .auth-form-surface input::placeholder {
+        color: rgba(255, 255, 255, 0.36);
+    }
+
+    .auth-form-surface input:focus-visible {
+        border-color: rgba(72, 209, 122, 0.55);
+        --tw-ring-color: rgba(72, 209, 122, 0.18);
+    }
+
+    .auth-form-surface button[type='submit'],
+    .auth-form-surface button:not([type]) {
+        min-height: 2.75rem;
+        border-radius: 0.375rem;
+        background: #48d17a;
+        color: #07110b;
+        font-weight: 600;
+    }
+
+    .auth-form-surface button[type='submit']:hover,
+    .auth-form-surface button:not([type]):hover {
+        background: #60df8b;
+    }
+
+    .auth-form-surface button[data-variant='outline'],
+    .auth-form-surface button[type='button'] {
+        border-color: rgba(255, 255, 255, 0.12);
+        background: rgba(255, 255, 255, 0.03);
+        color: #ffffff;
+    }
+
+    .auth-form-surface button[data-variant='outline']:hover,
+    .auth-form-surface button[type='button']:hover {
+        background: rgba(255, 255, 255, 0.07);
+        color: #ffffff;
+    }
+
+    .auth-form-surface a,
+    .auth-form-surface button[class*='underline'] {
+        color: #8df0ad;
+        text-decoration-color: rgba(141, 240, 173, 0.35);
+    }
+
+    .auth-form-surface a:hover,
+    .auth-form-surface button[class*='underline']:hover {
+        color: #b2f7c8;
+        text-decoration-color: currentColor;
+    }
+
+    .auth-form-surface .text-muted-foreground {
+        color: rgba(255, 255, 255, 0.5);
+    }
+
+    .auth-form-surface .border-t {
+        border-color: rgba(255, 255, 255, 0.1);
+    }
+
+    .auth-form-surface [data-slot='input-otp-slot'] {
+        border-color: rgba(255, 255, 255, 0.12);
+        background: rgba(16, 19, 18, 0.92);
+        color: #ffffff;
     }
 }

--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -64,8 +64,7 @@ const rightNavItems: NavItem[] = [
     },
 ];
 
-const activeItemStyles =
-    'text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100';
+const activeItemStyles = 'bg-primary/10 text-primary';
 
 interface AppHeaderProps {
     breadcrumbs?: BreadcrumbItem[];
@@ -77,7 +76,7 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
     const getInitials = useInitials();
     return (
         <>
-            <div className="border-b border-sidebar-border/80">
+            <div className="border-b border-sidebar-border bg-background/95">
                 <div className="mx-auto flex h-16 items-center px-4 md:max-w-7xl">
                     {/* Mobile Menu */}
                     <div className="lg:hidden">
@@ -93,13 +92,15 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                             </SheetTrigger>
                             <SheetContent
                                 side="left"
-                                className="flex h-full w-64 flex-col items-stretch justify-between bg-sidebar"
+                                className="flex h-full w-64 flex-col items-stretch justify-between border-sidebar-border bg-sidebar text-sidebar-foreground"
                             >
                                 <SheetTitle className="sr-only">
                                     Navigation Menu
                                 </SheetTitle>
                                 <SheetHeader className="flex justify-start text-left">
-                                    <AppLogoIcon className="h-6 w-6 fill-current text-black dark:text-white" />
+                                    <span className="flex size-8 items-center justify-center rounded-md bg-[#48d17a] text-[#07110b]">
+                                        <AppLogoIcon className="size-5 fill-current" />
+                                    </span>
                                 </SheetHeader>
                                 <div className="flex h-full flex-1 flex-col space-y-4 p-4">
                                     <div className="flex h-full flex-col justify-between text-sm">
@@ -183,7 +184,7 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                                             {item.title}
                                         </Link>
                                         {isSameUrl(page.url, item.href) && (
-                                            <div className="absolute bottom-0 left-0 h-0.5 w-full translate-y-px bg-black dark:bg-white"></div>
+                                            <div className="absolute bottom-0 left-0 h-0.5 w-full translate-y-px bg-primary"></div>
                                         )}
                                     </NavigationMenuItem>
                                 ))}
@@ -246,7 +247,7 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                                             src={auth.user.avatar_url}
                                             alt={auth.user.name}
                                         />
-                                        <AvatarFallback className="rounded-lg bg-neutral-200 text-black dark:bg-neutral-700 dark:text-white">
+                                        <AvatarFallback className="rounded-lg bg-primary/10 text-primary">
                                             {getInitials(auth.user.name)}
                                         </AvatarFallback>
                                     </Avatar>

--- a/resources/js/components/app-logo-icon.tsx
+++ b/resources/js/components/app-logo-icon.tsx
@@ -2,14 +2,22 @@ import { SVGAttributes } from 'react';
 
 export default function AppLogoIcon(props: SVGAttributes<SVGElement>) {
     return (
-        <svg
-            {...props}
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-        >
+        <svg {...props} viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path
                 fillRule="evenodd"
-                d="M12,1 L22,9 L19,21 L5,21 L2,9 Z M6.5,6.5 L12,18 L17.5,6.5 L15,6.5 L12,13.5 L9,6.5 Z"
+                d="M4.09 4.25c.5-.83 1.72-.81 2.18.05l5.82 10.86 5.66-10.84a1.25 1.25 0 0 1 2.22 1.16l-6.76 12.95a1.25 1.25 0 0 1-2.21.01L4.05 5.5a1.25 1.25 0 0 1 .04-1.25Z"
+                clipRule="evenodd"
+            />
+            <path
+                fillRule="evenodd"
+                d="M8.18 4.12c.62-.31 1.37-.06 1.68.56l3.9 7.79 1.53-2.97a1.25 1.25 0 1 1 2.22 1.14l-2.65 5.16a1.25 1.25 0 0 1-2.23 0L7.62 5.8a1.25 1.25 0 0 1 .56-1.68Z"
+                clipRule="evenodd"
+                opacity="0.52"
+            />
+            <path
+                fillRule="evenodd"
+                d="M17.95 17.15a1.25 1.25 0 0 1 1.67.58l.71 1.45a1.25 1.25 0 1 1-2.25 1.1l-.71-1.45a1.25 1.25 0 0 1 .58-1.68Z"
+                clipRule="evenodd"
             />
         </svg>
     );

--- a/resources/js/components/app-logo.tsx
+++ b/resources/js/components/app-logo.tsx
@@ -3,7 +3,7 @@ import AppLogoIcon from './app-logo-icon';
 export default function AppLogo() {
     return (
         <>
-            <div className="flex aspect-square size-8 items-center justify-center rounded-md bg-foreground text-background">
+            <div className="flex aspect-square size-8 items-center justify-center rounded-md bg-[#48d17a] text-[#07110b] shadow-sm">
                 <AppLogoIcon className="size-5 fill-current" />
             </div>
             <div className="ml-1 grid flex-1 text-left text-sm">

--- a/resources/js/components/app-sidebar-header.tsx
+++ b/resources/js/components/app-sidebar-header.tsx
@@ -9,7 +9,7 @@ export function AppSidebarHeader({
     breadcrumbs?: BreadcrumbItemType[];
 }) {
     return (
-        <header className="flex h-16 shrink-0 items-center justify-between gap-2 border-b border-sidebar-border/50 px-6 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 md:px-4">
+        <header className="flex h-16 shrink-0 items-center justify-between gap-2 border-b border-sidebar-border bg-background/95 px-6 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12 md:px-4">
             <div className="flex items-center gap-2">
                 <SidebarTrigger className="-ml-1" />
                 <Breadcrumbs breadcrumbs={breadcrumbs} />

--- a/resources/js/components/landing-footer.tsx
+++ b/resources/js/components/landing-footer.tsx
@@ -17,53 +17,65 @@ interface LandingFooterProps {
     canRegister?: boolean;
 }
 
+const footerLink =
+    'flex items-center gap-2 text-sm text-white/50 transition-colors hover:text-white';
+
 export default function LandingFooter({
     canRegister = true,
 }: LandingFooterProps) {
     const { auth } = usePage<SharedData>().props;
 
     return (
-        <footer className="border-t bg-muted/30">
-            <div className="container mx-auto px-4 py-12 md:px-6 md:py-16">
-                <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
-                    {/* Brand Section */}
-                    <div className="flex flex-col gap-4">
+        <footer className="border-t border-white/[0.08] bg-[#0c0f0d]">
+            <div className="mx-auto max-w-7xl px-4 py-12 md:px-6 md:py-16">
+                <div className="grid gap-10 md:grid-cols-2 lg:grid-cols-[1.25fr_1fr_1fr_1fr]">
+                    <div className="max-w-sm">
                         <Link
                             href={auth?.user ? teams.index().url : home().url}
-                            className="flex items-center gap-2"
+                            className="flex items-center gap-3"
                         >
-                            <div className="flex aspect-square size-8 items-center justify-center rounded-md bg-green-500">
-                                <AppLogoIcon className="size-5 fill-black" />
-                            </div>
-                            <span className="text-sm font-semibold">
+                            <span className="flex size-8 items-center justify-center rounded-md bg-[#48d17a]">
+                                <AppLogoIcon className="size-5 fill-[#07110b]" />
+                            </span>
+                            <span className="text-sm font-semibold tracking-wide text-white">
                                 Veltro
                             </span>
                         </Link>
-                        <p className="text-sm text-muted-foreground">
-                            La plataforma centralizada para gestionar equipos de
-                            fútbol amateur en Uruguay. Organiza partidos,
-                            rastrea estadísticas y conecta con otros equipos.
+                        <p className="mt-4 text-sm leading-6 text-white/50">
+                            Plataforma centralizada para gestionar equipos de
+                            fútbol amateur en Uruguay: partidos, disponibilidad,
+                            estadísticas y torneos en un solo lugar.
                         </p>
                     </div>
 
-                    {/* Platform Links */}
-                    <div className="flex flex-col gap-4">
-                        <h3 className="text-sm font-semibold">Plataforma</h3>
-                        <nav className="flex flex-col gap-3">
+                    <div>
+                        <h3 className="text-sm font-semibold text-white">
+                            Plataforma
+                        </h3>
+                        <nav className="mt-4 grid gap-3">
                             {auth?.user ? (
-                                <Link
-                                    href={teams.index().url}
-                                    className="flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-                                >
-                                    <Users className="h-4 w-4" />
-                                    Ver Equipos
-                                </Link>
+                                <>
+                                    <Link
+                                        href={teams.index().url}
+                                        className={footerLink}
+                                    >
+                                        <Users className="h-4 w-4" />
+                                        Explorar equipos
+                                    </Link>
+                                    <Link
+                                        href={matches.index().url}
+                                        className={footerLink}
+                                    >
+                                        <Trophy className="h-4 w-4" />
+                                        Ver partidos
+                                    </Link>
+                                </>
                             ) : (
                                 <>
                                     {canRegister && (
                                         <Link
                                             href={register().url}
-                                            className="flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                                            className={footerLink}
                                         >
                                             <Users className="h-4 w-4" />
                                             Registrarse
@@ -71,99 +83,59 @@ export default function LandingFooter({
                                     )}
                                     <Link
                                         href={login().url}
-                                        className="flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                                        className={footerLink}
                                     >
                                         <Trophy className="h-4 w-4" />
                                         Iniciar sesión
                                     </Link>
                                 </>
                             )}
-                            {auth?.user && (
-                                <>
-                                    <Link
-                                        href={teams.index().url}
-                                        className="flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-                                    >
-                                        <Users className="h-4 w-4" />
-                                        Explorar Equipos
-                                    </Link>
-                                    <Link
-                                        href={matches.index().url}
-                                        className="flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-                                    >
-                                        <Trophy className="h-4 w-4" />
-                                        Ver Partidos
-                                    </Link>
-                                </>
-                            )}
                         </nav>
                     </div>
 
-                    {/* Support & Resources */}
-                    <div className="flex flex-col gap-4">
-                        <h3 className="text-sm font-semibold">
-                            Soporte y Recursos
+                    <div>
+                        <h3 className="text-sm font-semibold text-white">
+                            Recursos
                         </h3>
-                        <nav className="flex flex-col gap-3">
-                            <Link
-                                href="/help"
-                                className="flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-                            >
+                        <nav className="mt-4 grid gap-3">
+                            <Link href="/help" className={footerLink}>
                                 <HelpCircle className="h-4 w-4" />
-                                Centro de Ayuda
+                                Centro de ayuda
                             </Link>
-                            <Link
-                                href="/contact"
-                                className="flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-                            >
+                            <Link href="/contact" className={footerLink}>
                                 <Mail className="h-4 w-4" />
                                 Contacto
                             </Link>
-                            <Link
-                                href="/about"
-                                className="flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-                            >
+                            <Link href="/about" className={footerLink}>
                                 <FileText className="h-4 w-4" />
                                 Acerca de
                             </Link>
                         </nav>
                     </div>
 
-                    {/* Legal */}
-                    <div className="flex flex-col gap-4">
-                        <h3 className="text-sm font-semibold">Legal</h3>
-                        <nav className="flex flex-col gap-3">
-                            <Link
-                                href="/terms"
-                                className="flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-                            >
+                    <div>
+                        <h3 className="text-sm font-semibold text-white">
+                            Legal
+                        </h3>
+                        <nav className="mt-4 grid gap-3">
+                            <Link href="/terms" className={footerLink}>
                                 <FileText className="h-4 w-4" />
-                                Términos y Condiciones
+                                Términos
                             </Link>
-                            <Link
-                                href="/privacy"
-                                className="flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-                            >
+                            <Link href="/privacy" className={footerLink}>
                                 <Shield className="h-4 w-4" />
-                                Política de Privacidad
+                                Privacidad
                             </Link>
                         </nav>
                     </div>
                 </div>
 
-                {/* Bottom Bar */}
-                <div className="mt-12 border-t pt-8">
-                    <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
-                        <p className="text-center text-sm text-muted-foreground sm:text-left">
-                            © {new Date().getFullYear()} Veltro. Todos los
-                            derechos reservados.
-                        </p>
-                        <div className="flex items-center gap-4 text-sm text-muted-foreground">
-                            <span>
-                                Hecho con ❤️ para equipos uruguayos amateurs
-                            </span>
-                        </div>
-                    </div>
+                <div className="mt-12 flex flex-col items-center justify-between gap-4 border-t border-white/[0.08] pt-8 text-sm text-white/40 sm:flex-row">
+                    <p className="text-center sm:text-left">
+                        © {new Date().getFullYear()} Veltro. Todos los derechos
+                        reservados.
+                    </p>
+                    <p>Hecho para equipos uruguayos amateurs.</p>
                 </div>
             </div>
         </footer>

--- a/resources/js/components/landing/previews.tsx
+++ b/resources/js/components/landing/previews.tsx
@@ -8,65 +8,64 @@ const teamInitial = (name: string) =>
         .join('')
         .toUpperCase();
 
+const previewCard =
+    'select-none rounded-lg border border-white/[0.08] bg-[#101312] p-5 shadow-[0_18px_60px_rgba(0,0,0,0.28)]';
+const mutedText = 'text-white/50';
+
 export function LandingMatchPreview() {
     return (
-        <div
-            aria-hidden="true"
-            className="select-none rounded-2xl border border-border/60 bg-background/70 p-5 shadow-xl ring-1 ring-black/[0.02] backdrop-blur-sm"
-        >
-            <div className="mb-4 flex items-center justify-between">
+        <div aria-hidden="true" className={previewCard}>
+            <div className="mb-5 flex items-center justify-between gap-3">
                 <div className="flex items-center gap-2">
                     <span className="relative flex h-2 w-2">
-                        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-500 opacity-75" />
-                        <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500" />
+                        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[#48d17a] opacity-60" />
+                        <span className="relative inline-flex h-2 w-2 rounded-full bg-[#48d17a]" />
                     </span>
-                    <span className="text-xs font-medium text-muted-foreground">
+                    <span className={`text-xs font-medium ${mutedText}`}>
                         Comienza en 3 días
                     </span>
                 </div>
-                <span className="rounded-full border border-border/60 bg-muted/40 px-2.5 py-0.5 text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
+                <span className="rounded-md border border-white/[0.08] bg-white/[0.04] px-2.5 py-1 text-[10px] font-semibold tracking-wide text-white/55 uppercase">
                     Fútbol 7
                 </span>
             </div>
 
-            <div className="flex items-center justify-between gap-3">
-                <div className="flex flex-1 flex-col items-center gap-2">
-                    <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/20 to-primary/5 text-base font-bold text-primary">
+            <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-3">
+                <div className="flex min-w-0 flex-col items-center gap-2">
+                    <div className="flex h-14 w-14 items-center justify-center rounded-md border border-[#48d17a]/20 bg-[#48d17a]/10 text-base font-semibold text-[#48d17a]">
                         LT
                     </div>
-                    <span className="text-center text-xs font-medium">
+                    <span className="max-w-full truncate text-center text-xs font-medium text-white">
                         Los Tigres FC
                     </span>
                 </div>
                 <div className="flex flex-col items-center gap-1 px-2">
-                    <span className="text-xs font-semibold tracking-wider text-muted-foreground">
+                    <span className="text-xs font-semibold tracking-wider text-white/40">
                         VS
                     </span>
-                    <span className="text-[10px] text-muted-foreground">
-                        20:00
-                    </span>
+                    <span className="text-[10px] text-white/40">20:00</span>
                 </div>
-                <div className="flex flex-1 flex-col items-center gap-2">
-                    <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-orange-500/20 to-orange-500/5 text-base font-bold text-orange-600 dark:text-orange-400">
+                <div className="flex min-w-0 flex-col items-center gap-2">
+                    <div className="flex h-14 w-14 items-center justify-center rounded-md border border-white/[0.08] bg-white/[0.05] text-base font-semibold text-white/70">
                         BU
                     </div>
-                    <span className="text-center text-xs font-medium">
+                    <span className="max-w-full truncate text-center text-xs font-medium text-white">
                         Barrio United
                     </span>
                 </div>
             </div>
 
-            <div className="mt-5 flex flex-col gap-2 border-t border-border/60 pt-4 text-xs text-muted-foreground">
+            <div className="mt-5 grid gap-2 border-t border-white/[0.08] pt-4 text-xs text-white/50">
                 <div className="flex items-center gap-2">
-                    <CalendarDays className="h-3.5 w-3.5" />
+                    <CalendarDays className="h-3.5 w-3.5 text-[#48d17a]" />
                     <span>Sábado · 20:00</span>
                 </div>
                 <div className="flex items-center gap-2">
-                    <MapPin className="h-3.5 w-3.5" />
+                    <MapPin className="h-3.5 w-3.5 text-[#48d17a]" />
                     <span>Cancha Parque Rodó</span>
                 </div>
                 <div className="flex items-center gap-2">
-                    <Clock className="h-3.5 w-3.5" />
+                    <Clock className="h-3.5 w-3.5 text-[#48d17a]" />
                     <span>Amistoso · 90 minutos</span>
                 </div>
             </div>
@@ -83,9 +82,9 @@ const availabilityRoster = [
 ];
 
 const statusDot: Record<string, string> = {
-    available: 'bg-green-500',
-    maybe: 'bg-amber-500',
-    unavailable: 'bg-red-500',
+    available: 'bg-[#48d17a]',
+    maybe: 'bg-[#d6b85f]',
+    unavailable: 'bg-[#ef7777]',
 };
 
 const statusLabel: Record<string, string> = {
@@ -96,58 +95,53 @@ const statusLabel: Record<string, string> = {
 
 export function LandingAvailabilityPreview() {
     return (
-        <div
-            aria-hidden="true"
-            className="select-none rounded-2xl border border-border/60 bg-background/70 p-5 shadow-xl ring-1 ring-black/[0.02] backdrop-blur-sm"
-        >
+        <div aria-hidden="true" className={previewCard}>
             <div className="mb-4 flex items-start justify-between gap-3">
-                <div className="flex flex-col gap-0.5">
-                    <span className="text-xs text-muted-foreground">
-                        Los Tigres FC
-                    </span>
-                    <span className="text-sm font-semibold">
+                <div>
+                    <span className="text-xs text-white/50">Los Tigres FC</span>
+                    <span className="mt-0.5 block text-sm font-semibold text-white">
                         Próximo partido
                     </span>
                 </div>
-                <div className="flex flex-col items-end">
-                    <span className="text-xl font-bold tabular-nums">
+                <div className="text-right">
+                    <span className="text-2xl font-semibold text-white tabular-nums">
                         9
-                        <span className="text-sm font-medium text-muted-foreground">
+                        <span className="text-sm font-medium text-white/40">
                             /11
                         </span>
                     </span>
-                    <span className="text-[10px] text-muted-foreground">
+                    <span className="block text-[10px] text-white/40">
                         confirmados
                     </span>
                 </div>
             </div>
 
-            <div className="mb-5 h-2 w-full overflow-hidden rounded-full bg-muted">
+            <div className="mb-5 h-2 w-full overflow-hidden rounded-full bg-white/[0.08]">
                 <div
-                    className="h-full rounded-full bg-gradient-to-r from-green-500 to-green-400"
+                    className="h-full rounded-full bg-[#48d17a]"
                     style={{ width: '82%' }}
                 />
             </div>
 
-            <div className="flex flex-col gap-2.5">
+            <div className="grid gap-2.5">
                 {availabilityRoster.map((player) => (
                     <div
                         key={player.name}
-                        className="flex items-center justify-between"
+                        className="flex items-center justify-between gap-3"
                     >
-                        <div className="flex items-center gap-2.5">
-                            <div className="flex h-6 w-6 items-center justify-center rounded-full bg-muted text-[10px] font-semibold text-muted-foreground">
+                        <div className="flex min-w-0 items-center gap-2.5">
+                            <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-white/[0.07] text-[10px] font-semibold text-white/60">
                                 {teamInitial(player.name)}
                             </div>
-                            <span className="text-xs font-medium">
+                            <span className="truncate text-xs font-medium text-white">
                                 {player.name}
                             </span>
                         </div>
-                        <div className="flex items-center gap-1.5">
+                        <div className="flex shrink-0 items-center gap-1.5">
                             <span
                                 className={`h-1.5 w-1.5 rounded-full ${statusDot[player.status]}`}
                             />
-                            <span className="text-[10px] text-muted-foreground">
+                            <span className="text-[10px] text-white/45">
                                 {statusLabel[player.status]}
                             </span>
                         </div>
@@ -155,7 +149,7 @@ export function LandingAvailabilityPreview() {
                 ))}
             </div>
 
-            <div className="mt-4 border-t border-border/60 pt-3 text-center text-[10px] text-muted-foreground">
+            <div className="mt-4 border-t border-white/[0.08] pt-3 text-center text-[10px] text-white/40">
                 +9 jugadores más
             </div>
         </div>
@@ -164,71 +158,64 @@ export function LandingAvailabilityPreview() {
 
 export function LandingTournamentPreview() {
     return (
-        <div
-            aria-hidden="true"
-            className="select-none rounded-2xl border border-border/60 bg-background/70 p-5 shadow-xl ring-1 ring-black/[0.02] backdrop-blur-sm"
-        >
-            <div className="mb-4 flex items-start justify-between gap-3">
-                <div className="flex items-center gap-3">
-                    <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br from-amber-500/20 to-amber-500/5 text-amber-600 dark:text-amber-400">
+        <div aria-hidden="true" className={previewCard}>
+            <div className="mb-5 flex items-start justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-3">
+                    <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-md border border-[#48d17a]/20 bg-[#48d17a]/10 text-[#48d17a]">
                         <Trophy className="h-5 w-5" />
                     </div>
-                    <div className="flex flex-col gap-0.5">
-                        <span className="text-sm font-semibold leading-tight">
+                    <div className="min-w-0">
+                        <span className="block truncate text-sm leading-tight font-semibold text-white">
                             Copa Veltro Verano
                         </span>
-                        <span className="text-[10px] text-muted-foreground">
+                        <span className="text-[10px] text-white/50">
                             Fútbol 7 · Montevideo
                         </span>
                     </div>
                 </div>
-                <span className="rounded-full border border-green-500/30 bg-green-500/10 px-2 py-0.5 text-[10px] font-semibold text-green-600 dark:text-green-400">
+                <span className="shrink-0 rounded-md border border-[#48d17a]/25 bg-[#48d17a]/10 px-2 py-1 text-[10px] font-semibold text-[#8df0ad]">
                     Abierta
                 </span>
             </div>
 
             <div className="mb-4">
-                <div className="mb-1.5 flex items-center justify-between text-[10px] text-muted-foreground">
+                <div className="mb-2 flex items-center justify-between text-[10px] text-white/50">
                     <span className="flex items-center gap-1">
-                        <Users className="h-3 w-3" />
+                        <Users className="h-3 w-3 text-[#48d17a]" />
                         Equipos inscritos
                     </span>
-                    <span className="font-semibold text-foreground tabular-nums">
+                    <span className="font-semibold text-white tabular-nums">
                         12/16
                     </span>
                 </div>
-                <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/[0.08]">
                     <div
-                        className="h-full rounded-full bg-gradient-to-r from-amber-500 to-amber-400"
+                        className="h-full rounded-full bg-[#48d17a]"
                         style={{ width: '75%' }}
                     />
                 </div>
             </div>
 
-            <div className="mb-4 flex items-center justify-between">
-                <div className="flex -space-x-2">
-                    {[
-                        'bg-primary/20 text-primary',
-                        'bg-orange-500/20 text-orange-600 dark:text-orange-400',
-                        'bg-sky-500/20 text-sky-600 dark:text-sky-400',
-                        'bg-emerald-500/20 text-emerald-600 dark:text-emerald-400',
-                        'bg-fuchsia-500/20 text-fuchsia-600 dark:text-fuchsia-400',
-                    ].map((cls, idx) => (
-                        <div
-                            key={idx}
-                            className={`flex h-7 w-7 items-center justify-center rounded-full border-2 border-background text-[10px] font-bold ${cls}`}
-                        >
-                            {['LT', 'BU', 'RA', 'CP', 'VM'][idx]}
-                        </div>
-                    ))}
-                    <div className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-background bg-muted text-[9px] font-semibold text-muted-foreground">
-                        +7
+            <div className="mb-4 flex -space-x-2">
+                {['LT', 'BU', 'RA', 'CP', 'VM'].map((team, idx) => (
+                    <div
+                        key={team}
+                        className={`flex h-7 w-7 items-center justify-center rounded-full border-2 border-[#101312] text-[10px] font-semibold ${
+                            idx === 0
+                                ? 'bg-[#48d17a] text-[#07110b]'
+                                : 'bg-white/[0.08] text-white/65'
+                        }`}
+                    >
+                        {team}
                     </div>
+                ))}
+                <div className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-[#101312] bg-white/[0.05] text-[9px] font-semibold text-white/45">
+                    +7
                 </div>
             </div>
 
-            <div className="flex items-center gap-2 border-t border-border/60 pt-3 text-[10px] text-muted-foreground">
-                <CalendarDays className="h-3 w-3" />
+            <div className="flex items-center gap-2 border-t border-white/[0.08] pt-3 text-[10px] text-white/50">
+                <CalendarDays className="h-3 w-3 text-[#48d17a]" />
                 <span>Comienza el 2 de mayo</span>
             </div>
         </div>

--- a/resources/js/components/nav-footer.tsx
+++ b/resources/js/components/nav-footer.tsx
@@ -28,7 +28,7 @@ export function NavFooter({
                         <SidebarMenuItem key={item.title}>
                             <SidebarMenuButton
                                 asChild
-                                className="text-neutral-600 hover:text-neutral-800 dark:text-neutral-300 dark:hover:text-neutral-100"
+                                className="text-sidebar-foreground/60 hover:text-sidebar-accent-foreground"
                             >
                                 <a
                                     href={resolveUrl(item.href)}

--- a/resources/js/components/tournament/group-draw.tsx
+++ b/resources/js/components/tournament/group-draw.tsx
@@ -1,0 +1,274 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+import type { Team, TournamentGroup, TournamentTeam } from '@/types';
+import { router } from '@inertiajs/react';
+import { Loader2, RotateCcw, Save } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+interface Props {
+    tournamentId: number;
+    groups: TournamentGroup[];
+    approvedTeams: (TournamentTeam & { team: Team })[];
+    groupSize: number;
+}
+
+const UNASSIGNED = 'unassigned';
+
+export function GroupDraw({
+    tournamentId,
+    groups,
+    approvedTeams,
+    groupSize,
+}: Props) {
+    // Local map of tournamentTeam.id → tournamentGroupId|null. Initialised
+    // from the backend payload so the UI reflects what's already saved.
+    const [assignments, setAssignments] = useState<
+        Record<number, number | null>
+    >(() => {
+        const init: Record<number, number | null> = {};
+        for (const tt of approvedTeams) {
+            init[tt.id] = tt.tournament_group_id ?? null;
+        }
+        return init;
+    });
+    const [saving, setSaving] = useState(false);
+
+    const teamsByGroup = useMemo(() => {
+        const map: Record<number, (TournamentTeam & { team: Team })[]> = {};
+        for (const group of groups) map[group.id] = [];
+        for (const tt of approvedTeams) {
+            const groupId = assignments[tt.id];
+            if (groupId != null && map[groupId]) map[groupId].push(tt);
+        }
+        return map;
+    }, [groups, approvedTeams, assignments]);
+
+    const totalAssigned = approvedTeams.filter(
+        (tt) => assignments[tt.id] != null,
+    ).length;
+    const allAssigned = totalAssigned === approvedTeams.length;
+    const overflow = groups.some(
+        (g) => (teamsByGroup[g.id]?.length ?? 0) > groupSize,
+    );
+
+    const handleAssign = (tournamentTeamId: number, value: string) => {
+        setAssignments((prev) => ({
+            ...prev,
+            [tournamentTeamId]:
+                value === UNASSIGNED ? null : parseInt(value, 10),
+        }));
+    };
+
+    const handleSave = () => {
+        if (overflow) {
+            toast.error(
+                'Algún grupo tiene más equipos que el tamaño permitido.',
+            );
+            return;
+        }
+        setSaving(true);
+        router.post(
+            `/tournaments/${tournamentId}/groups/draw`,
+            {
+                assignments: approvedTeams.map((tt) => ({
+                    tournament_team_id: tt.id,
+                    tournament_group_id: assignments[tt.id],
+                })),
+            },
+            {
+                preserveScroll: true,
+                onSuccess: () => toast.success('Sorteo guardado.'),
+                onError: () => toast.error('No se pudo guardar el sorteo.'),
+                onFinish: () => setSaving(false),
+            },
+        );
+    };
+
+    const handleClear = () => {
+        if (!confirm('¿Borrar todas las asignaciones?')) return;
+        router.delete(`/tournaments/${tournamentId}/groups/draw`, {
+            preserveScroll: true,
+            onSuccess: () => {
+                setAssignments(
+                    Object.fromEntries(
+                        approvedTeams.map((tt) => [tt.id, null]),
+                    ),
+                );
+                toast.success('Sorteo reiniciado.');
+            },
+            onError: () => toast.error('No se pudo reiniciar el sorteo.'),
+        });
+    };
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-start justify-between gap-4">
+                <div>
+                    <CardTitle className="text-base">
+                        Sorteo de Grupos
+                    </CardTitle>
+                    <CardDescription>
+                        Asigná cada equipo a un grupo antes de comenzar el
+                        torneo. {totalAssigned}/{approvedTeams.length}{' '}
+                        asignados.
+                    </CardDescription>
+                </div>
+                <div className="flex gap-2">
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={handleClear}
+                        disabled={saving || totalAssigned === 0}
+                    >
+                        <RotateCcw className="size-4" />
+                        Reiniciar
+                    </Button>
+                    <Button
+                        type="button"
+                        size="sm"
+                        onClick={handleSave}
+                        disabled={saving || overflow}
+                    >
+                        {saving ? (
+                            <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                            <Save className="size-4" />
+                        )}
+                        Guardar
+                    </Button>
+                </div>
+            </CardHeader>
+            <CardContent className="space-y-6">
+                {/* Team list with per-team group selector */}
+                <div className="space-y-2">
+                    <h3 className="text-sm font-medium text-muted-foreground">
+                        Equipos
+                    </h3>
+                    <div className="space-y-2">
+                        {approvedTeams.map((tt) => (
+                            <div
+                                key={tt.id}
+                                className="flex items-center justify-between gap-3 rounded-md border p-2"
+                            >
+                                <div className="flex min-w-0 items-center gap-2">
+                                    <Avatar className="size-7">
+                                        {tt.team?.logo_url && (
+                                            <AvatarImage
+                                                src={tt.team.logo_url}
+                                                alt={tt.team.name}
+                                            />
+                                        )}
+                                        <AvatarFallback className="text-xs">
+                                            {tt.team?.name
+                                                ?.slice(0, 2)
+                                                .toUpperCase() ?? '?'}
+                                        </AvatarFallback>
+                                    </Avatar>
+                                    <span className="truncate text-sm font-medium">
+                                        {tt.team?.name ?? `Team ${tt.team_id}`}
+                                    </span>
+                                </div>
+                                <Select
+                                    value={(
+                                        assignments[tt.id] ?? UNASSIGNED
+                                    ).toString()}
+                                    onValueChange={(value) =>
+                                        handleAssign(tt.id, value)
+                                    }
+                                >
+                                    <SelectTrigger className="w-32">
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value={UNASSIGNED}>
+                                            Sin grupo
+                                        </SelectItem>
+                                        {groups.map((group) => (
+                                            <SelectItem
+                                                key={group.id}
+                                                value={group.id.toString()}
+                                            >
+                                                Grupo {group.name}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Group overview */}
+                <div className="grid gap-3 md:grid-cols-2">
+                    {groups.map((group) => {
+                        const teams = teamsByGroup[group.id] ?? [];
+                        const overCapacity = teams.length > groupSize;
+                        return (
+                            <div
+                                key={group.id}
+                                className={cn(
+                                    'space-y-2 rounded-md border p-3',
+                                    overCapacity &&
+                                        'border-destructive/60 bg-destructive/5',
+                                )}
+                            >
+                                <div className="flex items-center justify-between text-sm font-medium">
+                                    <span>Grupo {group.name}</span>
+                                    <span
+                                        className={cn(
+                                            'text-xs text-muted-foreground tabular-nums',
+                                            overCapacity && 'text-destructive',
+                                        )}
+                                    >
+                                        {teams.length}/{groupSize}
+                                    </span>
+                                </div>
+                                {teams.length === 0 ? (
+                                    <p className="text-xs text-muted-foreground">
+                                        Sin equipos asignados.
+                                    </p>
+                                ) : (
+                                    <ul className="space-y-1">
+                                        {teams.map((tt) => (
+                                            <li
+                                                key={tt.id}
+                                                className="truncate text-xs text-muted-foreground"
+                                            >
+                                                {tt.team?.name ??
+                                                    `Team ${tt.team_id}`}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
+
+                {!allAssigned && (
+                    <p className="text-xs text-muted-foreground">
+                        Faltan {approvedTeams.length - totalAssigned} equipos
+                        por asignar para poder iniciar el torneo.
+                    </p>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/resources/js/components/tournament/groups-grid.tsx
+++ b/resources/js/components/tournament/groups-grid.tsx
@@ -1,0 +1,40 @@
+import { StandingsTable } from '@/components/tournament/standings-table';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { StandingRow, TournamentGroup } from '@/types';
+
+interface Props {
+    groups: TournamentGroup[];
+    standingsByGroup: Record<number, StandingRow[]>;
+    highlightTopN?: number;
+}
+
+export function GroupsGrid({
+    groups,
+    standingsByGroup,
+    highlightTopN = 2,
+}: Props) {
+    if (groups.length === 0) return null;
+
+    return (
+        <div className="grid gap-4 md:grid-cols-2">
+            {groups.map((group) => {
+                const rows = standingsByGroup[group.id] ?? [];
+                return (
+                    <Card key={group.id}>
+                        <CardHeader className="pb-3">
+                            <CardTitle className="text-base">
+                                Grupo {group.name}
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <StandingsTable
+                                rows={rows}
+                                highlightTopN={highlightTopN}
+                            />
+                        </CardContent>
+                    </Card>
+                );
+            })}
+        </div>
+    );
+}

--- a/resources/js/components/tournament/standings-table.tsx
+++ b/resources/js/components/tournament/standings-table.tsx
@@ -1,0 +1,143 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { cn } from '@/lib/utils';
+import type { StandingRow } from '@/types';
+
+interface Props {
+    rows: StandingRow[];
+    highlightTopN?: number;
+    title?: string;
+    className?: string;
+}
+
+export function StandingsTable({
+    rows,
+    highlightTopN,
+    title,
+    className,
+}: Props) {
+    return (
+        <div className={cn('overflow-hidden rounded-md border', className)}>
+            {title && (
+                <div className="border-b bg-muted/40 px-4 py-2 text-sm font-semibold">
+                    {title}
+                </div>
+            )}
+            <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                    <thead>
+                        <tr className="bg-muted/40 text-xs text-muted-foreground uppercase">
+                            <th className="px-3 py-2 text-left">#</th>
+                            <th className="px-3 py-2 text-left">Equipo</th>
+                            <th className="px-2 py-2 text-center">PJ</th>
+                            <th className="hidden px-2 py-2 text-center sm:table-cell">
+                                G
+                            </th>
+                            <th className="hidden px-2 py-2 text-center sm:table-cell">
+                                E
+                            </th>
+                            <th className="hidden px-2 py-2 text-center sm:table-cell">
+                                P
+                            </th>
+                            <th className="hidden px-2 py-2 text-center md:table-cell">
+                                GF
+                            </th>
+                            <th className="hidden px-2 py-2 text-center md:table-cell">
+                                GC
+                            </th>
+                            <th className="px-2 py-2 text-center">DG</th>
+                            <th className="px-3 py-2 text-center font-semibold">
+                                Pts
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows.length === 0 && (
+                            <tr>
+                                <td
+                                    colSpan={10}
+                                    className="px-3 py-6 text-center text-muted-foreground"
+                                >
+                                    Aún no hay equipos en la tabla.
+                                </td>
+                            </tr>
+                        )}
+                        {rows.map((row) => {
+                            const highlighted =
+                                highlightTopN !== undefined &&
+                                row.position <= highlightTopN;
+                            return (
+                                <tr
+                                    key={row.team_id}
+                                    className={cn(
+                                        'border-t',
+                                        highlighted && 'bg-emerald-500/5',
+                                        row.tied_with_above && 'border-dashed',
+                                    )}
+                                >
+                                    <td className="px-3 py-2 text-left font-medium tabular-nums">
+                                        {row.position}
+                                    </td>
+                                    <td className="px-3 py-2 text-left">
+                                        <div className="flex items-center gap-2">
+                                            <Avatar className="size-6">
+                                                {row.team?.logo_url && (
+                                                    <AvatarImage
+                                                        src={row.team.logo_url}
+                                                        alt={row.team?.name}
+                                                    />
+                                                )}
+                                                <AvatarFallback className="text-[10px]">
+                                                    {row.team?.name
+                                                        ?.slice(0, 2)
+                                                        .toUpperCase() ?? '?'}
+                                                </AvatarFallback>
+                                            </Avatar>
+                                            <span className="truncate">
+                                                {row.team?.name ??
+                                                    `Team ${row.team_id}`}
+                                            </span>
+                                        </div>
+                                    </td>
+                                    <td className="px-2 py-2 text-center tabular-nums">
+                                        {row.played}
+                                    </td>
+                                    <td className="hidden px-2 py-2 text-center tabular-nums sm:table-cell">
+                                        {row.wins}
+                                    </td>
+                                    <td className="hidden px-2 py-2 text-center tabular-nums sm:table-cell">
+                                        {row.draws}
+                                    </td>
+                                    <td className="hidden px-2 py-2 text-center tabular-nums sm:table-cell">
+                                        {row.losses}
+                                    </td>
+                                    <td className="hidden px-2 py-2 text-center tabular-nums md:table-cell">
+                                        {row.goals_for}
+                                    </td>
+                                    <td className="hidden px-2 py-2 text-center tabular-nums md:table-cell">
+                                        {row.goals_against}
+                                    </td>
+                                    <td
+                                        className={cn(
+                                            'px-2 py-2 text-center tabular-nums',
+                                            row.goal_difference > 0 &&
+                                                'text-emerald-600',
+                                            row.goal_difference < 0 &&
+                                                'text-rose-600',
+                                        )}
+                                    >
+                                        {row.goal_difference > 0
+                                            ? `+${row.goal_difference}`
+                                            : row.goal_difference}
+                                    </td>
+                                    <td className="px-3 py-2 text-center font-semibold tabular-nums">
+                                        {row.points}
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/components/ui/sidebar.tsx
+++ b/resources/js/components/ui/sidebar.tsx
@@ -470,7 +470,7 @@ const sidebarMenuButtonVariants = cva(
       variant: {
         default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
         outline:
-          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+          "bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]",
       },
       size: {
         default: "h-8 text-sm",

--- a/resources/js/components/user-info.tsx
+++ b/resources/js/components/user-info.tsx
@@ -15,7 +15,7 @@ export function UserInfo({
         <>
             <Avatar className="h-8 w-8 overflow-hidden rounded-full">
                 <AvatarImage src={user.avatar_url} alt={user.name} />
-                <AvatarFallback className="rounded-lg bg-neutral-200 text-black dark:bg-neutral-700 dark:text-white">
+                <AvatarFallback className="rounded-lg bg-primary/10 text-primary">
                     {getInitials(user.name)}
                 </AvatarFallback>
             </Avatar>

--- a/resources/js/components/variant-badge.tsx
+++ b/resources/js/components/variant-badge.tsx
@@ -29,7 +29,7 @@ const variantConfig = {
 export function VariantBadge({ variant, className }: VariantBadgeProps) {
     const config = variantConfig[variant as keyof typeof variantConfig] || {
         label: variant,
-        color: 'bg-gray-100 text-gray-700 hover:bg-gray-100',
+        color: 'bg-muted text-muted-foreground hover:bg-muted',
     };
 
     return (

--- a/resources/js/layouts/auth/auth-card-layout.tsx
+++ b/resources/js/layouts/auth/auth-card-layout.tsx
@@ -27,7 +27,7 @@ export default function AuthCardLayout({
                     className="flex items-center gap-2 self-center font-medium"
                 >
                     <div className="flex h-9 w-9 items-center justify-center">
-                        <AppLogoIcon className="size-9 fill-current text-black dark:text-white" />
+                        <AppLogoIcon className="size-9 fill-current text-primary" />
                     </div>
                 </Link>
 

--- a/resources/js/layouts/auth/auth-simple-layout.tsx
+++ b/resources/js/layouts/auth/auth-simple-layout.tsx
@@ -1,7 +1,7 @@
 import AppLogoIcon from '@/components/app-logo-icon';
 import { home } from '@/routes';
 import { Head, Link } from '@inertiajs/react';
-import { CalendarDays, Trophy, Users } from 'lucide-react';
+import { CalendarDays, CheckCircle2, Trophy, Users } from 'lucide-react';
 import { type PropsWithChildren } from 'react';
 
 interface AuthLayoutProps {
@@ -16,31 +16,25 @@ const PitchLines = () => (
         className="pointer-events-none absolute inset-0 h-full w-full"
         viewBox="0 0 800 900"
         preserveAspectRatio="xMidYMid slice"
-        style={{ opacity: 0.05 }}
+        style={{ opacity: 0.045 }}
     >
-        <g fill="none" stroke="white" strokeWidth="1.5">
-            <rect x="50" y="50" width="700" height="800" />
-            <line x1="400" y1="50" x2="400" y2="850" />
-            <circle cx="400" cy="450" r="100" />
+        <g fill="none" stroke="white" strokeWidth="1.4">
+            <rect x="58" y="60" width="684" height="780" rx="8" />
+            <line x1="400" y1="60" x2="400" y2="840" />
+            <circle cx="400" cy="450" r="98" />
             <circle cx="400" cy="450" r="4" fill="white" stroke="none" />
-            <rect x="50" y="270" width="160" height="260" />
-            <rect x="590" y="270" width="160" height="260" />
-            <rect x="50" y="340" width="55" height="120" />
-            <rect x="695" y="340" width="55" height="120" />
-            <path d="M50,50 Q70,50 70,70" />
-            <path d="M750,50 Q730,50 730,70" />
-            <path d="M50,850 Q70,850 70,830" />
-            <path d="M750,850 Q730,850 730,830" />
-            <circle cx="130" cy="450" r="4" fill="white" stroke="none" />
-            <circle cx="670" cy="450" r="4" fill="white" stroke="none" />
+            <rect x="58" y="274" width="158" height="252" rx="4" />
+            <rect x="584" y="274" width="158" height="252" rx="4" />
+            <rect x="58" y="342" width="54" height="116" rx="3" />
+            <rect x="688" y="342" width="54" height="116" rx="3" />
         </g>
     </svg>
 );
 
 const features = [
     { icon: Users, text: 'Invitá a tu plantel con un enlace' },
-    { icon: CalendarDays, text: 'Organizá partidos en segundos' },
-    { icon: Trophy, text: 'Competí en torneos organizados' },
+    { icon: CalendarDays, text: 'Organizá partidos sin perseguir mensajes' },
+    { icon: Trophy, text: 'Competí con estructura de torneo real' },
 ];
 
 export default function AuthSimpleLayout({
@@ -50,67 +44,51 @@ export default function AuthSimpleLayout({
 }: PropsWithChildren<AuthLayoutProps>) {
     return (
         <>
-            <Head>
-                <link rel="preconnect" href="https://fonts.googleapis.com" />
-                <link
-                    rel="preconnect"
-                    href="https://fonts.gstatic.com"
-                    crossOrigin="anonymous"
-                />
-                <link
-                    href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@700;800&display=swap"
-                    rel="stylesheet"
-                />
-            </Head>
+            <Head />
 
-            <div
-                className="flex min-h-svh flex-col text-white lg:flex-row"
-                style={{ background: '#060d17' }}
-            >
-                {/* Left: brand panel — desktop only */}
-                <div className="relative hidden flex-col justify-between overflow-hidden p-12 lg:flex lg:w-[45%]">
+            <div className="grid min-h-svh bg-[#101312] text-white lg:grid-cols-[0.92fr_1.08fr]">
+                <aside className="relative hidden overflow-hidden border-r border-white/[0.08] bg-[#141815] lg:flex lg:flex-col lg:justify-between lg:p-10 xl:p-12">
                     <PitchLines />
-                    <div
-                        aria-hidden="true"
-                        className="pointer-events-none absolute top-[-20%] left-[-10%] h-[500px] w-[500px] rounded-full blur-[130px]"
-                        style={{ background: 'rgba(34,197,94,0.1)' }}
-                    />
-                    <div
-                        aria-hidden="true"
-                        className="pointer-events-none absolute right-[-10%] bottom-[-10%] h-[300px] w-[300px] rounded-full blur-[100px]"
-                        style={{ background: 'rgba(34,197,94,0.06)' }}
-                    />
 
-                    {/* Logo */}
                     <Link
                         href={home()}
                         className="relative z-10 flex items-center gap-3"
                     >
-                        <div className="flex aspect-square size-9 items-center justify-center rounded-md bg-green-500">
-                            <AppLogoIcon className="size-5 fill-black" />
-                        </div>
-                        <span className="text-sm font-semibold">Veltro</span>
+                        <span className="flex size-9 items-center justify-center rounded-md bg-[#48d17a]">
+                            <AppLogoIcon className="size-5 fill-[#07110b]" />
+                        </span>
+                        <span className="text-sm font-semibold tracking-wide">
+                            Veltro
+                        </span>
                     </Link>
 
-                    {/* Tagline + features */}
-                    <div className="relative z-10">
-                        <h2 className="font-display mb-4 text-5xl font-bold uppercase leading-none xl:text-6xl">
-                            Tu equipo.
-                            <br />
-                            <span className="text-green-400">Sin caos.</span>
+                    <div className="relative z-10 max-w-md">
+                        <span className="mb-5 inline-flex items-center gap-2 rounded-md border border-[#48d17a]/25 bg-[#48d17a]/10 px-3 py-1.5 text-xs font-semibold text-[#8df0ad]">
+                            <CheckCircle2 className="h-3.5 w-3.5" />
+                            Hecho en Uruguay para capitanes amateur
+                        </span>
+
+                        <h2 className="text-5xl leading-[1.02] font-semibold tracking-normal xl:text-6xl">
+                            Gestioná tu equipo sin depender del grupo de
+                            WhatsApp.
                         </h2>
-                        <p className="mb-10 max-w-xs text-sm leading-relaxed text-white/50">
-                            La plataforma para equipos de fútbol amateur en
-                            Uruguay. Partidos, asistencia y torneos en un solo
-                            lugar.
+
+                        <p className="mt-5 max-w-sm text-sm leading-6 text-white/55">
+                            Partidos, asistencia, estadísticas y torneos en una
+                            experiencia simple para capitanes y clara para
+                            jugadores.
                         </p>
-                        <div className="flex flex-col gap-4">
+
+                        <div className="mt-9 grid gap-3">
                             {features.map(({ icon: Icon, text }) => (
-                                <div key={text} className="flex items-center gap-3">
-                                    <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-lg bg-green-500/[0.15] text-green-400">
-                                        <Icon className="h-3.5 w-3.5" />
+                                <div
+                                    key={text}
+                                    className="flex items-center gap-3 rounded-lg border border-white/[0.08] bg-[#101312]/75 px-3 py-3"
+                                >
+                                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[#48d17a]/10 text-[#48d17a]">
+                                        <Icon className="h-4 w-4" />
                                     </span>
-                                    <span className="text-sm text-white/55">
+                                    <span className="text-sm text-white/58">
                                         {text}
                                     </span>
                                 </div>
@@ -118,56 +96,52 @@ export default function AuthSimpleLayout({
                         </div>
                     </div>
 
-                    {/* Bottom badge */}
-                    <div className="relative z-10">
-                        <span className="inline-flex items-center gap-2 rounded-full border border-green-500/25 bg-green-500/[0.1] px-3 py-1 text-xs font-medium text-green-400">
-                            <span className="relative flex h-1.5 w-1.5">
-                                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
-                                <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-green-400" />
+                    <p className="relative z-10 text-xs text-white/38">
+                        Gratis, sin publicidad y preparado para fútbol 11, 7, 5
+                        y futsal.
+                    </p>
+                </aside>
+
+                <section className="relative flex min-h-svh items-center justify-center overflow-hidden px-4 py-10 sm:px-6 lg:px-12">
+                    <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.035),rgba(255,255,255,0))]" />
+                    <PitchLines />
+
+                    <div className="relative z-10 w-full max-w-[430px]">
+                        <Link
+                            href={home()}
+                            className="mb-8 flex items-center justify-center gap-3 lg:hidden"
+                        >
+                            <span className="flex size-9 items-center justify-center rounded-md bg-[#48d17a]">
+                                <AppLogoIcon className="size-5 fill-[#07110b]" />
                             </span>
-                            Hecho en Uruguay · 100% Gratis
-                        </span>
-                    </div>
-                </div>
+                            <span className="text-sm font-semibold tracking-wide">
+                                Veltro
+                            </span>
+                        </Link>
 
-                {/* Right: form panel */}
-                <div
-                    className="flex flex-1 flex-col items-center justify-center p-6 md:p-10 lg:p-12"
-                    style={{ borderLeft: '1px solid rgba(255,255,255,0.06)' }}
-                >
-                    {/* Mobile logo */}
-                    <Link
-                        href={home()}
-                        className="mb-10 flex items-center gap-2 lg:hidden"
-                    >
-                        <div className="flex aspect-square size-8 items-center justify-center rounded-md bg-green-500">
-                            <AppLogoIcon className="size-5 fill-black" />
-                        </div>
-                        <span className="text-sm font-semibold">Veltro</span>
-                    </Link>
+                        <div className="rounded-lg border border-white/[0.08] bg-[#171b19]/96 p-6 shadow-[0_28px_90px_rgba(0,0,0,0.34)] sm:p-8">
+                            <div className="mb-7">
+                                <h1 className="text-3xl leading-tight font-semibold tracking-normal">
+                                    {title}
+                                </h1>
+                                <p className="mt-2 text-sm leading-6 text-white/55">
+                                    {description}
+                                </p>
+                            </div>
 
-                    <div className="w-full max-w-sm">
-                        <div className="mb-8">
-                            <h1 className="font-display mb-2 text-4xl font-bold uppercase leading-none">
-                                {title}
-                            </h1>
-                            <p className="text-sm text-white/50">
-                                {description}
-                            </p>
+                            <div className="auth-form-surface">{children}</div>
                         </div>
 
-                        {children}
-
-                        <div className="mt-8 text-center">
+                        <div className="mt-6 text-center">
                             <Link
                                 href={home()}
-                                className="text-xs text-white/30 transition-colors hover:text-white/60"
+                                className="text-xs font-medium text-white/40 transition-colors hover:text-white/70"
                             >
-                                ← Volver al inicio
+                                Volver al inicio
                             </Link>
                         </div>
                     </div>
-                </div>
+                </section>
             </div>
         </>
     );

--- a/resources/js/pages/auth/forgot-password.tsx
+++ b/resources/js/pages/auth/forgot-password.tsx
@@ -20,7 +20,7 @@ export default function ForgotPassword({ status }: { status?: string }) {
             <Head title="Olvidé mi contraseña" />
 
             {status && (
-                <div className="mb-4 text-center text-sm font-medium text-green-600">
+                <div className="mb-4 rounded-md border border-[#48d17a]/25 bg-[#48d17a]/10 px-3 py-2 text-center text-sm font-medium text-[#8df0ad]">
                     {status}
                 </div>
             )}

--- a/resources/js/pages/auth/login.tsx
+++ b/resources/js/pages/auth/login.tsx
@@ -96,7 +96,7 @@ export default function Login({
                 <Button
                     type="button"
                     variant="outline"
-                    className="w-full border-white/20 bg-transparent text-white hover:bg-white/10 hover:text-white"
+                    className="w-full"
                     onClick={() =>
                         window.location.assign('/auth/google/redirect')
                     }
@@ -124,10 +124,7 @@ export default function Login({
                         <span className="w-full border-t" />
                     </div>
                     <div className="relative flex justify-center text-xs uppercase">
-                        <span
-                            className="px-2 text-white/40"
-                            style={{ background: '#060d17' }}
-                        >
+                        <span className="bg-[#171b19] px-2 text-white/40">
                             O continuar con
                         </span>
                     </div>
@@ -222,7 +219,7 @@ export default function Login({
 
                                 <Button
                                     type="submit"
-                                    className="mt-4 w-full bg-green-500 font-semibold text-black hover:bg-green-400"
+                                    className="mt-4 w-full"
                                     tabIndex={4}
                                     disabled={processing}
                                     data-test="login-button"

--- a/resources/js/pages/auth/register.tsx
+++ b/resources/js/pages/auth/register.tsx
@@ -141,7 +141,7 @@ export default function Register() {
                 <Button
                     type="button"
                     variant="outline"
-                    className="w-full border-white/20 bg-transparent text-white hover:bg-white/10 hover:text-white"
+                    className="w-full"
                     onClick={() =>
                         window.location.assign('/auth/google/redirect')
                     }
@@ -169,10 +169,7 @@ export default function Register() {
                         <span className="w-full border-t" />
                     </div>
                     <div className="relative flex justify-center text-xs uppercase">
-                        <span
-                            className="px-2 text-white/40"
-                            style={{ background: '#060d17' }}
-                        >
+                        <span className="bg-[#171b19] px-2 text-white/40">
                             O continuar con
                         </span>
                     </div>
@@ -319,7 +316,7 @@ export default function Register() {
 
                                 <Button
                                     type="submit"
-                                    className="mt-2 w-full bg-green-500 font-semibold text-black hover:bg-green-400"
+                                    className="mt-2 w-full"
                                     tabIndex={5}
                                     data-test="register-user-button"
                                 >

--- a/resources/js/pages/auth/two-factor-challenge.tsx
+++ b/resources/js/pages/auth/two-factor-challenge.tsx
@@ -114,7 +114,7 @@ export default function TwoFactorChallenge() {
                                 <span>o puedes </span>
                                 <button
                                     type="button"
-                                    className="cursor-pointer text-foreground underline decoration-neutral-300 underline-offset-4 transition-colors duration-300 ease-out hover:decoration-current! dark:decoration-neutral-500"
+                                    className="cursor-pointer underline underline-offset-4 transition-colors duration-300 ease-out"
                                     onClick={() =>
                                         toggleRecoveryMode(clearErrors)
                                     }

--- a/resources/js/pages/auth/verify-email.tsx
+++ b/resources/js/pages/auth/verify-email.tsx
@@ -16,7 +16,7 @@ export default function VerifyEmail({ status }: { status?: string }) {
             <Head title="Verificación de correo" />
 
             {status === 'verification-link-sent' && (
-                <div className="mb-4 text-center text-sm font-medium text-green-600">
+                <div className="mb-4 rounded-md border border-[#48d17a]/25 bg-[#48d17a]/10 px-3 py-2 text-center text-sm font-medium text-[#8df0ad]">
                     Se ha enviado un nuevo enlace de verificación al correo
                     electrónico que proporcionaste durante el registro.
                 </div>
@@ -25,7 +25,7 @@ export default function VerifyEmail({ status }: { status?: string }) {
             <Form {...send.form()} className="space-y-6 text-center">
                 {({ processing }) => (
                     <>
-                        <Button disabled={processing} variant="secondary">
+                        <Button disabled={processing}>
                             {processing && <Spinner />}
                             Reenviar correo de verificación
                         </Button>

--- a/resources/js/pages/landing-page.tsx
+++ b/resources/js/pages/landing-page.tsx
@@ -14,11 +14,14 @@ import {
     ArrowRight,
     BellRing,
     CalendarDays,
-    Globe,
+    CheckCircle2,
+    ShieldCheck,
     Trophy,
     Users,
 } from 'lucide-react';
 import type { ElementType, ReactNode } from 'react';
+
+const accent = '#48d17a';
 
 const PitchLines = () => (
     <svg
@@ -26,28 +29,28 @@ const PitchLines = () => (
         className="pointer-events-none absolute inset-0 h-full w-full"
         viewBox="0 0 1200 700"
         preserveAspectRatio="xMidYMid slice"
-        style={{ opacity: 0.05 }}
+        style={{ opacity: 0.045 }}
     >
-        <g fill="none" stroke="white" strokeWidth="1.5">
-            <rect x="80" y="60" width="1040" height="580" />
-            <line x1="600" y1="60" x2="600" y2="640" />
-            <circle cx="600" cy="350" r="100" />
+        <g fill="none" stroke="white" strokeWidth="1.4">
+            <rect x="90" y="70" width="1020" height="560" rx="8" />
+            <line x1="600" y1="70" x2="600" y2="630" />
+            <circle cx="600" cy="350" r="96" />
             <circle cx="600" cy="350" r="4" fill="white" stroke="none" />
-            <rect x="80" y="210" width="165" height="280" />
-            <rect x="955" y="210" width="165" height="280" />
-            <rect x="80" y="280" width="55" height="140" />
-            <rect x="1065" y="280" width="55" height="140" />
-            <path d="M80,60 Q100,60 100,80" />
-            <path d="M1120,60 Q1100,60 1100,80" />
-            <path d="M80,640 Q100,640 100,620" />
-            <path d="M1120,640 Q1100,640 1100,620" />
-            <circle cx="176" cy="350" r="4" fill="white" stroke="none" />
-            <circle cx="1024" cy="350" r="4" fill="white" stroke="none" />
+            <rect x="90" y="215" width="164" height="270" rx="4" />
+            <rect x="946" y="215" width="164" height="270" rx="4" />
+            <rect x="90" y="285" width="56" height="130" rx="3" />
+            <rect x="1054" y="285" width="56" height="130" rx="3" />
         </g>
     </svg>
 );
 
-const DarkBentoCard = ({
+const SectionLabel = ({ children }: { children: ReactNode }) => (
+    <span className="text-xs font-semibold tracking-[0.18em] text-[#48d17a] uppercase">
+        {children}
+    </span>
+);
+
+const ProductCard = ({
     children,
     className = '',
 }: {
@@ -55,26 +58,103 @@ const DarkBentoCard = ({
     className?: string;
 }) => (
     <div
-        className={`group relative flex flex-col overflow-hidden rounded-3xl border border-white/[0.08] bg-white/[0.04] p-8 backdrop-blur-sm transition-colors hover:border-white/[0.14] hover:bg-white/[0.06] sm:p-10 ${className}`}
+        className={`flex h-full flex-col rounded-lg border border-white/[0.08] bg-[#171b19] p-6 shadow-[0_18px_70px_rgba(0,0,0,0.28)] ${className}`}
     >
         {children}
     </div>
 );
 
-const BentoIcon = ({
+const FeatureIcon = ({
     icon: Icon,
     label,
 }: {
     icon: ElementType;
     label: string;
 }) => (
-    <div className="mb-6 flex items-center gap-3">
-        <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-green-500/[0.15] text-green-400">
+    <div className="mb-5 flex items-center gap-3">
+        <span className="flex h-9 w-9 items-center justify-center rounded-md border border-[#48d17a]/20 bg-[#48d17a]/10 text-[#48d17a]">
             <Icon className="h-4 w-4" />
         </span>
-        <span className="text-sm font-medium text-white/40">{label}</span>
+        <span className="text-xs font-semibold tracking-[0.16em] text-white/40 uppercase">
+            {label}
+        </span>
     </div>
 );
+
+const stats = [
+    { value: '500+', label: 'Partidos organizados' },
+    { value: '80+', label: 'Equipos registrados' },
+    { value: '1.200+', label: 'Jugadores activos' },
+];
+
+const features = [
+    {
+        icon: CalendarDays,
+        label: 'Partidos',
+        title: 'Organizá partidos sin perseguir mensajes',
+        description:
+            'Centralizá fecha, cancha, rival, formato y marcador en una vista clara para todo el plantel.',
+        preview: <LandingMatchPreview />,
+        className: 'lg:col-span-7',
+    },
+    {
+        icon: Users,
+        label: 'Disponibilidad',
+        title: 'Confirmaciones visibles antes de llegar a la cancha',
+        description:
+            'Sabé quién va, quién falta responder y cuándo necesitás mover suplentes.',
+        preview: <LandingAvailabilityPreview />,
+        className: 'lg:col-span-5',
+    },
+    {
+        icon: BellRing,
+        label: 'Recordatorios',
+        title: 'Menos ruido, más respuestas',
+        description:
+            'Recordatorios puntuales para quienes todavía no confirmaron asistencia al próximo partido.',
+        preview: (
+            <div className="space-y-3 rounded-lg border border-white/[0.08] bg-[#101312] p-4">
+                <div className="flex items-center gap-3">
+                    <span className="flex h-10 w-10 items-center justify-center rounded-md bg-[#48d17a]/10 text-[#48d17a]">
+                        <BellRing className="h-4 w-4" />
+                    </span>
+                    <div>
+                        <span className="block text-sm font-medium text-white">
+                            Partido mañana
+                        </span>
+                        <span className="text-xs text-white/45">
+                            3 jugadores pendientes
+                        </span>
+                    </div>
+                </div>
+                <div className="grid grid-cols-3 gap-2">
+                    {['Voy', 'Tal vez', 'No voy'].map((item, index) => (
+                        <span
+                            key={item}
+                            className={`rounded-md border px-3 py-2 text-center text-xs font-semibold ${
+                                index === 0
+                                    ? 'border-[#48d17a]/30 bg-[#48d17a]/10 text-[#48d17a]'
+                                    : 'border-white/[0.08] bg-white/[0.035] text-white/50'
+                            }`}
+                        >
+                            {item}
+                        </span>
+                    ))}
+                </div>
+            </div>
+        ),
+        className: 'lg:col-span-5',
+    },
+    {
+        icon: Trophy,
+        label: 'Torneos',
+        title: 'Competí con estructura de torneo real',
+        description:
+            'Inscribí equipos, seguí cupos disponibles y mantené el calendario competitivo ordenado.',
+        preview: <LandingTournamentPreview />,
+        className: 'lg:col-span-7',
+    },
+];
 
 export default function LandingPage({
     canRegister = true,
@@ -84,39 +164,45 @@ export default function LandingPage({
     const { auth } = usePage<SharedData>().props;
     const isLoggedIn = !!auth?.user;
 
-    const ctaButtons = isLoggedIn ? (
+    const primaryCta = isLoggedIn ? (
         <Button
             size="lg"
-            className="rounded-xl bg-green-500 font-semibold text-black hover:bg-green-400"
+            className="h-11 rounded-md bg-[#48d17a] px-5 font-semibold text-[#07110b] shadow-[0_12px_34px_rgba(72,209,122,0.22)] hover:bg-[#60df8b]"
             asChild
         >
             <Link href={teams.index().url}>
-                Ver Equipos
+                Ver equipos
                 <ArrowRight className="ml-2 h-4 w-4" />
             </Link>
         </Button>
     ) : (
-        <>
-            {canRegister && (
-                <Button
-                    size="lg"
-                    className="rounded-xl bg-green-500 font-semibold text-black hover:bg-green-400"
-                    asChild
-                >
-                    <Link href={register().url}>
-                        Comenzar gratis
-                        <ArrowRight className="ml-2 h-4 w-4" />
-                    </Link>
-                </Button>
-            )}
+        canRegister && (
             <Button
                 size="lg"
-                variant="outline"
-                className="rounded-xl border-white/20 bg-transparent text-white hover:bg-white/10 hover:text-white"
+                className="h-11 rounded-md bg-[#48d17a] px-5 font-semibold text-[#07110b] shadow-[0_12px_34px_rgba(72,209,122,0.22)] hover:bg-[#60df8b]"
                 asChild
             >
-                <Link href={login().url}>Iniciar sesión</Link>
+                <Link href={register().url}>
+                    Comenzar gratis
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                </Link>
             </Button>
+        )
+    );
+
+    const ctaButtons = (
+        <>
+            {primaryCta}
+            {!isLoggedIn && (
+                <Button
+                    size="lg"
+                    variant="outline"
+                    className="h-11 rounded-md border-white/15 bg-white/[0.03] px-5 text-white hover:bg-white/[0.07] hover:text-white"
+                    asChild
+                >
+                    <Link href={login().url}>Iniciar sesión</Link>
+                </Button>
+            )}
         </>
     );
 
@@ -124,36 +210,26 @@ export default function LandingPage({
         <>
             <Head>
                 <title>
-                    Veltro — Plataforma para equipos de fútbol amateur en
+                    Veltro - Plataforma para equipos de futbol amateur en
                     Uruguay
                 </title>
                 <meta
                     name="description"
-                    content="Gestioná tu equipo, organizá partidos, seguí estadísticas y conectá con otros equipos de fútbol amateur en Uruguay. Todo en un solo lugar."
+                    content="Gestiona tu equipo, organiza partidos, confirma asistencia y conecta con otros equipos de futbol amateur en Uruguay."
                 />
             </Head>
 
-            <div
-                className="flex min-h-screen flex-col text-white"
-                style={{ background: '#060d17' }}
-            >
-                {/* Header */}
-                <header
-                    className="sticky top-0 z-50 backdrop-blur-xl"
-                    style={{
-                        background: 'rgba(6,13,23,0.88)',
-                        borderBottom: '1px solid rgba(255,255,255,0.07)',
-                    }}
-                >
-                    <div className="container mx-auto flex h-16 items-center justify-between px-4 md:px-6">
+            <div className="min-h-screen bg-[#101312] text-white">
+                <header className="sticky top-0 z-50 border-b border-white/[0.08] bg-[#101312]/90 backdrop-blur-xl">
+                    <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 md:px-6">
                         <Link
                             href={home().url}
-                            className="flex items-center gap-2"
+                            className="flex items-center gap-3"
                         >
-                            <div className="flex aspect-square size-8 items-center justify-center rounded-md bg-green-500">
-                                <AppLogoIcon className="size-5 fill-black" />
-                            </div>
-                            <span className="ml-1 text-sm font-semibold text-white">
+                            <span className="flex size-8 items-center justify-center rounded-md bg-[#48d17a]">
+                                <AppLogoIcon className="size-5 fill-[#07110b]" />
+                            </span>
+                            <span className="text-sm font-semibold tracking-wide text-white">
                                 Veltro
                             </span>
                         </Link>
@@ -162,11 +238,11 @@ export default function LandingPage({
                             {isLoggedIn ? (
                                 <Button
                                     size="sm"
-                                    className="bg-green-500 font-medium text-black hover:bg-green-400"
+                                    className="h-9 rounded-md bg-[#48d17a] px-3 font-semibold text-[#07110b] hover:bg-[#60df8b]"
                                     asChild
                                 >
                                     <Link href={teams.index().url}>
-                                        Ver Equipos
+                                        Ver equipos
                                         <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
                                     </Link>
                                 </Button>
@@ -175,7 +251,7 @@ export default function LandingPage({
                                     <Button
                                         size="sm"
                                         variant="ghost"
-                                        className="hidden text-white/60 hover:bg-white/10 hover:text-white sm:inline-flex"
+                                        className="hidden h-9 rounded-md px-3 text-white/60 hover:bg-white/[0.06] hover:text-white sm:inline-flex"
                                         asChild
                                     >
                                         <Link href={login().url}>
@@ -185,7 +261,7 @@ export default function LandingPage({
                                     {canRegister && (
                                         <Button
                                             size="sm"
-                                            className="bg-green-500 font-medium text-black hover:bg-green-400"
+                                            className="h-9 rounded-md bg-[#48d17a] px-3 font-semibold text-[#07110b] hover:bg-[#60df8b]"
                                             asChild
                                         >
                                             <Link href={register().url}>
@@ -199,374 +275,235 @@ export default function LandingPage({
                     </div>
                 </header>
 
-                {/* Hero */}
-                <section className="relative overflow-hidden pt-20 pb-24 md:pt-28 md:pb-32">
-                    <PitchLines />
-                    <div
-                        aria-hidden="true"
-                        className="pointer-events-none absolute top-[-20%] left-[5%] h-[700px] w-[700px] rounded-full blur-[140px]"
-                        style={{ background: 'rgba(34,197,94,0.09)' }}
-                    />
-                    <div
-                        aria-hidden="true"
-                        className="pointer-events-none absolute right-[0%] bottom-[-10%] h-[400px] w-[400px] rounded-full blur-[120px]"
-                        style={{ background: 'rgba(34,197,94,0.06)' }}
-                    />
-
-                    <div className="container mx-auto max-w-7xl px-4 md:px-6">
-                        <div className="flex flex-col items-center gap-16 lg:flex-row lg:items-center lg:gap-16">
-                            {/* Text column */}
-                            <div className="flex max-w-2xl flex-1 flex-col gap-7 text-center lg:text-left">
-                                <div className="flex justify-center lg:justify-start">
-                                    <span className="inline-flex items-center gap-2 rounded-full border border-green-500/25 bg-green-500/[0.1] px-3 py-1 text-xs font-medium text-green-400">
-                                        <span className="relative flex h-1.5 w-1.5">
-                                            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
-                                            <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-green-400" />
-                                        </span>
-                                        Hecho en Uruguay · 100% Gratis
+                <main>
+                    <section className="relative overflow-hidden border-b border-white/[0.08] bg-[#101312]">
+                        <PitchLines />
+                        <div className="relative mx-auto grid max-w-7xl items-center gap-12 px-4 py-18 md:px-6 md:py-24 lg:grid-cols-[1.02fr_0.98fr] lg:gap-16">
+                            <div className="max-w-2xl text-center lg:text-left">
+                                <div className="mb-6 flex justify-center lg:justify-start">
+                                    <span className="inline-flex items-center gap-2 rounded-md border border-[#48d17a]/25 bg-[#48d17a]/10 px-3 py-1.5 text-xs font-semibold text-[#8df0ad]">
+                                        <ShieldCheck className="h-3.5 w-3.5" />
+                                        Hecho en Uruguay para capitanes amateur
                                     </span>
                                 </div>
 
-                                <h1 className="font-display text-[5.5rem] font-bold uppercase leading-none tracking-tight sm:text-[7rem] lg:text-[6.5rem] xl:text-[8rem]">
-                                    Tu equipo.
-                                    <br />
-                                    <span className="text-green-400">
-                                        Sin caos.
-                                    </span>
+                                <h1 className="text-5xl leading-[0.98] font-semibold tracking-normal text-white sm:text-6xl lg:text-7xl">
+                                    Gestioná tu equipo sin depender del grupo de
+                                    WhatsApp.
                                 </h1>
 
-                                <p className="mx-auto max-w-xl text-lg leading-relaxed text-white/55 lg:mx-0">
-                                    Veltro reemplaza los grupos de WhatsApp con
-                                    una plataforma para capitanes: partidos,
-                                    asistencia, estadísticas y torneos en un
-                                    solo lugar.
+                                <p className="mx-auto mt-6 max-w-xl text-base leading-7 text-white/60 sm:text-lg lg:mx-0">
+                                    Veltro reúne partidos, disponibilidad,
+                                    estadísticas y torneos en una experiencia
+                                    simple para capitanes y clara para
+                                    jugadores.
                                 </p>
 
-                                <div className="flex flex-col justify-center gap-3 sm:flex-row lg:justify-start">
+                                <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row lg:justify-start">
                                     {ctaButtons}
                                 </div>
 
-                                <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm text-white/35 lg:justify-start">
+                                <div className="mt-8 grid gap-3 text-left text-sm text-white/55 sm:grid-cols-3">
                                     {[
                                         'Sin publicidad',
                                         'Sin tarjeta de crédito',
                                         'Fútbol 11, 7, 5 y futsal',
                                     ].map((text) => (
-                                        <span
+                                        <div
                                             key={text}
-                                            className="flex items-center gap-2"
+                                            className="flex items-center gap-2 rounded-md border border-white/[0.08] bg-white/[0.025] px-3 py-2"
                                         >
-                                            <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
-                                            {text}
-                                        </span>
+                                            <CheckCircle2
+                                                className="h-4 w-4 shrink-0"
+                                                style={{ color: accent }}
+                                            />
+                                            <span>{text}</span>
+                                        </div>
                                     ))}
                                 </div>
                             </div>
 
-                            {/* Preview column */}
-                            <div className="relative w-full max-w-sm flex-shrink-0 lg:max-w-md">
-                                <div
-                                    style={{
-                                        filter: 'drop-shadow(0 30px 80px rgba(34,197,94,0.18))',
-                                    }}
-                                >
+                            <div className="mx-auto w-full max-w-[520px] lg:mx-0">
+                                <div className="rounded-lg border border-white/[0.08] bg-[#171b19] p-3 shadow-[0_30px_100px_rgba(0,0,0,0.34)]">
                                     <LandingMatchPreview />
                                 </div>
-                                <div className="absolute -top-5 -right-5 hidden rounded-2xl border border-white/10 bg-white/[0.08] px-4 py-3 backdrop-blur-sm lg:block">
-                                    <span className="font-display block text-3xl font-bold leading-none text-green-400">
-                                        9/11
-                                    </span>
-                                    <span className="text-xs text-white/50">
-                                        confirmados
-                                    </span>
-                                </div>
-                                <div className="absolute -bottom-5 -left-5 hidden rounded-2xl border border-white/10 bg-white/[0.08] px-4 py-3 backdrop-blur-sm lg:block">
-                                    <span className="block text-sm font-medium">
-                                        Recordatorio enviado
-                                    </span>
-                                    <span className="text-xs text-white/50">
-                                        a 3 jugadores
-                                    </span>
+                                <div className="mt-3 grid grid-cols-2 gap-3">
+                                    <div className="rounded-lg border border-white/[0.08] bg-[#171b19] p-4">
+                                        <span className="block text-3xl font-semibold text-[#48d17a]">
+                                            9/11
+                                        </span>
+                                        <span className="text-xs text-white/50">
+                                            jugadores confirmados
+                                        </span>
+                                    </div>
+                                    <div className="rounded-lg border border-white/[0.08] bg-[#171b19] p-4">
+                                        <span className="block text-sm font-semibold text-white">
+                                            Recordatorio enviado
+                                        </span>
+                                        <span className="text-xs text-white/50">
+                                            a 3 jugadores pendientes
+                                        </span>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                </section>
+                    </section>
 
-                {/* Stats strip */}
-                <div
-                    className="py-12"
-                    style={{
-                        borderTop: '1px solid rgba(255,255,255,0.06)',
-                        borderBottom: '1px solid rgba(255,255,255,0.06)',
-                        background: 'rgba(255,255,255,0.02)',
-                    }}
-                >
-                    <div className="container mx-auto max-w-4xl px-4">
-                        <div className="grid grid-cols-1 gap-8 text-center sm:grid-cols-3">
-                            {[
-                                {
-                                    value: '500+',
-                                    label: 'Partidos organizados',
-                                },
-                                { value: '80+', label: 'Equipos registrados' },
-                                {
-                                    value: '1.200+',
-                                    label: 'Jugadores activos',
-                                },
-                            ].map(({ value, label }) => (
+                    <section className="border-b border-white/[0.08] bg-[#141815] py-10">
+                        <div className="mx-auto grid max-w-5xl gap-6 px-4 text-center sm:grid-cols-3 md:px-6">
+                            {stats.map(({ value, label }) => (
                                 <div
                                     key={label}
-                                    className="flex flex-col gap-2"
+                                    className="rounded-lg border border-white/[0.08] bg-[#101312] px-5 py-6"
                                 >
-                                    <span className="font-display text-5xl font-bold leading-none text-green-400">
+                                    <span className="block text-4xl font-semibold tracking-normal text-[#48d17a]">
                                         {value}
                                     </span>
-                                    <span className="text-sm text-white/40">
+                                    <span className="mt-2 block text-sm text-white/50">
                                         {label}
                                     </span>
                                 </div>
                             ))}
                         </div>
-                    </div>
-                </div>
+                    </section>
 
-                {/* Features bento */}
-                <section className="py-24 md:py-32">
-                    <div className="container mx-auto max-w-6xl px-4">
-                        <div className="mx-auto mb-16 flex max-w-2xl flex-col items-center gap-4 text-center">
-                            <span className="text-xs font-semibold tracking-[0.2em] text-green-500 uppercase">
-                                Qué podés hacer
-                            </span>
-                            <h2 className="font-display text-5xl font-bold uppercase leading-none tracking-tight sm:text-6xl">
-                                Diseñado para capitanes,
-                                <br />
-                                <span className="text-white/35">
-                                    pensado para jugadores.
-                                </span>
-                            </h2>
+                    <section className="py-20 md:py-28">
+                        <div className="mx-auto max-w-7xl px-4 md:px-6">
+                            <div className="mb-12 grid gap-4 lg:grid-cols-[0.72fr_1fr] lg:items-end">
+                                <div>
+                                    <SectionLabel>Qué podés hacer</SectionLabel>
+                                    <h2 className="mt-4 max-w-xl text-4xl leading-tight font-semibold sm:text-5xl">
+                                        Una plataforma ordenada para cada semana
+                                        de partido.
+                                    </h2>
+                                </div>
+                                <p className="max-w-2xl text-base leading-7 text-white/55 lg:justify-self-end">
+                                    Diseñada para reducir fricción operativa:
+                                    menos mensajes repetidos, menos dudas de
+                                    asistencia y mejor trazabilidad del equipo.
+                                </p>
+                            </div>
+
+                            <div className="grid gap-4 lg:grid-cols-12">
+                                {features.map(
+                                    ({
+                                        icon,
+                                        label,
+                                        title,
+                                        description,
+                                        preview,
+                                        className,
+                                    }) => (
+                                        <ProductCard
+                                            key={title}
+                                            className={className}
+                                        >
+                                            <FeatureIcon
+                                                icon={icon}
+                                                label={label}
+                                            />
+                                            <div className="grid flex-1 gap-6 md:grid-cols-[0.86fr_1.14fr] md:items-center">
+                                                <div>
+                                                    <h3 className="text-2xl leading-tight font-semibold text-white">
+                                                        {title}
+                                                    </h3>
+                                                    <p className="mt-3 text-sm leading-6 text-white/50">
+                                                        {description}
+                                                    </p>
+                                                </div>
+                                                <div className="min-w-0">
+                                                    {preview}
+                                                </div>
+                                            </div>
+                                        </ProductCard>
+                                    ),
+                                )}
+                            </div>
                         </div>
+                    </section>
 
-                        <div className="grid gap-4 lg:grid-cols-12 lg:gap-5">
-                            <DarkBentoCard className="lg:col-span-8">
-                                <BentoIcon
-                                    icon={CalendarDays}
-                                    label="Partidos"
-                                />
-                                <h3 className="font-display mb-3 text-3xl font-bold uppercase leading-none sm:text-4xl">
-                                    Organizá partidos en segundos
-                                </h3>
-                                <p className="mb-8 max-w-md text-sm text-white/45">
-                                    Fecha, cancha, rival y marcador — todo en
-                                    una tarjeta que los jugadores entienden al
-                                    instante.
-                                </p>
-                                <div className="relative mt-auto">
-                                    <div
-                                        className="absolute inset-0 rounded-xl"
-                                        style={{
-                                            background:
-                                                'radial-gradient(ellipse at center, rgba(34,197,94,0.07) 0%, transparent 70%)',
-                                        }}
-                                    />
-                                    <LandingMatchPreview />
-                                </div>
-                            </DarkBentoCard>
+                    <section className="border-y border-white/[0.08] bg-[#141815] py-20 md:py-24">
+                        <div className="mx-auto max-w-7xl px-4 md:px-6">
+                            <div className="mb-12 max-w-2xl">
+                                <SectionLabel>Cómo funciona</SectionLabel>
+                                <h2 className="mt-4 text-4xl leading-tight font-semibold sm:text-5xl">
+                                    De crear el equipo a jugar en minutos.
+                                </h2>
+                            </div>
 
-                            <DarkBentoCard className="lg:col-span-4">
-                                <BentoIcon
-                                    icon={BellRing}
-                                    label="Recordatorios"
-                                />
-                                <h3 className="font-display mb-3 text-3xl font-bold uppercase leading-none">
-                                    Nadie se olvida del partido
-                                </h3>
-                                <p className="mb-8 text-sm text-white/45">
-                                    Recordatorios automáticos 48 horas antes a
-                                    quien no confirmó.
-                                </p>
-                                <div className="mt-auto space-y-3">
-                                    <div className="flex items-center gap-3 rounded-xl border border-white/[0.08] bg-white/[0.05] p-4">
-                                        <span className="flex h-10 w-10 items-center justify-center rounded-full bg-green-500/[0.15] text-green-400">
-                                            <BellRing className="h-4 w-4" />
-                                        </span>
-                                        <div className="flex flex-col gap-0.5">
-                                            <span className="text-sm font-medium">
-                                                Partido mañana
-                                            </span>
-                                            <span className="text-xs text-white/40">
-                                                ¿Venís a jugar?
-                                            </span>
-                                        </div>
-                                    </div>
-                                    <div className="flex gap-2">
-                                        <span className="flex-1 rounded-lg border border-green-500/30 bg-green-500/[0.15] px-3 py-2.5 text-center text-xs font-semibold text-green-400">
-                                            Voy
-                                        </span>
-                                        <span className="flex-1 rounded-lg border border-white/[0.08] bg-white/[0.05] px-3 py-2.5 text-center text-xs font-medium text-white/35">
-                                            Tal vez
-                                        </span>
-                                        <span className="flex-1 rounded-lg border border-white/[0.08] bg-white/[0.05] px-3 py-2.5 text-center text-xs font-medium text-white/35">
-                                            No
-                                        </span>
-                                    </div>
-                                </div>
-                            </DarkBentoCard>
-
-                            <DarkBentoCard className="lg:col-span-5">
-                                <BentoIcon
-                                    icon={Users}
-                                    label="Disponibilidad"
-                                />
-                                <h3 className="font-display mb-3 text-3xl font-bold uppercase leading-none">
-                                    Sabé quién va antes del silbato
-                                </h3>
-                                <p className="mb-8 text-sm text-white/45">
-                                    Panorama completo de tu plantel con alertas
-                                    si no llegás al mínimo.
-                                </p>
-                                <div className="mt-auto">
-                                    <LandingAvailabilityPreview />
-                                </div>
-                            </DarkBentoCard>
-
-                            <DarkBentoCard className="lg:col-span-7">
-                                <BentoIcon icon={Trophy} label="Torneos" />
-                                <h3 className="font-display mb-3 text-3xl font-bold uppercase leading-none sm:text-4xl">
-                                    Competí en torneos organizados
-                                </h3>
-                                <p className="mb-8 max-w-sm text-sm text-white/45">
-                                    Inscribite, seguí la capacidad en tiempo
-                                    real y jugá contra equipos de tu zona.
-                                </p>
-                                <div className="relative mt-auto">
-                                    <div
-                                        className="absolute inset-0 rounded-xl"
-                                        style={{
-                                            background:
-                                                'radial-gradient(ellipse at center, rgba(245,158,11,0.06) 0%, transparent 70%)',
-                                        }}
-                                    />
-                                    <LandingTournamentPreview />
-                                </div>
-                            </DarkBentoCard>
-                        </div>
-                    </div>
-                </section>
-
-                {/* How it works */}
-                <section
-                    className="py-24 md:py-32"
-                    style={{
-                        borderTop: '1px solid rgba(255,255,255,0.06)',
-                        borderBottom: '1px solid rgba(255,255,255,0.06)',
-                        background: 'rgba(255,255,255,0.015)',
-                    }}
-                >
-                    <div className="container mx-auto max-w-6xl px-4">
-                        <div className="mx-auto mb-16 flex max-w-2xl flex-col items-center gap-4 text-center">
-                            <span className="text-xs font-semibold tracking-[0.2em] text-green-500 uppercase">
-                                Cómo funciona
-                            </span>
-                            <h2 className="font-display text-5xl font-bold uppercase leading-none tracking-tight sm:text-6xl">
-                                De cero a jugar en minutos.
-                            </h2>
-                        </div>
-
-                        <div className="relative grid gap-10 md:grid-cols-3 md:gap-8">
-                            <div
-                                aria-hidden="true"
-                                className="absolute top-7 right-0 left-0 hidden h-px md:block"
-                                style={{
-                                    background:
-                                        'linear-gradient(to right, transparent, rgba(34,197,94,0.25) 20%, rgba(34,197,94,0.25) 80%, transparent)',
-                                }}
-                            />
-
-                            {[
-                                {
-                                    step: '01',
-                                    icon: Users,
-                                    title: 'Armá tu equipo',
-                                    description:
-                                        'Creá el equipo, invitá jugadores con un enlace y asigná roles de capitán y vice-capitán.',
-                                },
-                                {
-                                    step: '02',
-                                    icon: CalendarDays,
-                                    title: 'Programá el partido',
-                                    description:
-                                        'Publicá fecha, cancha y rival. Los jugadores confirman asistencia desde el celular.',
-                                },
-                                {
-                                    step: '03',
-                                    icon: Trophy,
-                                    title: 'Jugá y registrá',
-                                    description:
-                                        'Anotá goles, seguí resultados y mirá cómo mejora tu equipo partido a partido.',
-                                },
-                            ].map(({ step, icon: Icon, title, description }) => (
-                                <div
-                                    key={step}
-                                    className="relative flex flex-col gap-5"
-                                >
-                                    <span className="relative z-10 flex h-14 w-14 items-center justify-center rounded-2xl border border-white/10 bg-white/[0.05]">
-                                        <Icon className="h-6 w-6 text-green-400" />
-                                    </span>
-                                    <div>
-                                        <div className="mb-2 flex items-baseline gap-3">
-                                            <span className="font-display text-5xl font-bold leading-none text-white/[0.1]">
-                                                {step}
-                                            </span>
-                                            <h3 className="font-display text-2xl font-bold uppercase leading-none">
+                            <div className="grid gap-4 md:grid-cols-3">
+                                {[
+                                    {
+                                        step: '01',
+                                        icon: Users,
+                                        title: 'Armá tu equipo',
+                                        description:
+                                            'Creá el plantel, invitá jugadores y definí roles de gestión.',
+                                    },
+                                    {
+                                        step: '02',
+                                        icon: CalendarDays,
+                                        title: 'Programá el partido',
+                                        description:
+                                            'Publicá fecha, cancha y rival para que todos confirmen desde el celular.',
+                                    },
+                                    {
+                                        step: '03',
+                                        icon: Trophy,
+                                        title: 'Jugá y registrá',
+                                        description:
+                                            'Cargá resultados, goles y datos útiles para seguir la evolución del equipo.',
+                                    },
+                                ].map(
+                                    ({
+                                        step,
+                                        icon: Icon,
+                                        title,
+                                        description,
+                                    }) => (
+                                        <div
+                                            key={step}
+                                            className="rounded-lg border border-white/[0.08] bg-[#101312] p-6"
+                                        >
+                                            <div className="mb-8 flex items-center justify-between">
+                                                <span className="text-sm font-semibold text-white/35">
+                                                    {step}
+                                                </span>
+                                                <span className="flex h-10 w-10 items-center justify-center rounded-md bg-[#48d17a]/10 text-[#48d17a]">
+                                                    <Icon className="h-5 w-5" />
+                                                </span>
+                                            </div>
+                                            <h3 className="text-xl font-semibold">
                                                 {title}
                                             </h3>
+                                            <p className="mt-3 text-sm leading-6 text-white/50">
+                                                {description}
+                                            </p>
                                         </div>
-                                        <p className="text-sm text-white/45">
-                                            {description}
-                                        </p>
-                                    </div>
-                                </div>
-                            ))}
+                                    ),
+                                )}
+                            </div>
                         </div>
-                    </div>
-                </section>
+                    </section>
 
-                {/* Final CTA */}
-                <section className="relative overflow-hidden py-28 md:py-36">
-                    <PitchLines />
-                    <div
-                        aria-hidden="true"
-                        className="pointer-events-none absolute inset-0"
-                        style={{
-                            background:
-                                'radial-gradient(ellipse 60% 60% at 50% 60%, rgba(34,197,94,0.09) 0%, transparent 70%)',
-                        }}
-                    />
-
-                    <div className="relative container mx-auto max-w-3xl px-4 text-center">
-                        <div className="mb-6 flex justify-center">
-                            <span className="inline-flex items-center gap-2 rounded-full border border-green-500/25 bg-green-500/[0.1] px-3 py-1 text-xs font-medium text-green-400">
-                                <Globe className="h-3 w-3" />
-                                Empezá hoy
-                            </span>
+                    <section className="relative overflow-hidden py-20 md:py-28">
+                        <PitchLines />
+                        <div className="relative mx-auto max-w-4xl px-4 text-center md:px-6">
+                            <SectionLabel>Empezá hoy</SectionLabel>
+                            <h2 className="mt-4 text-4xl leading-tight font-semibold sm:text-5xl md:text-6xl">
+                                Ordená el próximo partido antes de que empiece
+                                la semana.
+                            </h2>
+                            <p className="mx-auto mt-5 max-w-2xl text-base leading-7 text-white/55">
+                                Gratis, sin publicidad y preparado para la forma
+                                en que se organiza el fútbol amateur en Uruguay.
+                            </p>
+                            <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+                                {ctaButtons}
+                            </div>
                         </div>
-                        <h2 className="font-display mb-6 text-6xl font-bold uppercase leading-none tracking-tight sm:text-7xl md:text-8xl">
-                            Dejá el caos atrás.
-                            <br />
-                            <span className="text-green-400">
-                                Armá el próximo partido.
-                            </span>
-                        </h2>
-                        <p className="mx-auto mb-10 max-w-xl text-lg text-white/50">
-                            Gratis, sin publicidad, y hecho por gente que
-                            también juega los sábados.
-                        </p>
-                        <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
-                            {ctaButtons}
-                        </div>
-                    </div>
-                </section>
+                    </section>
+                </main>
 
                 <LandingFooter canRegister={canRegister} />
             </div>

--- a/resources/js/pages/settings/password.tsx
+++ b/resources/js/pages/settings/password.tsx
@@ -174,7 +174,7 @@ export default function Password({
                                         leave="transition ease-in-out"
                                         leaveTo="opacity-0"
                                     >
-                                        <p className="text-sm text-neutral-600">
+                                        <p className="text-sm text-primary">
                                             Guardado
                                         </p>
                                     </Transition>

--- a/resources/js/pages/settings/profile.tsx
+++ b/resources/js/pages/settings/profile.tsx
@@ -373,7 +373,7 @@ export default function Profile({
                                         leave="transition ease-in-out"
                                         leaveTo="opacity-0"
                                     >
-                                        <p className="text-sm text-neutral-600">
+                                        <p className="text-sm text-primary">
                                             Guardado
                                         </p>
                                     </Transition>

--- a/resources/js/pages/tournaments/create.tsx
+++ b/resources/js/pages/tournaments/create.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import AppLayout from '@/layouts/app-layout';
-import type { BreadcrumbItem } from '@/types';
+import type { BreadcrumbItem, TournamentFormat } from '@/types';
 import { Head, router } from '@inertiajs/react';
 import { AlertCircle, ArrowLeft, ImagePlus, Save, X } from 'lucide-react';
 import { useRef, useState } from 'react';
@@ -33,6 +33,9 @@ interface FormData {
     description: string;
     visibility: 'public' | 'invite_only';
     variant: string;
+    format: TournamentFormat;
+    group_count: number;
+    group_size: number;
     max_teams: number;
     min_teams: number;
     registration_deadline: string;
@@ -46,6 +49,9 @@ export default function TournamentCreate() {
         description: '',
         visibility: 'public',
         variant: '',
+        format: 'single_elimination',
+        group_count: 4,
+        group_size: 4,
         max_teams: 8,
         min_teams: 4,
         registration_deadline: '',
@@ -103,12 +109,37 @@ export default function TournamentCreate() {
         if (fileInputRef.current) fileInputRef.current.value = '';
     };
 
+    const derivedMaxTeams =
+        data.format === 'group_stage_knockout'
+            ? data.group_count * data.group_size
+            : data.max_teams;
+
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         setProcessing(true);
 
         const formData = new FormData();
-        Object.entries(data).forEach(([key, value]) => {
+        const payload: Record<string, string | number> = {
+            name: data.name,
+            description: data.description,
+            visibility: data.visibility,
+            variant: data.variant,
+            format: data.format,
+            min_teams: data.min_teams,
+            registration_deadline: data.registration_deadline,
+            starts_at: data.starts_at,
+            ends_at: data.ends_at,
+        };
+
+        if (data.format === 'group_stage_knockout') {
+            payload.group_count = data.group_count;
+            payload.group_size = data.group_size;
+            payload.max_teams = derivedMaxTeams;
+        } else {
+            payload.max_teams = data.max_teams;
+        }
+
+        Object.entries(payload).forEach(([key, value]) => {
             formData.append(key, String(value));
         });
         if (selectedLogo) {
@@ -338,55 +369,227 @@ export default function TournamentCreate() {
                                     )}
                                 </div>
 
-                                {/* Max Teams */}
+                                {/* Format */}
                                 <div className="space-y-2">
-                                    <Label htmlFor="max_teams">
-                                        Número Máximo de Equipos{' '}
+                                    <Label htmlFor="format">
+                                        Formato del Torneo{' '}
                                         <span className="text-destructive">
                                             *
                                         </span>
                                     </Label>
                                     <Select
-                                        value={data.max_teams.toString()}
-                                        onValueChange={(value) =>
-                                            setData(
-                                                'max_teams',
-                                                parseInt(value),
-                                            )
-                                        }
+                                        value={data.format}
+                                        onValueChange={(
+                                            value: TournamentFormat,
+                                        ) => setData('format', value)}
                                     >
                                         <SelectTrigger>
                                             <SelectValue />
                                         </SelectTrigger>
                                         <SelectContent>
-                                            <SelectItem value="4">
-                                                4 equipos
+                                            <SelectItem value="single_elimination">
+                                                Eliminación directa - Brackets,
+                                                un partido por ronda
                                             </SelectItem>
-                                            <SelectItem value="8">
-                                                8 equipos
+                                            <SelectItem value="league">
+                                                Liga - Todos contra todos, gana
+                                                el de más puntos
                                             </SelectItem>
-                                            <SelectItem value="16">
-                                                16 equipos
-                                            </SelectItem>
-                                            <SelectItem value="32">
-                                                32 equipos
-                                            </SelectItem>
-                                            <SelectItem value="64">
-                                                64 equipos
+                                            <SelectItem value="group_stage_knockout">
+                                                Fase de grupos + eliminación -
+                                                Grupos primero, luego bracket
                                             </SelectItem>
                                         </SelectContent>
                                     </Select>
-                                    <p className="text-xs text-muted-foreground">
-                                        Debe ser una potencia de 2 para el
-                                        bracket de eliminación
-                                    </p>
-                                    {errors.max_teams && (
+                                    {errors.format && (
                                         <p className="flex items-center gap-1 text-sm text-destructive">
                                             <AlertCircle className="size-3" />
-                                            {errors.max_teams}
+                                            {errors.format}
                                         </p>
                                     )}
                                 </div>
+
+                                {/* Max Teams (single_elimination) */}
+                                {data.format === 'single_elimination' && (
+                                    <div className="space-y-2">
+                                        <Label htmlFor="max_teams">
+                                            Número Máximo de Equipos{' '}
+                                            <span className="text-destructive">
+                                                *
+                                            </span>
+                                        </Label>
+                                        <Select
+                                            value={data.max_teams.toString()}
+                                            onValueChange={(value) =>
+                                                setData(
+                                                    'max_teams',
+                                                    parseInt(value),
+                                                )
+                                            }
+                                        >
+                                            <SelectTrigger>
+                                                <SelectValue />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                <SelectItem value="4">
+                                                    4 equipos
+                                                </SelectItem>
+                                                <SelectItem value="8">
+                                                    8 equipos
+                                                </SelectItem>
+                                                <SelectItem value="16">
+                                                    16 equipos
+                                                </SelectItem>
+                                                <SelectItem value="32">
+                                                    32 equipos
+                                                </SelectItem>
+                                                <SelectItem value="64">
+                                                    64 equipos
+                                                </SelectItem>
+                                            </SelectContent>
+                                        </Select>
+                                        <p className="text-xs text-muted-foreground">
+                                            Debe ser una potencia de 2 para el
+                                            bracket
+                                        </p>
+                                        {errors.max_teams && (
+                                            <p className="flex items-center gap-1 text-sm text-destructive">
+                                                <AlertCircle className="size-3" />
+                                                {errors.max_teams}
+                                            </p>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* Max Teams (league) */}
+                                {data.format === 'league' && (
+                                    <div className="space-y-2">
+                                        <Label htmlFor="max_teams">
+                                            Número Máximo de Equipos{' '}
+                                            <span className="text-destructive">
+                                                *
+                                            </span>
+                                        </Label>
+                                        <Input
+                                            id="max_teams"
+                                            type="number"
+                                            value={data.max_teams}
+                                            onChange={(e) =>
+                                                setData(
+                                                    'max_teams',
+                                                    parseInt(e.target.value) ||
+                                                        2,
+                                                )
+                                            }
+                                            min={2}
+                                            max={64}
+                                        />
+                                        <p className="text-xs text-muted-foreground">
+                                            Cualquier número de 2 a 64. Cada
+                                            equipo jugará{' '}
+                                            {Math.max(0, data.max_teams - 1)}{' '}
+                                            partidos.
+                                        </p>
+                                        {errors.max_teams && (
+                                            <p className="flex items-center gap-1 text-sm text-destructive">
+                                                <AlertCircle className="size-3" />
+                                                {errors.max_teams}
+                                            </p>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* Group config (group_stage_knockout) */}
+                                {data.format === 'group_stage_knockout' && (
+                                    <>
+                                        <div className="space-y-2">
+                                            <Label htmlFor="group_count">
+                                                Cantidad de Grupos{' '}
+                                                <span className="text-destructive">
+                                                    *
+                                                </span>
+                                            </Label>
+                                            <Select
+                                                value={data.group_count.toString()}
+                                                onValueChange={(value) =>
+                                                    setData(
+                                                        'group_count',
+                                                        parseInt(value),
+                                                    )
+                                                }
+                                            >
+                                                <SelectTrigger>
+                                                    <SelectValue />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    <SelectItem value="2">
+                                                        2 grupos
+                                                    </SelectItem>
+                                                    <SelectItem value="4">
+                                                        4 grupos
+                                                    </SelectItem>
+                                                    <SelectItem value="8">
+                                                        8 grupos
+                                                    </SelectItem>
+                                                    <SelectItem value="16">
+                                                        16 grupos
+                                                    </SelectItem>
+                                                </SelectContent>
+                                            </Select>
+                                            <p className="text-xs text-muted-foreground">
+                                                Debe ser potencia de 2 para que
+                                                los 2 mejores de cada grupo
+                                                formen un bracket limpio.
+                                            </p>
+                                            {errors.group_count && (
+                                                <p className="flex items-center gap-1 text-sm text-destructive">
+                                                    <AlertCircle className="size-3" />
+                                                    {errors.group_count}
+                                                </p>
+                                            )}
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label htmlFor="group_size">
+                                                Equipos por Grupo{' '}
+                                                <span className="text-destructive">
+                                                    *
+                                                </span>
+                                            </Label>
+                                            <Input
+                                                id="group_size"
+                                                type="number"
+                                                value={data.group_size}
+                                                onChange={(e) =>
+                                                    setData(
+                                                        'group_size',
+                                                        parseInt(
+                                                            e.target.value,
+                                                        ) || 2,
+                                                    )
+                                                }
+                                                min={2}
+                                                max={16}
+                                            />
+                                            <p className="text-xs text-muted-foreground">
+                                                Total: {derivedMaxTeams} equipos
+                                                ({data.group_count} ×{' '}
+                                                {data.group_size}). Cada equipo
+                                                jugará{' '}
+                                                {Math.max(
+                                                    0,
+                                                    data.group_size - 1,
+                                                )}{' '}
+                                                partidos en su grupo.
+                                            </p>
+                                            {errors.group_size && (
+                                                <p className="flex items-center gap-1 text-sm text-destructive">
+                                                    <AlertCircle className="size-3" />
+                                                    {errors.group_size}
+                                                </p>
+                                            )}
+                                        </div>
+                                    </>
+                                )}
 
                                 {/* Min Teams */}
                                 <div className="space-y-2">

--- a/resources/js/pages/tournaments/edit.tsx
+++ b/resources/js/pages/tournaments/edit.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import AppLayout from '@/layouts/app-layout';
-import type { BreadcrumbItem, Tournament } from '@/types';
+import type { BreadcrumbItem, Tournament, TournamentFormat } from '@/types';
 import { Head, router } from '@inertiajs/react';
 import { AlertCircle, ArrowLeft, ImagePlus, Save, Trash2 } from 'lucide-react';
 import { useRef, useState } from 'react';
@@ -39,6 +39,9 @@ interface FormData {
     description: string;
     visibility: 'public' | 'invite_only';
     variant: string;
+    format: TournamentFormat;
+    group_count: number;
+    group_size: number;
     max_teams: number;
     min_teams: number;
     registration_deadline: string;
@@ -47,11 +50,15 @@ interface FormData {
 }
 
 export default function TournamentEdit({ tournament }: PageProps) {
+    const formatLocked = (tournament.registered_teams_count ?? 0) > 0;
     const [data, setDataState] = useState<FormData>({
         name: tournament.name,
         description: tournament.description || '',
         visibility: tournament.visibility,
         variant: tournament.variant,
+        format: tournament.format,
+        group_count: tournament.group_count ?? 4,
+        group_size: tournament.group_size ?? 4,
         max_teams: tournament.max_teams,
         min_teams: tournament.min_teams,
         registration_deadline: tournament.registration_deadline
@@ -124,13 +131,39 @@ export default function TournamentEdit({ tournament }: PageProps) {
         if (fileInputRef.current) fileInputRef.current.value = '';
     };
 
+    const derivedMaxTeams =
+        data.format === 'group_stage_knockout'
+            ? data.group_count * data.group_size
+            : data.max_teams;
+
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         setProcessing(true);
 
         const formData = new FormData();
         formData.append('_method', 'PUT');
-        Object.entries(data).forEach(([key, value]) => {
+
+        const payload: Record<string, string | number> = {
+            name: data.name,
+            description: data.description,
+            visibility: data.visibility,
+            variant: data.variant,
+            format: data.format,
+            min_teams: data.min_teams,
+            registration_deadline: data.registration_deadline,
+            starts_at: data.starts_at,
+            ends_at: data.ends_at,
+        };
+
+        if (data.format === 'group_stage_knockout') {
+            payload.group_count = data.group_count;
+            payload.group_size = data.group_size;
+            payload.max_teams = derivedMaxTeams;
+        } else {
+            payload.max_teams = data.max_teams;
+        }
+
+        Object.entries(payload).forEach(([key, value]) => {
             formData.append(key, String(value));
         });
         if (selectedLogo) {
@@ -372,51 +405,211 @@ export default function TournamentEdit({ tournament }: PageProps) {
                                     )}
                                 </div>
 
-                                {/* Max Teams */}
+                                {/* Format */}
                                 <div className="space-y-2">
-                                    <Label htmlFor="max_teams">
-                                        Número Máximo de Equipos{' '}
+                                    <Label htmlFor="format">
+                                        Formato del Torneo{' '}
                                         <span className="text-destructive">
                                             *
                                         </span>
                                     </Label>
                                     <Select
-                                        value={data.max_teams.toString()}
-                                        onValueChange={(value) =>
-                                            setData(
-                                                'max_teams',
-                                                parseInt(value),
-                                            )
-                                        }
+                                        value={data.format}
+                                        disabled={formatLocked}
+                                        onValueChange={(
+                                            value: TournamentFormat,
+                                        ) => setData('format', value)}
                                     >
                                         <SelectTrigger>
                                             <SelectValue />
                                         </SelectTrigger>
                                         <SelectContent>
-                                            <SelectItem value="4">
-                                                4 equipos
+                                            <SelectItem value="single_elimination">
+                                                Eliminación directa
                                             </SelectItem>
-                                            <SelectItem value="8">
-                                                8 equipos
+                                            <SelectItem value="league">
+                                                Liga
                                             </SelectItem>
-                                            <SelectItem value="16">
-                                                16 equipos
-                                            </SelectItem>
-                                            <SelectItem value="32">
-                                                32 equipos
-                                            </SelectItem>
-                                            <SelectItem value="64">
-                                                64 equipos
+                                            <SelectItem value="group_stage_knockout">
+                                                Fase de grupos + eliminación
                                             </SelectItem>
                                         </SelectContent>
                                     </Select>
-                                    {errors.max_teams && (
+                                    {formatLocked && (
+                                        <p className="text-xs text-muted-foreground">
+                                            El formato no se puede cambiar
+                                            después de que se hayan registrado
+                                            equipos.
+                                        </p>
+                                    )}
+                                    {errors.format && (
                                         <p className="flex items-center gap-1 text-sm text-destructive">
                                             <AlertCircle className="size-3" />
-                                            {errors.max_teams}
+                                            {errors.format}
                                         </p>
                                     )}
                                 </div>
+
+                                {/* Max Teams (single_elimination) */}
+                                {data.format === 'single_elimination' && (
+                                    <div className="space-y-2">
+                                        <Label htmlFor="max_teams">
+                                            Número Máximo de Equipos{' '}
+                                            <span className="text-destructive">
+                                                *
+                                            </span>
+                                        </Label>
+                                        <Select
+                                            value={data.max_teams.toString()}
+                                            onValueChange={(value) =>
+                                                setData(
+                                                    'max_teams',
+                                                    parseInt(value),
+                                                )
+                                            }
+                                        >
+                                            <SelectTrigger>
+                                                <SelectValue />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                <SelectItem value="4">
+                                                    4 equipos
+                                                </SelectItem>
+                                                <SelectItem value="8">
+                                                    8 equipos
+                                                </SelectItem>
+                                                <SelectItem value="16">
+                                                    16 equipos
+                                                </SelectItem>
+                                                <SelectItem value="32">
+                                                    32 equipos
+                                                </SelectItem>
+                                                <SelectItem value="64">
+                                                    64 equipos
+                                                </SelectItem>
+                                            </SelectContent>
+                                        </Select>
+                                        {errors.max_teams && (
+                                            <p className="flex items-center gap-1 text-sm text-destructive">
+                                                <AlertCircle className="size-3" />
+                                                {errors.max_teams}
+                                            </p>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* Max Teams (league) */}
+                                {data.format === 'league' && (
+                                    <div className="space-y-2">
+                                        <Label htmlFor="max_teams">
+                                            Número Máximo de Equipos{' '}
+                                            <span className="text-destructive">
+                                                *
+                                            </span>
+                                        </Label>
+                                        <Input
+                                            id="max_teams"
+                                            type="number"
+                                            value={data.max_teams}
+                                            onChange={(e) =>
+                                                setData(
+                                                    'max_teams',
+                                                    parseInt(e.target.value) ||
+                                                        2,
+                                                )
+                                            }
+                                            min={2}
+                                            max={64}
+                                        />
+                                        {errors.max_teams && (
+                                            <p className="flex items-center gap-1 text-sm text-destructive">
+                                                <AlertCircle className="size-3" />
+                                                {errors.max_teams}
+                                            </p>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* Group config (group_stage_knockout) */}
+                                {data.format === 'group_stage_knockout' && (
+                                    <>
+                                        <div className="space-y-2">
+                                            <Label htmlFor="group_count">
+                                                Cantidad de Grupos{' '}
+                                                <span className="text-destructive">
+                                                    *
+                                                </span>
+                                            </Label>
+                                            <Select
+                                                value={data.group_count.toString()}
+                                                onValueChange={(value) =>
+                                                    setData(
+                                                        'group_count',
+                                                        parseInt(value),
+                                                    )
+                                                }
+                                            >
+                                                <SelectTrigger>
+                                                    <SelectValue />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    <SelectItem value="2">
+                                                        2 grupos
+                                                    </SelectItem>
+                                                    <SelectItem value="4">
+                                                        4 grupos
+                                                    </SelectItem>
+                                                    <SelectItem value="8">
+                                                        8 grupos
+                                                    </SelectItem>
+                                                    <SelectItem value="16">
+                                                        16 grupos
+                                                    </SelectItem>
+                                                </SelectContent>
+                                            </Select>
+                                            {errors.group_count && (
+                                                <p className="flex items-center gap-1 text-sm text-destructive">
+                                                    <AlertCircle className="size-3" />
+                                                    {errors.group_count}
+                                                </p>
+                                            )}
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label htmlFor="group_size">
+                                                Equipos por Grupo{' '}
+                                                <span className="text-destructive">
+                                                    *
+                                                </span>
+                                            </Label>
+                                            <Input
+                                                id="group_size"
+                                                type="number"
+                                                value={data.group_size}
+                                                onChange={(e) =>
+                                                    setData(
+                                                        'group_size',
+                                                        parseInt(
+                                                            e.target.value,
+                                                        ) || 2,
+                                                    )
+                                                }
+                                                min={2}
+                                                max={16}
+                                            />
+                                            <p className="text-xs text-muted-foreground">
+                                                Total: {derivedMaxTeams} equipos
+                                                ({data.group_count} ×{' '}
+                                                {data.group_size}).
+                                            </p>
+                                            {errors.group_size && (
+                                                <p className="flex items-center gap-1 text-sm text-destructive">
+                                                    <AlertCircle className="size-3" />
+                                                    {errors.group_size}
+                                                </p>
+                                            )}
+                                        </div>
+                                    </>
+                                )}
 
                                 {/* Min Teams */}
                                 <div className="space-y-2">

--- a/resources/js/pages/tournaments/edit.tsx
+++ b/resources/js/pages/tournaments/edit.tsx
@@ -22,6 +22,7 @@ import type { BreadcrumbItem, Tournament } from '@/types';
 import { Head, router } from '@inertiajs/react';
 import { AlertCircle, ArrowLeft, ImagePlus, Save, Trash2 } from 'lucide-react';
 import { useRef, useState } from 'react';
+import { toast } from 'sonner';
 
 interface PageProps {
     tournament: Tournament;
@@ -143,6 +144,9 @@ export default function TournamentEdit({ tournament }: PageProps) {
             onError: (errs) => {
                 setProcessing(false);
                 setErrors(errs as Record<string, string>);
+                if (errs.error) {
+                    toast.error(errs.error as string);
+                }
             },
         });
     };
@@ -173,6 +177,13 @@ export default function TournamentEdit({ tournament }: PageProps) {
                                 </CardDescription>
                             </CardHeader>
                             <CardContent className="space-y-6">
+                                {errors.error && (
+                                    <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+                                        <AlertCircle className="mt-0.5 size-4 shrink-0" />
+                                        <span>{errors.error}</span>
+                                    </div>
+                                )}
+
                                 {/* Name */}
                                 <div className="space-y-2">
                                     <Label htmlFor="name">

--- a/resources/js/pages/tournaments/index.tsx
+++ b/resources/js/pages/tournaments/index.tsx
@@ -1,7 +1,7 @@
-import { TournamentCard } from '@/components/tournament/tournament-card';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { Progress } from '@/components/ui/progress';
 import {
     Select,
     SelectContent,
@@ -9,12 +9,25 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { VariantBadge } from '@/components/variant-badge';
 import AppLayout from '@/layouts/app-layout';
-import type { BreadcrumbItem, Tournament } from '@/types';
+import { cn } from '@/lib/utils';
+import tournamentsRoute from '@/routes/tournaments';
+import type { BreadcrumbItem, Tournament, TournamentStatus } from '@/types';
 import { Head, Link, router } from '@inertiajs/react';
-import { Calendar, Plus, Search, Trophy, Zap } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import {
+    ArrowUpDown,
+    Calendar,
+    ChevronLeft,
+    ChevronRight,
+    CircleDot,
+    Plus,
+    Search,
+    Trophy,
+    Users,
+    X,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -23,161 +36,250 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
+type TournamentStatusFilter = TournamentStatus | 'all';
+
 interface PageProps {
     tournaments: {
         data: Tournament[];
         current_page: number;
         last_page: number;
+        from: number | null;
+        to: number | null;
         per_page: number;
         total: number;
     };
+    statusCounts: Record<TournamentStatusFilter, number>;
     filters: {
-        status: string;
+        status: TournamentStatusFilter;
         variant: string;
+        search: string;
+        sort: string;
     };
 }
 
-export default function TournamentsIndex({ tournaments, filters }: PageProps) {
-    const [searchQuery, setSearchQuery] = useState('');
-    const [activeTab, setActiveTab] = useState('all');
+const statusOptions: Array<{
+    value: TournamentStatusFilter;
+    label: string;
+}> = [
+    { value: 'all', label: 'Todos' },
+    { value: 'registration_open', label: 'Inscripción' },
+    { value: 'in_progress', label: 'En juego' },
+    { value: 'completed', label: 'Finalizados' },
+    { value: 'draft', label: 'Borradores' },
+    { value: 'cancelled', label: 'Cancelados' },
+];
 
-    const handleVariantChange = (variant: string) => {
-        router.get(
-            '/tournaments',
-            { ...filters, variant },
-            { preserveState: true },
+const statusConfig: Record<
+    TournamentStatus,
+    {
+        label: string;
+        className: string;
+        variant: 'default' | 'secondary' | 'outline' | 'destructive';
+    }
+> = {
+    draft: {
+        label: 'Borrador',
+        variant: 'secondary',
+        className: 'bg-muted text-muted-foreground',
+    },
+    registration_open: {
+        label: 'Inscripción abierta',
+        variant: 'secondary',
+        className: 'bg-primary/10 text-primary',
+    },
+    in_progress: {
+        label: 'En juego',
+        variant: 'secondary',
+        className: 'bg-primary/10 text-primary',
+    },
+    completed: {
+        label: 'Finalizado',
+        variant: 'outline',
+        className: 'text-muted-foreground',
+    },
+    cancelled: {
+        label: 'Cancelado',
+        variant: 'destructive',
+        className: '',
+    },
+};
+
+const formatDate = (value?: string) => {
+    if (!value) return 'Sin fecha';
+
+    return new Date(value).toLocaleDateString('es-UY', {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+    });
+};
+
+const cleanFilters = (
+    filters: PageProps['filters'] & { page?: number | null },
+) => ({
+    status: filters.status === 'all' ? undefined : filters.status,
+    variant: filters.variant === 'all' ? undefined : filters.variant,
+    search: filters.search.trim() === '' ? undefined : filters.search.trim(),
+    sort: filters.sort === 'newest' ? undefined : filters.sort,
+    page: filters.page ?? undefined,
+});
+
+export default function TournamentsIndex({
+    tournaments,
+    statusCounts,
+    filters,
+}: PageProps) {
+    const [searchQuery, setSearchQuery] = useState(filters.search ?? '');
+
+    const updateFilters = useCallback(
+        (
+            updates: Partial<PageProps['filters']> & { page?: number | null },
+            options: { replace?: boolean } = {},
+        ) => {
+            const nextFilters = {
+                ...filters,
+                ...updates,
+            };
+
+            router.get(
+                tournamentsRoute.index.url(),
+                cleanFilters(nextFilters),
+                {
+                    preserveScroll: true,
+                    preserveState: true,
+                    replace: options.replace ?? true,
+                },
+            );
+        },
+        [filters],
+    );
+
+    useEffect(() => {
+        const timeout = window.setTimeout(() => {
+            if (searchQuery !== (filters.search ?? '')) {
+                updateFilters({ search: searchQuery, page: null });
+            }
+        }, 350);
+
+        return () => window.clearTimeout(timeout);
+    }, [filters.search, searchQuery, updateFilters]);
+
+    const activeFilterCount = useMemo(
+        () =>
+            [
+                filters.status !== 'all',
+                filters.variant !== 'all',
+                filters.search.trim() !== '',
+                filters.sort !== 'newest',
+            ].filter(Boolean).length,
+        [filters],
+    );
+
+    const pageNumbers = useMemo(() => {
+        const start = Math.max(1, tournaments.current_page - 2);
+        const end = Math.min(
+            tournaments.last_page,
+            tournaments.current_page + 2,
         );
-    };
 
-    const categorizedTournaments = useMemo(() => {
-        const all = tournaments.data;
-        const upcoming = all.filter((t) => t.status === 'registration_open');
-        const active = all.filter((t) => t.status === 'in_progress');
-        const past = all.filter((t) => t.status === 'completed');
-
-        return { all, upcoming, active, past };
-    }, [tournaments.data]);
-
-    const filteredTournaments = useMemo(() => {
-        const source =
-            activeTab === 'all'
-                ? categorizedTournaments.all
-                : categorizedTournaments[
-                      activeTab as keyof typeof categorizedTournaments
-                  ];
-
-        if (!searchQuery.trim()) return source;
-
-        return source.filter(
-            (t) =>
-                t.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-                t.description
-                    ?.toLowerCase()
-                    .includes(searchQuery.toLowerCase()),
+        return Array.from(
+            { length: end - start + 1 },
+            (_, index) => start + index,
         );
-    }, [categorizedTournaments, activeTab, searchQuery]);
+    }, [tournaments.current_page, tournaments.last_page]);
 
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Torneos" />
 
-            <div className="flex h-full flex-1 flex-col gap-6 p-6">
-                {/* Header */}
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                    <div>
-                        <h1 className="text-3xl font-bold tracking-tight">
+            <div className="flex h-full flex-1 flex-col gap-6 p-4 sm:p-6">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                    <div className="space-y-1">
+                        <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">
                             Torneos
                         </h1>
-                        <p className="text-muted-foreground">
-                            Compite y demuestra tu talento
+                        <p className="text-sm text-muted-foreground">
+                            {tournaments.total === 1
+                                ? '1 torneo encontrado'
+                                : `${tournaments.total} torneos encontrados`}
                         </p>
                     </div>
-                    <Link href="/tournaments/create">
-                        <Button className="gap-2">
+
+                    <Button asChild className="w-full gap-2 sm:w-fit">
+                        <Link href={tournamentsRoute.create.url()}>
                             <Plus className="size-4" />
-                            Crear Torneo
-                        </Button>
-                    </Link>
+                            Crear torneo
+                        </Link>
+                    </Button>
                 </div>
 
-                {/* Toggle Group + Filters */}
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                    <ToggleGroup
-                        type="single"
-                        value={activeTab}
-                        onValueChange={(value) => {
-                            if (value) setActiveTab(value);
-                        }}
-                        className="justify-start"
-                    >
-                        <ToggleGroupItem
-                            value="all"
-                            aria-label="Todos"
-                            className="gap-2"
-                        >
-                            <Trophy className="h-4 w-4" />
-                            Todos
-                            <span className="ml-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
-                                {categorizedTournaments.all.length}
-                            </span>
-                        </ToggleGroupItem>
-                        <ToggleGroupItem
-                            value="upcoming"
-                            aria-label="Abiertos"
-                            className="gap-2"
-                        >
-                            <Calendar className="h-4 w-4" />
-                            Abiertos
-                            <span className="ml-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
-                                {categorizedTournaments.upcoming.length}
-                            </span>
-                        </ToggleGroupItem>
-                        <ToggleGroupItem
-                            value="active"
-                            aria-label="Activos"
-                            className="gap-2"
-                        >
-                            <Zap className="h-4 w-4" />
-                            Activos
-                            <span className="ml-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
-                                {categorizedTournaments.active.length}
-                            </span>
-                        </ToggleGroupItem>
-                        <ToggleGroupItem
-                            value="past"
-                            aria-label="Pasados"
-                            className="gap-2"
-                        >
-                            Pasados
-                            <span className="ml-1 rounded-full bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground">
-                                {categorizedTournaments.past.length}
-                            </span>
-                        </ToggleGroupItem>
-                    </ToggleGroup>
+                <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
+                    {statusOptions.map((option) => {
+                        const isActive = filters.status === option.value;
+
+                        return (
+                            <button
+                                key={option.value}
+                                type="button"
+                                onClick={() =>
+                                    updateFilters({
+                                        status: option.value,
+                                        page: null,
+                                    })
+                                }
+                                className={cn(
+                                    'flex min-h-20 flex-col justify-between rounded-lg border bg-background p-3 text-left transition-colors hover:bg-muted/50',
+                                    isActive &&
+                                        'border-primary bg-primary/5 ring-1 ring-primary/15',
+                                )}
+                            >
+                                <span className="flex items-center justify-between gap-2 text-sm font-medium">
+                                    {option.label}
+                                    {isActive && (
+                                        <CircleDot className="size-4 text-primary" />
+                                    )}
+                                </span>
+                                <span
+                                    className={cn(
+                                        'text-2xl leading-none font-semibold',
+                                        isActive
+                                            ? 'text-primary'
+                                            : option.value === 'cancelled'
+                                              ? 'text-destructive'
+                                              : 'text-foreground',
+                                    )}
+                                >
+                                    {statusCounts[option.value] ?? 0}
+                                </span>
+                            </button>
+                        );
+                    })}
                 </div>
 
-                {/* Search and Variant Filter */}
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-                    <div className="relative flex-1">
-                        <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <div className="flex flex-col gap-3 rounded-lg border bg-background p-3 lg:flex-row lg:items-center">
+                    <div className="relative min-w-0 flex-1">
+                        <Search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
                         <Input
-                            placeholder="Buscar torneos por nombre..."
                             value={searchQuery}
-                            onChange={(e) => setSearchQuery(e.target.value)}
+                            onChange={(event) =>
+                                setSearchQuery(event.target.value)
+                            }
+                            placeholder="Buscar por nombre o descripción"
                             className="pl-9"
                         />
                     </div>
+
                     <Select
                         value={filters.variant}
-                        onValueChange={handleVariantChange}
+                        onValueChange={(variant) =>
+                            updateFilters({ variant, page: null })
+                        }
                     >
-                        <SelectTrigger className="w-full sm:w-[180px]">
+                        <SelectTrigger className="w-full lg:w-44">
                             <SelectValue placeholder="Variante" />
                         </SelectTrigger>
                         <SelectContent>
-                            <SelectItem value="all">
-                                Todas las variantes
-                            </SelectItem>
+                            <SelectItem value="all">Todas</SelectItem>
                             <SelectItem value="football_11">
                                 Fútbol 11
                             </SelectItem>
@@ -186,45 +288,248 @@ export default function TournamentsIndex({ tournaments, filters }: PageProps) {
                             <SelectItem value="futsal">Futsal</SelectItem>
                         </SelectContent>
                     </Select>
+
+                    <Select
+                        value={filters.sort}
+                        onValueChange={(sort) =>
+                            updateFilters({ sort, page: null })
+                        }
+                    >
+                        <SelectTrigger className="w-full lg:w-48">
+                            <ArrowUpDown className="size-4 text-muted-foreground" />
+                            <SelectValue placeholder="Orden" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="newest">
+                                Más recientes
+                            </SelectItem>
+                            <SelectItem value="start_soon">
+                                Próximos a iniciar
+                            </SelectItem>
+                            <SelectItem value="name">Nombre</SelectItem>
+                        </SelectContent>
+                    </Select>
+
+                    {activeFilterCount > 0 && (
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            className="gap-2 lg:ml-auto"
+                            onClick={() => {
+                                setSearchQuery('');
+                                updateFilters({
+                                    status: 'all',
+                                    variant: 'all',
+                                    search: '',
+                                    sort: 'newest',
+                                    page: null,
+                                });
+                            }}
+                        >
+                            <X className="size-4" />
+                            Limpiar
+                        </Button>
+                    )}
                 </div>
 
-                {/* Tournament Grid */}
-                {filteredTournaments.length === 0 ? (
-                    <Card className="flex flex-col items-center justify-center py-12">
-                        <CardContent className="flex flex-col items-center gap-4 pt-6">
-                            <div className="rounded-full bg-muted p-4">
-                                <Trophy className="h-8 w-8 text-muted-foreground" />
-                            </div>
-                            <div className="text-center">
-                                <h3 className="text-lg font-semibold">
-                                    No se encontraron torneos
-                                </h3>
-                                <p className="text-sm text-muted-foreground">
-                                    {searchQuery
-                                        ? 'Intenta con otra búsqueda o ajusta los filtros'
-                                        : 'No hay torneos disponibles en esta categoría'}
-                                </p>
-                            </div>
-                            {activeTab === 'all' &&
-                                !searchQuery &&
-                                tournaments.data.length === 0 && (
-                                    <Link href="/tournaments/create">
-                                        <Button className="gap-2">
-                                            <Plus className="size-4" />
-                                            Crear Primer Torneo
-                                        </Button>
-                                    </Link>
-                                )}
-                        </CardContent>
-                    </Card>
+                {tournaments.data.length === 0 ? (
+                    <div className="flex min-h-80 flex-col items-center justify-center gap-4 rounded-lg border border-dashed p-8 text-center">
+                        <div className="rounded-full bg-muted p-4">
+                            <Trophy className="size-8 text-muted-foreground" />
+                        </div>
+                        <div className="space-y-1">
+                            <h2 className="text-lg font-semibold">
+                                No hay torneos para mostrar
+                            </h2>
+                            <p className="max-w-md text-sm text-muted-foreground">
+                                Ajusta la búsqueda o limpia los filtros para ver
+                                más resultados.
+                            </p>
+                        </div>
+                    </div>
                 ) : (
-                    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                        {filteredTournaments.map((tournament) => (
-                            <TournamentCard
-                                key={tournament.id}
-                                tournament={tournament}
-                            />
-                        ))}
+                    <div className="overflow-hidden rounded-lg border bg-background">
+                        <div className="hidden grid-cols-[minmax(0,1.7fr)_150px_150px_150px_120px] gap-4 border-b bg-muted/40 px-4 py-3 text-xs font-medium text-muted-foreground lg:grid">
+                            <span>Torneo</span>
+                            <span>Estado</span>
+                            <span>Equipos</span>
+                            <span>Inicio</span>
+                            <span className="text-right">Acción</span>
+                        </div>
+
+                        <div className="divide-y">
+                            {tournaments.data.map((tournament) => {
+                                const status = statusConfig[tournament.status];
+                                const registeredTeams =
+                                    tournament.registered_teams_count ?? 0;
+                                const capacity = Math.min(
+                                    100,
+                                    Math.round(
+                                        (registeredTeams /
+                                            tournament.max_teams) *
+                                            100,
+                                    ),
+                                );
+
+                                return (
+                                    <div
+                                        key={tournament.id}
+                                        className="grid gap-4 px-4 py-4 transition-colors hover:bg-muted/30 lg:grid-cols-[minmax(0,1.7fr)_150px_150px_150px_120px] lg:items-center"
+                                    >
+                                        <div className="flex min-w-0 items-start gap-3">
+                                            <div className="flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-md border bg-muted">
+                                                {tournament.logo_url ? (
+                                                    <img
+                                                        src={
+                                                            tournament.logo_url
+                                                        }
+                                                        alt={tournament.name}
+                                                        className="size-full object-cover"
+                                                        loading="lazy"
+                                                    />
+                                                ) : (
+                                                    <div className="flex size-full items-center justify-center bg-muted text-muted-foreground">
+                                                        <Trophy className="size-5" />
+                                                    </div>
+                                                )}
+                                            </div>
+
+                                            <div className="min-w-0 space-y-2">
+                                                <div className="flex flex-wrap items-center gap-2">
+                                                    <Link
+                                                        href={tournamentsRoute.show.url(
+                                                            tournament.id,
+                                                        )}
+                                                        className="min-w-0 text-base font-semibold hover:underline"
+                                                    >
+                                                        <span className="line-clamp-1">
+                                                            {tournament.name}
+                                                        </span>
+                                                    </Link>
+                                                    <VariantBadge
+                                                        variant={
+                                                            tournament.variant
+                                                        }
+                                                        className="border-border bg-muted text-muted-foreground hover:bg-muted [&>svg]:text-muted-foreground"
+                                                    />
+                                                </div>
+                                                {tournament.description && (
+                                                    <p className="line-clamp-2 text-sm text-muted-foreground">
+                                                        {tournament.description}
+                                                    </p>
+                                                )}
+                                            </div>
+                                        </div>
+
+                                        <div>
+                                            <Badge
+                                                variant={status.variant}
+                                                className={status.className}
+                                            >
+                                                {status.label}
+                                            </Badge>
+                                        </div>
+
+                                        <div className="space-y-2">
+                                            <div className="flex items-center justify-between gap-3 text-sm">
+                                                <span className="inline-flex items-center gap-2 text-muted-foreground">
+                                                    <Users className="size-4" />
+                                                    Equipos
+                                                </span>
+                                                <span className="font-medium">
+                                                    {registeredTeams}/
+                                                    {tournament.max_teams}
+                                                </span>
+                                            </div>
+                                            <Progress value={capacity} />
+                                        </div>
+
+                                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                            <Calendar className="size-4" />
+                                            <span>
+                                                {formatDate(
+                                                    tournament.starts_at,
+                                                )}
+                                            </span>
+                                        </div>
+
+                                        <Button
+                                            asChild
+                                            variant="outline"
+                                            size="sm"
+                                            className="w-full lg:w-auto"
+                                        >
+                                            <Link
+                                                href={tournamentsRoute.show.url(
+                                                    tournament.id,
+                                                )}
+                                            >
+                                                Ver torneo
+                                            </Link>
+                                        </Button>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    </div>
+                )}
+
+                {tournaments.last_page > 1 && (
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <p className="text-sm text-muted-foreground">
+                            Mostrando {tournaments.from} a {tournaments.to} de{' '}
+                            {tournaments.total}
+                        </p>
+
+                        <div className="flex items-center gap-2">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="icon"
+                                disabled={tournaments.current_page === 1}
+                                onClick={() =>
+                                    updateFilters({
+                                        page: tournaments.current_page - 1,
+                                    })
+                                }
+                            >
+                                <ChevronLeft className="size-4" />
+                            </Button>
+
+                            {pageNumbers.map((page) => (
+                                <Button
+                                    key={page}
+                                    type="button"
+                                    variant={
+                                        page === tournaments.current_page
+                                            ? 'default'
+                                            : 'outline'
+                                    }
+                                    size="sm"
+                                    className="min-w-9"
+                                    onClick={() => updateFilters({ page })}
+                                >
+                                    {page}
+                                </Button>
+                            ))}
+
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="icon"
+                                disabled={
+                                    tournaments.current_page ===
+                                    tournaments.last_page
+                                }
+                                onClick={() =>
+                                    updateFilters({
+                                        page: tournaments.current_page + 1,
+                                    })
+                                }
+                            >
+                                <ChevronRight className="size-4" />
+                            </Button>
+                        </div>
                     </div>
                 )}
             </div>

--- a/resources/js/pages/tournaments/show.tsx
+++ b/resources/js/pages/tournaments/show.tsx
@@ -1,4 +1,7 @@
 import { TeamAvatar } from '@/components/team-avatar';
+import { GroupDraw } from '@/components/tournament/group-draw';
+import { GroupsGrid } from '@/components/tournament/groups-grid';
+import { StandingsTable } from '@/components/tournament/standings-table';
 import { TournamentBracket } from '@/components/tournament/tournament-bracket';
 import {
     AlertDialog,
@@ -46,8 +49,10 @@ import tournamentMatches from '@/routes/tournaments/matches';
 import type {
     BreadcrumbItem,
     FootballMatch,
+    StandingRow,
     Team,
     Tournament,
+    TournamentGroup,
     TournamentTeam,
 } from '@/types';
 import { Head, Link, router, usePage } from '@inertiajs/react';
@@ -79,7 +84,10 @@ interface PageProps {
             name: string;
             matches: FootballMatch[];
         }>;
+        groups?: TournamentGroup[];
     };
+    standings: StandingRow[] | null;
+    groupStandings: Record<number, StandingRow[]> | null;
     userTeams: Team[];
     permissions: {
         canEdit: boolean;
@@ -88,6 +96,7 @@ interface PageProps {
         canCancel: boolean;
         canApprove: boolean;
         canScheduleMatches: boolean;
+        canDrawGroups: boolean;
     };
 }
 
@@ -299,6 +308,8 @@ const breadcrumbs = (tournament: Tournament): BreadcrumbItem[] => [
 
 export default function TournamentShow({
     tournament,
+    standings,
+    groupStandings,
     userTeams,
     permissions,
 }: PageProps) {
@@ -635,17 +646,93 @@ export default function TournamentShow({
                 <div className="grid gap-6 lg:grid-cols-3">
                     {/* Left column — main content */}
                     <div className="space-y-6 lg:col-span-2">
-                        {/* Bracket */}
+                        {/* Group draw (group_stage_knockout, pre-start) */}
+                        {tournament.format === 'group_stage_knockout' &&
+                            permissions.canDrawGroups &&
+                            tournament.groups &&
+                            tournament.groups.length > 0 &&
+                            (tournament.status === 'draft' ||
+                                tournament.status === 'registration_open') && (
+                                <GroupDraw
+                                    tournamentId={tournament.id}
+                                    groups={tournament.groups}
+                                    approvedTeams={
+                                        approvedTeams as (TournamentTeam & {
+                                            team: Team;
+                                        })[]
+                                    }
+                                    groupSize={tournament.group_size ?? 4}
+                                />
+                            )}
+
+                        {/* Bracket / Standings / Groups */}
                         {hasBracket ? (
                             <>
-                                <section className="space-y-4">
-                                    <h2 className="text-lg font-semibold">
-                                        Bracket
-                                    </h2>
-                                    <TournamentBracket
-                                        rounds={tournament.rounds}
-                                    />
-                                </section>
+                                {tournament.format === 'league' && standings ? (
+                                    <section className="space-y-4">
+                                        <h2 className="text-lg font-semibold">
+                                            Tabla de Posiciones
+                                        </h2>
+                                        <StandingsTable
+                                            rows={standings}
+                                            highlightTopN={1}
+                                        />
+                                    </section>
+                                ) : tournament.format ===
+                                  'group_stage_knockout' ? (
+                                    <>
+                                        {tournament.groups &&
+                                            groupStandings && (
+                                                <section className="space-y-4">
+                                                    <h2 className="text-lg font-semibold">
+                                                        {tournament.phase ===
+                                                            'knockout' ||
+                                                        tournament.phase ===
+                                                            'completed'
+                                                            ? 'Tablas Finales de Grupos'
+                                                            : 'Fase de Grupos'}
+                                                    </h2>
+                                                    <GroupsGrid
+                                                        groups={
+                                                            tournament.groups
+                                                        }
+                                                        standingsByGroup={
+                                                            groupStandings
+                                                        }
+                                                        highlightTopN={2}
+                                                    />
+                                                </section>
+                                            )}
+                                        {(tournament.phase === 'knockout' ||
+                                            tournament.phase ===
+                                                'completed') && (
+                                            <section className="space-y-4">
+                                                <h2 className="text-lg font-semibold">
+                                                    Bracket
+                                                </h2>
+                                                <TournamentBracket
+                                                    rounds={tournament.rounds.filter(
+                                                        (r) =>
+                                                            !r.matches?.some(
+                                                                (m) =>
+                                                                    m.tournament_group_id !=
+                                                                    null,
+                                                            ),
+                                                    )}
+                                                />
+                                            </section>
+                                        )}
+                                    </>
+                                ) : (
+                                    <section className="space-y-4">
+                                        <h2 className="text-lg font-semibold">
+                                            Bracket
+                                        </h2>
+                                        <TournamentBracket
+                                            rounds={tournament.rounds}
+                                        />
+                                    </section>
+                                )}
 
                                 <Card>
                                     <CardHeader>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -255,6 +255,42 @@ export type TournamentTeamStatus =
     | 'rejected'
     | 'withdrawn';
 
+export type TournamentFormat =
+    | 'single_elimination'
+    | 'league'
+    | 'group_stage_knockout';
+
+export type TournamentPhase =
+    | 'not_started'
+    | 'league'
+    | 'group_stage'
+    | 'knockout'
+    | 'completed';
+
+export interface StandingRow {
+    team_id: number;
+    team?: Team;
+    played: number;
+    wins: number;
+    draws: number;
+    losses: number;
+    goals_for: number;
+    goals_against: number;
+    goal_difference: number;
+    points: number;
+    position: number;
+    tied_with_above: boolean;
+}
+
+export interface TournamentGroup {
+    id: number;
+    tournament_id: number;
+    name: string;
+    position: number;
+    teams?: TournamentTeam[];
+    standings?: StandingRow[];
+}
+
 export interface Tournament {
     id: number;
     name: string;
@@ -266,6 +302,10 @@ export interface Tournament {
     visibility: TournamentVisibility;
     status: TournamentStatus;
     variant: string;
+    format: TournamentFormat;
+    phase: TournamentPhase;
+    group_count?: number | null;
+    group_size?: number | null;
     max_teams: number;
     min_teams: number;
     registered_teams_count?: number;
@@ -276,6 +316,7 @@ export interface Tournament {
     updated_at: string;
     tournament_teams?: TournamentTeam[];
     rounds?: TournamentRound[];
+    groups?: TournamentGroup[];
     [key: string]: unknown;
 }
 
@@ -286,6 +327,7 @@ export interface TournamentTeam {
     team?: Team;
     status: TournamentTeamStatus;
     seed?: number;
+    tournament_group_id?: number | null;
     registered_by: number;
     registered_at: string;
     approved_at?: string;
@@ -312,7 +354,10 @@ export interface FootballMatch {
     tournament?: Tournament;
     tournament_round_id?: number;
     tournament_round?: TournamentRound;
+    tournament_group_id?: number | null;
+    tournament_group?: TournamentGroup;
     bracket_position?: number;
+    matchday?: number | null;
     variant: string;
     scheduled_at: string | null;
     location: string | null;

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -1,34 +1,24 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" @class(['dark'=> ($appearance ?? 'system') == 'dark'])>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
 
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
 
-    {{-- Inline script to detect system dark mode preference and apply it immediately --}}
+    {{-- Keep the application on the fixed dark Veltro theme before React hydrates. --}}
     <script>
         (function() {
-            const appearance = '{{ $appearance ?? "system" }}';
-
-            if (appearance === 'system') {
-                const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-
-                if (prefersDark) {
-                    document.documentElement.classList.add('dark');
-                }
-            }
+            document.documentElement.classList.add('dark');
+            document.documentElement.style.colorScheme = 'dark';
         })();
     </script>
 
     {{-- Inline style to set the HTML background color based on our theme in app.css --}}
     <style>
-        html {
-            background-color: oklch(1 0 0);
-        }
-
+        html,
         html.dark {
-            background-color: oklch(0.145 0 0);
+            background-color: #101312;
         }
     </style>
 

--- a/routes/tournaments.php
+++ b/routes/tournaments.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\TournamentController;
+use App\Http\Controllers\TournamentGroupController;
 use App\Http\Controllers\TournamentLogoController;
 use App\Http\Controllers\TournamentMatchController;
 use App\Http\Controllers\TournamentRegistrationController;
@@ -23,6 +24,10 @@ Route::middleware(['auth', 'verified', 'throttle:tournaments', 'onboarding'])->g
 
     // Tournament Match Scheduling
     Route::patch('/tournaments/{tournament}/matches/{match}', [TournamentMatchController::class, 'update'])->name('tournaments.matches.update');
+
+    // Tournament Groups (group_stage_knockout draw)
+    Route::post('/tournaments/{id}/groups/draw', [TournamentGroupController::class, 'assign'])->name('tournaments.groups.assign');
+    Route::delete('/tournaments/{id}/groups/draw', [TournamentGroupController::class, 'clear'])->name('tournaments.groups.clear');
 
     // Tournament Logo
     Route::post('/tournaments/{id}/logo', [TournamentLogoController::class, 'store'])->name('tournaments.logo.store');

--- a/tests/Feature/Tournament/GroupStageKnockoutTest.php
+++ b/tests/Feature/Tournament/GroupStageKnockoutTest.php
@@ -1,0 +1,264 @@
+<?php
+
+use App\Models\Team;
+use App\Models\Tournament;
+use App\Models\TournamentGroup;
+use App\Models\TournamentTeam;
+use App\Models\User;
+use App\Services\MatchService;
+use App\Services\TournamentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Build a group_stage_knockout tournament with `groupCount * groupSize`
+ * approved teams. Returns the tournament with eager-loaded groups.
+ */
+function makeGroupTournament(int $groupCount, int $groupSize, User $organizer): Tournament
+{
+    $maxTeams = $groupCount * $groupSize;
+    $tournament = Tournament::factory()->create([
+        'organizer_id' => $organizer->id,
+        'status' => 'registration_open',
+        'variant' => 'football_11',
+        'format' => 'group_stage_knockout',
+        'phase' => 'not_started',
+        'group_count' => $groupCount,
+        'group_size' => $groupSize,
+        'max_teams' => $maxTeams,
+        'min_teams' => $maxTeams,
+    ]);
+
+    // Auto-create groups (mirrors what the service does on real creation).
+    for ($i = 0; $i < $groupCount; $i++) {
+        TournamentGroup::create([
+            'tournament_id' => $tournament->id,
+            'name' => chr(ord('A') + $i),
+            'position' => $i,
+        ]);
+    }
+
+    for ($i = 0; $i < $maxTeams; $i++) {
+        $team = Team::factory()->create(['variant' => 'football_11']);
+        TournamentTeam::factory()->create([
+            'tournament_id' => $tournament->id,
+            'team_id' => $team->id,
+            'status' => 'approved',
+            'seed' => $i + 1,
+            'registered_by' => $organizer->id,
+        ]);
+    }
+
+    return $tournament->fresh(['groups']);
+}
+
+test('creating a group_stage_knockout tournament auto-creates groups', function () {
+    $user = User::factory()->create(['email_verified_at' => now()]);
+    $this->actingAs($user);
+
+    $response = $this->post('/tournaments', [
+        'name' => 'Mundialito',
+        'visibility' => 'public',
+        'variant' => 'football_11',
+        'format' => 'group_stage_knockout',
+        'group_count' => 4,
+        'group_size' => 4,
+        'min_teams' => 16,
+        'starts_at' => now()->addDays(3)->toDateTimeString(),
+    ]);
+
+    $response->assertRedirect();
+    $tournament = Tournament::where('name', 'Mundialito')->first();
+    expect($tournament->format)->toBe('group_stage_knockout')
+        ->and($tournament->group_count)->toBe(4)
+        ->and($tournament->group_size)->toBe(4)
+        ->and($tournament->max_teams)->toBe(16)
+        ->and($tournament->groups()->count())->toBe(4);
+
+    $names = $tournament->groups()->orderBy('position')->pluck('name')->all();
+    expect($names)->toBe(['A', 'B', 'C', 'D']);
+});
+
+test('cannot start group_stage_knockout until every team is assigned to a group', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeGroupTournament(2, 4, $organizer); // 8 teams, 2 groups
+
+    // Assign only 4 teams (one full group, one empty)
+    $teams = $tournament->tournamentTeams()->orderBy('id')->get();
+    $groupA = $tournament->groups->first();
+    foreach ($teams->take(4) as $tt) {
+        $tt->update(['tournament_group_id' => $groupA->id]);
+    }
+
+    $this->actingAs($organizer);
+    $response = $this->post("/tournaments/{$tournament->id}/start");
+    $response->assertSessionHasErrors();
+
+    expect($tournament->fresh()->status)->toBe('registration_open');
+});
+
+test('group draw endpoint enforces capacity', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeGroupTournament(2, 4, $organizer); // 8 teams, 2 groups of 4
+    $teams = $tournament->tournamentTeams()->orderBy('id')->get();
+    $groupA = $tournament->groups->first();
+
+    $this->actingAs($organizer);
+
+    // Try to put 5 teams into a 4-team group
+    $assignments = $teams->take(5)->map(fn ($tt) => [
+        'tournament_team_id' => $tt->id,
+        'tournament_group_id' => $groupA->id,
+    ])->all();
+
+    $response = $this->post("/tournaments/{$tournament->id}/groups/draw", [
+        'assignments' => $assignments,
+    ]);
+
+    $response->assertSessionHasErrors();
+
+    // No assignments persisted.
+    expect($tournament->fresh()->tournamentTeams()->whereNotNull('tournament_group_id')->count())->toBe(0);
+});
+
+test('starting a group_stage_knockout generates round-robin matches across all groups', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeGroupTournament(2, 4, $organizer); // 8 teams, 2 groups of 4 → 6 matches/group, 3 matchdays
+
+    // Manually distribute teams: first 4 → group A, last 4 → group B
+    $teams = $tournament->tournamentTeams()->orderBy('id')->get();
+    $groupA = $tournament->groups->where('position', 0)->first();
+    $groupB = $tournament->groups->where('position', 1)->first();
+    foreach ($teams->take(4) as $tt) {
+        $tt->update(['tournament_group_id' => $groupA->id]);
+    }
+    foreach ($teams->skip(4) as $tt) {
+        $tt->update(['tournament_group_id' => $groupB->id]);
+    }
+
+    app(TournamentService::class)->startTournament($tournament);
+
+    $tournament = $tournament->fresh();
+    expect($tournament->status)->toBe('in_progress')
+        ->and($tournament->phase)->toBe('group_stage');
+
+    // Each group has n*(n-1)/2 = 6 matches
+    expect($tournament->matches()->where('tournament_group_id', $groupA->id)->count())->toBe(6);
+    expect($tournament->matches()->where('tournament_group_id', $groupB->id)->count())->toBe(6);
+
+    // 3 shared matchdays, each with 4 matches (2 per group × 2 groups)
+    expect($tournament->rounds()->count())->toBe(3);
+    for ($md = 1; $md <= 3; $md++) {
+        expect($tournament->matches()->where('matchday', $md)->count())->toBe(4);
+    }
+});
+
+test('completing all group matches transitions to knockout with cross-bracket pairings', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeGroupTournament(2, 4, $organizer);
+
+    // Distribute teams into groups deterministically by seed
+    $teams = $tournament->tournamentTeams()->orderBy('seed')->get();
+    $groupA = $tournament->groups->where('position', 0)->first();
+    $groupB = $tournament->groups->where('position', 1)->first();
+    foreach ($teams->take(4) as $tt) {
+        $tt->update(['tournament_group_id' => $groupA->id]);
+    }
+    foreach ($teams->skip(4) as $tt) {
+        $tt->update(['tournament_group_id' => $groupB->id]);
+    }
+
+    app(TournamentService::class)->startTournament($tournament);
+
+    // Complete every group match. Use scoring that produces a clean ordering:
+    // home team always wins by 2-0. Inside each group the team that plays home
+    // most often wins; we just verify the transition fires, not the exact order.
+    $tournament->fresh()->matches()->whereNotNull('tournament_group_id')->get()->each(function ($match) {
+        $match->update([
+            'status' => 'in_progress',
+            'started_at' => now()->subHours(2),
+            'scheduled_at' => now()->subHours(3),
+            'home_score' => 2,
+            'away_score' => 0,
+        ]);
+        app(MatchService::class)->completeMatch($match->fresh());
+    });
+
+    $tournament = $tournament->fresh();
+
+    // Phase advanced to knockout
+    expect($tournament->phase)->toBe('knockout');
+
+    // 4-team bracket = 2 rounds (Semifinal, Final). Group stage had 3 rounds, so
+    // bracket rounds continue at 4 and 5.
+    $bracketRounds = $tournament->rounds()->where('round_number', '>=', 4)->orderBy('round_number')->get();
+    expect($bracketRounds)->toHaveCount(2);
+    expect($bracketRounds[0]->name)->toBe('Semifinal');
+    expect($bracketRounds[1]->name)->toBe('Final');
+
+    // First bracket round (semifinals) should have 2 matches with both teams set
+    $semifinals = $tournament->matches()->where('tournament_round_id', $bracketRounds[0]->id)->get();
+    expect($semifinals)->toHaveCount(2);
+    foreach ($semifinals as $sf) {
+        expect($sf->home_team_id)->not->toBeNull();
+        expect($sf->away_team_id)->not->toBeNull();
+        expect($sf->status)->toBe('confirmed');
+    }
+});
+
+test('completing group matches with all groups incomplete does not transition', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeGroupTournament(2, 4, $organizer);
+
+    $teams = $tournament->tournamentTeams()->orderBy('seed')->get();
+    foreach ($teams->take(4) as $tt) {
+        $tt->update(['tournament_group_id' => $tournament->groups->where('position', 0)->first()->id]);
+    }
+    foreach ($teams->skip(4) as $tt) {
+        $tt->update(['tournament_group_id' => $tournament->groups->where('position', 1)->first()->id]);
+    }
+
+    app(TournamentService::class)->startTournament($tournament);
+
+    // Complete only the FIRST group match
+    $first = $tournament->fresh()->matches()->whereNotNull('tournament_group_id')->orderBy('id')->first();
+    $first->update([
+        'status' => 'in_progress',
+        'started_at' => now()->subHours(2),
+        'scheduled_at' => now()->subHours(3),
+        'home_score' => 1,
+        'away_score' => 0,
+    ]);
+    app(MatchService::class)->completeMatch($first->fresh());
+
+    expect($tournament->fresh()->phase)->toBe('group_stage');
+});
+
+test('group standings appear in show endpoint props', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeGroupTournament(2, 4, $organizer);
+
+    // Don't start; just request the page.
+    $this->actingAs($organizer);
+    $response = $this->get("/tournaments/{$tournament->id}");
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->component('tournaments/show')
+        ->has('groupStandings', 2)
+    );
+});
+
+test('non-organizer cannot draw groups', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $stranger = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeGroupTournament(2, 4, $organizer);
+
+    $this->actingAs($stranger);
+    $response = $this->post("/tournaments/{$tournament->id}/groups/draw", [
+        'assignments' => [],
+    ]);
+
+    $response->assertForbidden();
+});

--- a/tests/Feature/Tournament/LeagueFormatTest.php
+++ b/tests/Feature/Tournament/LeagueFormatTest.php
@@ -1,0 +1,256 @@
+<?php
+
+use App\Models\Team;
+use App\Models\Tournament;
+use App\Models\TournamentTeam;
+use App\Models\User;
+use App\Services\MatchService;
+use App\Services\TournamentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function makeLeagueTournament(int $teamCount, User $organizer): Tournament
+{
+    $tournament = Tournament::factory()->create([
+        'organizer_id' => $organizer->id,
+        'status' => 'registration_open',
+        'variant' => 'football_11',
+        'format' => 'league',
+        'phase' => 'not_started',
+        'max_teams' => $teamCount,
+        'min_teams' => 2,
+    ]);
+
+    for ($i = 0; $i < $teamCount; $i++) {
+        $team = Team::factory()->create(['variant' => 'football_11']);
+        TournamentTeam::factory()->create([
+            'tournament_id' => $tournament->id,
+            'team_id' => $team->id,
+            'status' => 'approved',
+            'seed' => $i + 1,
+            'registered_by' => $organizer->id,
+        ]);
+    }
+
+    return $tournament->fresh();
+}
+
+test('user can create a league tournament with a non-power-of-2 team count', function () {
+    $user = User::factory()->create(['email_verified_at' => now()]);
+    $this->actingAs($user);
+
+    $response = $this->post('/tournaments', [
+        'name' => 'Liga de Prueba',
+        'visibility' => 'public',
+        'variant' => 'football_11',
+        'format' => 'league',
+        'max_teams' => 6,
+        'min_teams' => 2,
+        'starts_at' => now()->addDays(3)->toDateTimeString(),
+    ]);
+
+    $response->assertRedirect();
+    $this->assertDatabaseHas('tournaments', [
+        'name' => 'Liga de Prueba',
+        'format' => 'league',
+        'phase' => 'not_started',
+        'max_teams' => 6,
+    ]);
+});
+
+test('league tournament requires max_teams between 2 and 64', function () {
+    $user = User::factory()->create(['email_verified_at' => now()]);
+    $this->actingAs($user);
+
+    $response = $this->post('/tournaments', [
+        'name' => 'Liga',
+        'visibility' => 'public',
+        'variant' => 'football_11',
+        'format' => 'league',
+        'max_teams' => 1,
+        'min_teams' => 2,
+    ]);
+
+    $response->assertSessionHasErrors('max_teams');
+});
+
+test('starting a league with fewer than min_teams fails', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = Tournament::factory()->create([
+        'organizer_id' => $organizer->id,
+        'status' => 'registration_open',
+        'format' => 'league',
+        'phase' => 'not_started',
+        'max_teams' => 6,
+        'min_teams' => 4,
+    ]);
+
+    // Only register 2 teams
+    for ($i = 0; $i < 2; $i++) {
+        $team = Team::factory()->create(['variant' => $tournament->variant]);
+        TournamentTeam::factory()->create([
+            'tournament_id' => $tournament->id,
+            'team_id' => $team->id,
+            'status' => 'approved',
+            'registered_by' => $organizer->id,
+        ]);
+    }
+
+    $this->actingAs($organizer);
+    $response = $this->post("/tournaments/{$tournament->id}/start");
+    $response->assertSessionHasErrors();
+
+    $this->assertDatabaseHas('tournaments', [
+        'id' => $tournament->id,
+        'status' => 'registration_open',
+    ]);
+});
+
+test('starting a league generates a full round-robin schedule', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeLeagueTournament(6, $organizer);
+
+    $this->actingAs($organizer);
+    $this->post("/tournaments/{$tournament->id}/start")->assertRedirect();
+
+    $tournament = $tournament->fresh();
+    expect($tournament->status)->toBe('in_progress')
+        ->and($tournament->phase)->toBe('league');
+
+    // n*(n-1)/2 = 15 matches across n-1 = 5 matchdays
+    expect($tournament->matches()->count())->toBe(15);
+    expect($tournament->rounds()->count())->toBe(5);
+
+    // Each matchday has exactly 3 matches (6 teams / 2)
+    for ($md = 1; $md <= 5; $md++) {
+        expect($tournament->matches()->where('matchday', $md)->count())->toBe(3);
+    }
+
+    // Every team plays every other team exactly once.
+    $teamIds = $tournament->approvedTeams()->pluck('team_id')->all();
+    foreach ($teamIds as $teamId) {
+        $opponents = $tournament->matches()
+            ->where(function ($q) use ($teamId) {
+                $q->where('home_team_id', $teamId)->orWhere('away_team_id', $teamId);
+            })
+            ->get()
+            ->map(fn ($m) => $m->home_team_id === $teamId ? $m->away_team_id : $m->home_team_id)
+            ->unique()
+            ->sort()
+            ->values()
+            ->all();
+
+        $expected = collect($teamIds)->reject(fn ($id) => $id === $teamId)->sort()->values()->all();
+        expect($opponents)->toBe($expected, "team {$teamId} should play every other team exactly once");
+    }
+});
+
+test('league matches accept draws without throwing', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeLeagueTournament(4, $organizer);
+    app(TournamentService::class)->startTournament($tournament);
+
+    $match = $tournament->fresh()->matches()->first();
+    $match->update([
+        'status' => 'in_progress',
+        'started_at' => now()->subMinutes(90),
+        'scheduled_at' => now()->subHours(2),
+        'home_score' => 1,
+        'away_score' => 1,
+    ]);
+
+    app(MatchService::class)->completeMatch($match->fresh());
+
+    expect($match->fresh()->status)->toBe('completed');
+});
+
+test('completing the last league match marks the tournament completed', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeLeagueTournament(4, $organizer);
+    app(TournamentService::class)->startTournament($tournament);
+
+    $matches = $tournament->fresh()->matches;
+    expect($matches)->toHaveCount(6); // 4 teams → 6 matches
+
+    foreach ($matches as $i => $match) {
+        $match->update([
+            'status' => 'in_progress',
+            'started_at' => now()->subMinutes(90),
+            'scheduled_at' => now()->subHours(2),
+            'home_score' => 2,
+            'away_score' => $i,
+        ]);
+        app(MatchService::class)->completeMatch($match->fresh());
+    }
+
+    $tournament = $tournament->fresh();
+    expect($tournament->status)->toBe('completed')
+        ->and($tournament->phase)->toBe('completed')
+        ->and($tournament->ends_at)->not->toBeNull();
+});
+
+test('tournament show endpoint includes standings for league format', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = makeLeagueTournament(4, $organizer);
+    app(TournamentService::class)->startTournament($tournament);
+
+    // Complete two matches with deterministic results.
+    $tournament->fresh()->matches->each(function ($match, $i) {
+        if ($i >= 2) {
+            return;
+        }
+        $match->update([
+            'status' => 'in_progress',
+            'started_at' => now()->subMinutes(90),
+            'scheduled_at' => now()->subHours(2),
+            'home_score' => 3,
+            'away_score' => 0,
+        ]);
+        app(MatchService::class)->completeMatch($match->fresh());
+    });
+
+    $this->actingAs($organizer);
+    $response = $this->get("/tournaments/{$tournament->id}");
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->component('tournaments/show')
+        ->has('standings', 4)
+        ->where('standings.0.position', 1)
+    );
+});
+
+test('single-elimination regression: existing flow still works', function () {
+    $organizer = User::factory()->create(['email_verified_at' => now()]);
+    $tournament = Tournament::factory()->create([
+        'organizer_id' => $organizer->id,
+        'status' => 'registration_open',
+        'variant' => 'football_11',
+        'max_teams' => 4,
+        'min_teams' => 4,
+    ]);
+
+    for ($i = 0; $i < 4; $i++) {
+        $team = Team::factory()->create(['variant' => 'football_11']);
+        TournamentTeam::factory()->create([
+            'tournament_id' => $tournament->id,
+            'team_id' => $team->id,
+            'status' => 'approved',
+            'seed' => $i + 1,
+            'registered_by' => $organizer->id,
+        ]);
+    }
+
+    $this->actingAs($organizer);
+    $this->post("/tournaments/{$tournament->id}/start")->assertRedirect();
+
+    $tournament = $tournament->fresh();
+    expect($tournament->status)->toBe('in_progress')
+        ->and($tournament->phase)->toBe('knockout')
+        ->and($tournament->format)->toBe('single_elimination');
+
+    // 4 teams → 2 rounds (Semifinal, Final), 3 matches total (2 in first round + 1 placeholder)
+    expect($tournament->rounds()->count())->toBe(2);
+    expect($tournament->matches()->count())->toBe(3);
+});

--- a/tests/Unit/Services/StandingsServiceTest.php
+++ b/tests/Unit/Services/StandingsServiceTest.php
@@ -1,0 +1,194 @@
+<?php
+
+use App\Models\FootballMatch;
+use App\Services\StandingsService;
+
+function standingsMatch(int $home, int $away, int $homeScore, int $awayScore, string $status = 'completed'): FootballMatch
+{
+    $match = new FootballMatch;
+    $match->home_team_id = $home;
+    $match->away_team_id = $away;
+    $match->home_score = $homeScore;
+    $match->away_score = $awayScore;
+    $match->status = $status;
+
+    return $match;
+}
+
+it('returns one row per team with zeros when no matches exist', function () {
+    $rows = (new StandingsService)->compute(collect(), collect([1, 2, 3]));
+
+    expect($rows)->toHaveCount(3);
+    foreach ($rows as $row) {
+        expect($row->played)->toBe(0)
+            ->and($row->wins)->toBe(0)
+            ->and($row->draws)->toBe(0)
+            ->and($row->losses)->toBe(0)
+            ->and($row->points)->toBe(0)
+            ->and($row->goalDifference)->toBe(0)
+            ->and($row->tiedWithAbove)->toBeFalse();
+    }
+    // Input order preserved when no matches have been played.
+    expect(array_map(fn ($r) => $r->teamId, $rows))->toBe([1, 2, 3]);
+});
+
+it('aggregates wins, draws, losses, goals, and points correctly', function () {
+    $matches = collect([
+        standingsMatch(1, 2, 3, 1),  // 1 beats 2
+        standingsMatch(2, 3, 2, 2),  // draw
+        standingsMatch(1, 3, 1, 0),  // 1 beats 3
+    ]);
+
+    $rows = (new StandingsService)->compute($matches, collect([1, 2, 3]));
+
+    // Team 1: 2W = 6 pts, GF 4 GA 1 GD +3
+    expect($rows[0]->teamId)->toBe(1)
+        ->and($rows[0]->wins)->toBe(2)
+        ->and($rows[0]->draws)->toBe(0)
+        ->and($rows[0]->losses)->toBe(0)
+        ->and($rows[0]->goalsFor)->toBe(4)
+        ->and($rows[0]->goalsAgainst)->toBe(1)
+        ->and($rows[0]->goalDifference)->toBe(3)
+        ->and($rows[0]->points)->toBe(6)
+        ->and($rows[0]->position)->toBe(1);
+
+    // Team 3: 0W 1D 1L = 1 pt, GF 2 GA 3 GD -1 (better than team 2's GD -2)
+    expect($rows[1]->teamId)->toBe(3)
+        ->and($rows[1]->points)->toBe(1)
+        ->and($rows[1]->goalDifference)->toBe(-1)
+        ->and($rows[1]->position)->toBe(2);
+
+    // Team 2: 0W 1D 1L = 1 pt, GF 3 GA 5 GD -2
+    expect($rows[2]->teamId)->toBe(2)
+        ->and($rows[2]->points)->toBe(1)
+        ->and($rows[2]->goalDifference)->toBe(-2)
+        ->and($rows[2]->position)->toBe(3);
+});
+
+it('breaks ties by goal difference', function () {
+    $matches = collect([
+        standingsMatch(1, 3, 3, 0),  // 1 beats 3 by 3
+        standingsMatch(2, 3, 1, 0),  // 2 beats 3 by 1
+    ]);
+
+    $rows = (new StandingsService)->compute($matches, collect([1, 2, 3]));
+
+    // Teams 1 and 2 both have 3 pts; team 1 has GD +3, team 2 has GD +1.
+    expect($rows[0]->teamId)->toBe(1)->and($rows[0]->goalDifference)->toBe(3);
+    expect($rows[1]->teamId)->toBe(2)->and($rows[1]->goalDifference)->toBe(1);
+    expect($rows[2]->teamId)->toBe(3);
+});
+
+it('breaks ties by goals scored when GD is equal', function () {
+    $matches = collect([
+        standingsMatch(1, 3, 4, 2),  // 1 beats 3
+        standingsMatch(4, 1, 3, 1),  // 4 beats 1 — team 1 GD: +2 -2 = 0
+        standingsMatch(2, 3, 1, 0),  // 2 beats 3
+        standingsMatch(4, 2, 1, 0),  // 4 beats 2 — team 2 GD: +1 -1 = 0
+    ]);
+
+    $rows = (new StandingsService)->compute($matches, collect([1, 2, 3, 4]));
+
+    // Team 4: 2W = 6 pts (top)
+    // Team 1: 1W 1L = 3 pts, GD 0, GF 5
+    // Team 2: 1W 1L = 3 pts, GD 0, GF 1 — same pts/GD, less GF
+    // Team 3: 0W 2L = 0 pts (bottom)
+    expect($rows[0]->teamId)->toBe(4)->and($rows[0]->points)->toBe(6);
+    expect($rows[1]->teamId)->toBe(1)->and($rows[1]->goalsFor)->toBe(5);
+    expect($rows[2]->teamId)->toBe(2)->and($rows[2]->goalsFor)->toBe(1);
+    expect($rows[3]->teamId)->toBe(3);
+});
+
+it('breaks ties by head-to-head when primary stats are identical', function () {
+    // 4 teams. A=1, B=2, C=3, D=4. All play each other once.
+    $matches = collect([
+        standingsMatch(1, 4, 5, 0),  // A beats D 5-0
+        standingsMatch(1, 2, 1, 0),  // A beats B 1-0
+        standingsMatch(3, 1, 1, 0),  // C beats A 1-0
+        standingsMatch(4, 2, 5, 0),  // D beats B 5-0
+        standingsMatch(3, 4, 5, 0),  // C beats D 5-0
+        standingsMatch(2, 3, 1, 0),  // B beats C 1-0
+    ]);
+
+    $rows = (new StandingsService)->compute($matches, collect([1, 2, 3, 4]));
+
+    // A: 6 pts, GF 6 GA 1 GD +5
+    // C: 6 pts, GF 6 GA 1 GD +5  ← tied with A on (pts, GD, GF); H2H: C beat A, so C first
+    // D: 3 pts, GF 5 GA 10 GD -5
+    // B: 3 pts, GF 1 GA 6  GD -5  ← tied with D on (pts, GD); GF tiebreak: D ahead (5 > 1)
+    expect($rows[0]->teamId)->toBe(3); // C
+    expect($rows[1]->teamId)->toBe(1); // A
+    expect($rows[2]->teamId)->toBe(4); // D
+    expect($rows[3]->teamId)->toBe(2); // B
+});
+
+it('uses seeded RNG to break truly unbreakable ties deterministically', function () {
+    // Rock-paper-scissors: each team beats one and loses to the other.
+    // All 3 teams: 1W 1L = 3 pts, GF 1 GA 1 GD 0. H2H mini-table is identical.
+    $matches = collect([
+        standingsMatch(1, 2, 1, 0),
+        standingsMatch(2, 3, 1, 0),
+        standingsMatch(3, 1, 1, 0),
+    ]);
+
+    $svc = new StandingsService;
+    $rows1 = $svc->compute($matches, collect([1, 2, 3]), rngSeed: 42);
+    $rows2 = $svc->compute($matches, collect([1, 2, 3]), rngSeed: 42);
+
+    $ids1 = array_map(fn ($r) => $r->teamId, $rows1);
+    $ids2 = array_map(fn ($r) => $r->teamId, $rows2);
+
+    // Same seed → identical order.
+    expect($ids1)->toBe($ids2);
+
+    // The 2nd and 3rd teams are flagged as tied with above.
+    expect($rows1[1]->tiedWithAbove)->toBeTrue();
+    expect($rows1[2]->tiedWithAbove)->toBeTrue();
+    expect($rows1[0]->tiedWithAbove)->toBeFalse();
+});
+
+it('preserves input order when tied teams have not yet played each other', function () {
+    // Mid-stage standings: teams 1, 2, 3 are all at zero having only played team 4.
+    // No actual H2H between 1/2/3 — should NOT shuffle them via RNG.
+    $matches = collect([
+        standingsMatch(4, 1, 1, 0),  // team 1 lost to 4
+        standingsMatch(4, 2, 1, 0),  // team 2 lost to 4
+        standingsMatch(4, 3, 1, 0),  // team 3 lost to 4
+    ]);
+
+    $rows = (new StandingsService)->compute($matches, collect([1, 2, 3, 4]));
+
+    expect($rows[0]->teamId)->toBe(4);
+    // Teams 1, 2, 3 all tied (0 pts, GD -1, GF 0) and have NOT played each
+    // other → input order preserved, no _tied_with_above markers.
+    expect($rows[1]->teamId)->toBe(1)->and($rows[1]->tiedWithAbove)->toBeFalse();
+    expect($rows[2]->teamId)->toBe(2)->and($rows[2]->tiedWithAbove)->toBeFalse();
+    expect($rows[3]->teamId)->toBe(3)->and($rows[3]->tiedWithAbove)->toBeFalse();
+});
+
+it('ignores matches involving teams outside the team set', function () {
+    $matches = collect([
+        standingsMatch(1, 2, 3, 1),
+        standingsMatch(99, 1, 5, 0), // team 99 not in the set
+    ]);
+
+    $rows = (new StandingsService)->compute($matches, collect([1, 2]));
+
+    expect($rows[0]->teamId)->toBe(1)
+        ->and($rows[0]->played)->toBe(1)
+        ->and($rows[0]->goalsFor)->toBe(3);
+});
+
+it('ignores non-completed matches', function () {
+    $matches = collect([
+        standingsMatch(1, 2, 3, 1, 'completed'),
+        standingsMatch(1, 2, 0, 0, 'in_progress'),
+        standingsMatch(1, 2, 0, 0, 'confirmed'),
+    ]);
+
+    $rows = (new StandingsService)->compute($matches, collect([1, 2]));
+
+    expect($rows[0]->played)->toBe(1)
+        ->and($rows[0]->teamId)->toBe(1)
+        ->and($rows[0]->wins)->toBe(1);
+});


### PR DESCRIPTION
## Summary
- Add server-backed tournament index filters, counts, sorting, and pagination
- Replace the tournament cards with a denser list view with thumbnails and capacity progress
- Commit the remaining UI updates currently on the branch

## Tests
- bun run types
- bunx eslint resources/js/pages/tournaments/index.tsx
- php -l app/Http/Controllers/TournamentController.php
- ./vendor/bin/pint app/Http/Controllers/TournamentController.php
- bun run build