### PR TITLE
feat: improve tournament detail layout

### DIFF
--- a/resources/js/components/tournament/tournament-bracket.tsx
+++ b/resources/js/components/tournament/tournament-bracket.tsx
@@ -1,5 +1,4 @@
 import { Badge } from '@/components/ui/badge';
-import { Card, CardContent } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 import type { FootballMatch, TournamentRound } from '@/types';
 import { Link } from '@inertiajs/react';
@@ -23,92 +22,90 @@ const BracketMatch = ({ match }: BracketMatchProps) => {
     const wrapperProps = match.id ? { href: `/matches/${match.id}` } : {};
 
     return (
-        <MatchWrapper {...wrapperProps}>
-            <Card
+        <MatchWrapper {...wrapperProps} className={cn(match.id && 'block')}>
+            <div
                 className={cn(
-                    'mb-4 transition-all',
+                    'overflow-hidden rounded-lg border bg-card text-card-foreground shadow-sm transition-colors',
                     match.id &&
-                        'cursor-pointer hover:border-primary/30 hover:shadow-md',
-                    isPending && 'opacity-60',
+                        'cursor-pointer hover:border-primary/40 hover:bg-muted/20',
+                    isPending && 'opacity-70',
                 )}
             >
-                <CardContent className="p-0">
-                    {/* Home Team */}
-                    <div
-                        className={cn(
-                            'flex items-center justify-between border-b px-3 py-2.5 transition-colors',
-                            winnerId === match.home_team_id &&
-                                'bg-primary/10 font-semibold',
-                        )}
-                    >
-                        <div className="flex min-w-0 flex-1 items-center gap-2">
-                            <span
-                                className={cn(
-                                    'truncate text-sm',
-                                    !match.home_team_id &&
-                                        'text-muted-foreground italic',
-                                )}
-                            >
-                                {match.home_team?.name || 'TBD'}
-                            </span>
-                            {winnerId === match.home_team_id && (
-                                <Trophy className="size-3.5 flex-shrink-0 text-yellow-600 dark:text-yellow-500" />
-                            )}
-                        </div>
-                        {isCompleted && match.home_score !== undefined && (
-                            <span className="ml-2 text-sm font-bold tabular-nums">
-                                {match.home_score}
-                            </span>
+                <BracketTeamRow
+                    name={match.home_team?.name || 'TBD'}
+                    score={match.home_score}
+                    isWinner={winnerId === match.home_team_id}
+                    isPlaceholder={!match.home_team_id}
+                    showScore={isCompleted}
+                    hasBorder
+                />
+                <BracketTeamRow
+                    name={match.away_team?.name || 'TBD'}
+                    score={match.away_score}
+                    isWinner={winnerId === match.away_team_id}
+                    isPlaceholder={!match.away_team_id}
+                    showScore={isCompleted}
+                />
+                {(isPending || isUpcoming) && (
+                    <div className="border-t bg-muted/25 px-3 py-1.5 text-center">
+                        {isPending ? (
+                            <Badge variant="outline" className="h-5 text-xs">
+                                Pendiente
+                            </Badge>
+                        ) : (
+                            <Badge className="h-5 text-xs">Próximo</Badge>
                         )}
                     </div>
-
-                    {/* Away Team */}
-                    <div
-                        className={cn(
-                            'flex items-center justify-between px-3 py-2.5 transition-colors',
-                            winnerId === match.away_team_id &&
-                                'bg-primary/10 font-semibold',
-                        )}
-                    >
-                        <div className="flex min-w-0 flex-1 items-center gap-2">
-                            <span
-                                className={cn(
-                                    'truncate text-sm',
-                                    !match.away_team_id &&
-                                        'text-muted-foreground italic',
-                                )}
-                            >
-                                {match.away_team?.name || 'TBD'}
-                            </span>
-                            {winnerId === match.away_team_id && (
-                                <Trophy className="size-3.5 flex-shrink-0 text-yellow-600 dark:text-yellow-500" />
-                            )}
-                        </div>
-                        {isCompleted && match.away_score !== undefined && (
-                            <span className="ml-2 text-sm font-bold tabular-nums">
-                                {match.away_score}
-                            </span>
-                        )}
-                    </div>
-
-                    {/* Status Badge */}
-                    {(isPending || isUpcoming) && (
-                        <div className="border-t bg-muted/30 px-3 py-1.5 text-center">
-                            {isPending && (
-                                <Badge variant="outline" className="text-xs">
-                                    Pendiente
-                                </Badge>
-                            )}
-                            {isUpcoming && (
-                                <Badge className="text-xs">Próximo</Badge>
-                            )}
-                        </div>
-                    )}
-                </CardContent>
-            </Card>
+                )}
+            </div>
         </MatchWrapper>
     );
 };
+
+function BracketTeamRow({
+    name,
+    score,
+    isWinner,
+    isPlaceholder,
+    showScore,
+    hasBorder,
+}: {
+    name: string;
+    score?: number;
+    isWinner: boolean;
+    isPlaceholder: boolean;
+    showScore: boolean;
+    hasBorder?: boolean;
+}) {
+    return (
+        <div
+            className={cn(
+                'flex h-11 items-center justify-between gap-3 px-3 transition-colors',
+                hasBorder && 'border-b',
+                isWinner && 'bg-emerald-500/10 font-semibold text-foreground',
+            )}
+        >
+            <div className="flex min-w-0 items-center gap-2">
+                <span
+                    className={cn(
+                        'truncate text-sm',
+                        isPlaceholder && 'text-muted-foreground italic',
+                    )}
+                >
+                    {name}
+                </span>
+                {isWinner && (
+                    <Trophy className="size-3.5 shrink-0 text-yellow-500" />
+                )}
+            </div>
+            {showScore && (
+                <span className="text-sm font-bold tabular-nums">
+                    {score ?? 0}
+                </span>
+            )}
+        </div>
+    );
+}
 
 const getWinnerId = (match: FootballMatch): number | null => {
     if (
@@ -138,21 +135,20 @@ export const TournamentBracket = ({ rounds }: TournamentBracketProps) => {
     }
 
     return (
-        <div className="overflow-x-auto">
-            <div className="inline-flex gap-6 pb-4">
-                {rounds.map((round, index) => (
-                    <div key={round.id} className="flex flex-col">
-                        {/* Round Header */}
+        <div className="overflow-x-auto rounded-lg border bg-muted/10 p-3">
+            <div className="grid min-w-max auto-cols-[minmax(16rem,18rem)] grid-flow-col gap-4 pb-1">
+                {rounds.map((round) => (
+                    <div key={round.id} className="flex min-w-64 flex-col">
                         <div
                             className={cn(
-                                'mb-4 rounded-lg border bg-card p-3 text-center',
+                                'sticky top-0 left-0 z-10 mb-3 rounded-lg border bg-card/95 p-3 text-center backdrop-blur',
                                 round.round_number === rounds.length &&
-                                    'border-primary/50 bg-primary/5',
+                                    'border-primary/50 bg-primary/10',
                             )}
                         >
                             <h3
                                 className={cn(
-                                    'text-base font-semibold',
+                                    'text-sm font-semibold',
                                     round.round_number === rounds.length &&
                                         'text-primary',
                                 )}
@@ -163,35 +159,20 @@ export const TournamentBracket = ({ rounds }: TournamentBracketProps) => {
                                 Ronda {round.round_number}
                             </p>
                         </div>
-
-                        {/* Matches in Round */}
                         <div
-                            className="min-w-[260px] space-y-4"
+                            className="flex flex-1 flex-col justify-around gap-4"
                             style={{
-                                // Add vertical spacing that increases with each round
-                                marginTop:
-                                    index > 0
-                                        ? `${Math.pow(2, index - 1) * 40}px`
-                                        : '0',
+                                minHeight: `${Math.max(1, rounds[0]?.matches?.length ?? 1) * 8.5}rem`,
                             }}
                         >
                             {round.matches && round.matches.length > 0 ? (
-                                round.matches.map((match, matchIndex) => (
-                                    <div
-                                        key={match.id}
-                                        style={{
-                                            // Add spacing between matches that increases with rounds
-                                            marginTop:
-                                                matchIndex > 0
-                                                    ? `${Math.pow(2, index) * 40}px`
-                                                    : '0',
-                                        }}
-                                    >
+                                round.matches.map((match) => (
+                                    <div key={match.id} className="relative">
                                         <BracketMatch match={match} />
                                     </div>
                                 ))
                             ) : (
-                                <div className="text-center text-sm text-muted-foreground">
+                                <div className="rounded-lg border border-dashed px-3 py-8 text-center text-sm text-muted-foreground">
                                     Sin partidos
                                 </div>
                             )}

--- a/resources/js/pages/tournaments/show.tsx
+++ b/resources/js/pages/tournaments/show.tsx
@@ -25,6 +25,7 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { UserAvatar } from '@/components/user-avatar';
 import AppLayout from '@/layouts/app-layout';
+import { cn } from '@/lib/utils';
 import teams from '@/routes/teams';
 import tournamentRegistrations from '@/routes/tournament-registrations';
 import tournaments from '@/routes/tournaments';
@@ -327,7 +328,7 @@ export default function TournamentShow({
         <AppLayout breadcrumbs={breadcrumbs(tournament)}>
             <Head title={tournament.name} />
 
-            <div className="flex h-full flex-1 flex-col gap-6 p-6">
+            <div className="mx-auto flex h-full w-full max-w-[1600px] flex-1 flex-col gap-6 px-4 py-5 sm:px-6 lg:px-8">
                 <TournamentHeader
                     tournament={tournament}
                     approvedTeamsCount={approvedTeams.length}
@@ -340,10 +341,8 @@ export default function TournamentShow({
                     onDelete={() => setShowDeleteDialog(true)}
                 />
 
-                {/* Two-column layout */}
-                <div className="grid gap-6 lg:grid-cols-3">
-                    {/* Left column — main content */}
-                    <div className="space-y-6 lg:col-span-2">
+                <div className="grid items-start gap-6 xl:grid-cols-[minmax(0,1fr)_22rem] 2xl:grid-cols-[minmax(0,1fr)_24rem]">
+                    <div className="min-w-0 space-y-6">
                         {/* Group draw (group_stage_knockout, pre-start) */}
                         {tournament.format === 'group_stage_knockout' &&
                             permissions.canDrawGroups &&
@@ -367,15 +366,22 @@ export default function TournamentShow({
                         {hasBracket ? (
                             <>
                                 {tournament.format === 'league' && standings ? (
-                                    <section className="space-y-4">
-                                        <h2 className="text-lg font-semibold">
-                                            Tabla de Posiciones
-                                        </h2>
-                                        <StandingsTable
-                                            rows={standings}
-                                            highlightTopN={1}
-                                        />
-                                    </section>
+                                    <Card>
+                                        <CardHeader>
+                                            <CardTitle>
+                                                Tabla de Posiciones
+                                            </CardTitle>
+                                            <CardDescription>
+                                                Clasificación general del torneo
+                                            </CardDescription>
+                                        </CardHeader>
+                                        <CardContent>
+                                            <StandingsTable
+                                                rows={standings}
+                                                highlightTopN={1}
+                                            />
+                                        </CardContent>
+                                    </Card>
                                 ) : tournament.format ===
                                   'group_stage_knockout' ? (
                                     <>
@@ -404,36 +410,49 @@ export default function TournamentShow({
                                         {(tournament.phase === 'knockout' ||
                                             tournament.phase ===
                                                 'completed') && (
-                                            <section className="space-y-4">
-                                                <h2 className="text-lg font-semibold">
-                                                    Bracket
-                                                </h2>
-                                                <TournamentBracket
-                                                    rounds={tournament.rounds.filter(
-                                                        (r) =>
-                                                            !r.matches?.some(
-                                                                (m) =>
-                                                                    m.tournament_group_id !=
-                                                                    null,
-                                                            ),
-                                                    )}
-                                                />
-                                            </section>
+                                            <Card>
+                                                <CardHeader>
+                                                    <CardTitle>
+                                                        Bracket
+                                                    </CardTitle>
+                                                    <CardDescription>
+                                                        Cruces de eliminación
+                                                        directa
+                                                    </CardDescription>
+                                                </CardHeader>
+                                                <CardContent>
+                                                    <TournamentBracket
+                                                        rounds={tournament.rounds.filter(
+                                                            (r) =>
+                                                                !r.matches?.some(
+                                                                    (m) =>
+                                                                        m.tournament_group_id !=
+                                                                        null,
+                                                                ),
+                                                        )}
+                                                    />
+                                                </CardContent>
+                                            </Card>
                                         )}
                                     </>
                                 ) : (
-                                    <section className="space-y-4">
-                                        <h2 className="text-lg font-semibold">
-                                            Bracket
-                                        </h2>
-                                        <TournamentBracket
-                                            rounds={tournament.rounds}
-                                        />
-                                    </section>
+                                    <Card>
+                                        <CardHeader>
+                                            <CardTitle>Bracket</CardTitle>
+                                            <CardDescription>
+                                                Camino hacia la final del torneo
+                                            </CardDescription>
+                                        </CardHeader>
+                                        <CardContent>
+                                            <TournamentBracket
+                                                rounds={tournament.rounds}
+                                            />
+                                        </CardContent>
+                                    </Card>
                                 )}
 
                                 <Card>
-                                    <CardHeader>
+                                    <CardHeader className="border-b">
                                         <CardTitle className="text-base">
                                             Programación de partidos
                                         </CardTitle>
@@ -443,13 +462,13 @@ export default function TournamentShow({
                                                 : 'Fechas y canchas confirmadas por el organizador.'}
                                         </CardDescription>
                                     </CardHeader>
-                                    <CardContent className="space-y-6">
+                                    <CardContent className="space-y-5">
                                         {tournament.rounds.map((round) => (
                                             <div
                                                 key={round.id}
-                                                className="space-y-2"
+                                                className="space-y-2.5"
                                             >
-                                                <h3 className="text-sm font-medium text-muted-foreground">
+                                                <h3 className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
                                                     {round.name}
                                                 </h3>
                                                 <div className="space-y-2">
@@ -484,7 +503,11 @@ export default function TournamentShow({
                                                                         key={
                                                                             match.id
                                                                         }
-                                                                        className="flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+                                                                        className={cn(
+                                                                            'flex flex-col gap-3 rounded-lg border bg-card/40 p-3 transition-colors sm:flex-row sm:items-center sm:justify-between',
+                                                                            canEditMatch &&
+                                                                                'hover:border-primary/30 hover:bg-muted/20',
+                                                                        )}
                                                                     >
                                                                         <div className="min-w-0 flex-1">
                                                                             <p className="truncate text-sm font-medium">
@@ -531,7 +554,7 @@ export default function TournamentShow({
                                                                                         match,
                                                                                     )
                                                                                 }
-                                                                                className="gap-1.5"
+                                                                                className="w-full gap-1.5 sm:w-auto"
                                                                             >
                                                                                 <Pencil className="size-3.5" />
                                                                                 {match.scheduled_at
@@ -724,8 +747,7 @@ export default function TournamentShow({
                         </Card>
                     </div>
 
-                    {/* Right column — sidebar */}
-                    <div className="space-y-6">
+                    <div className="order-first space-y-4 xl:sticky xl:top-20 xl:order-none">
                         {/* Tournament Info */}
                         <Card>
                             <CardHeader>


### PR DESCRIPTION
## Summary
- Rework tournament detail page into a bracket-first layout with a sticky info sidebar
- Tighten fixture scheduling rows and preserve scheduling permissions
- Redesign bracket columns and match cards for cleaner spacing and scanability

## Tests
- bun run types
- bun run build
- git diff --check