### PR TITLE
feat: complete team invite link signup flow

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -3,8 +3,8 @@
 namespace App\Actions\Fortify;
 
 use App\Models\TeamInvitation;
-use App\Models\TeamMember;
 use App\Models\User;
+use App\Services\TeamInvitationService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
@@ -49,20 +49,7 @@ class CreateNewUser implements CreatesNewUsers
                     ->first();
 
                 if ($invitation && $invitation->isValid()) {
-                    // Add user to team
-                    TeamMember::create([
-                        'team_id' => $invitation->team_id,
-                        'user_id' => $user->id,
-                        'role' => $invitation->role,
-                        'status' => 'active',
-                    ]);
-
-                    // Mark invitation as accepted
-                    $invitation->update([
-                        'status' => 'accepted',
-                        'accepted_by' => $user->id,
-                        'accepted_at' => now(),
-                    ]);
+                    app(TeamInvitationService::class)->acceptInvitation($invitation, $user);
                 }
             }
 

--- a/app/Http/Controllers/Auth/GoogleAuthController.php
+++ b/app/Http/Controllers/Auth/GoogleAuthController.php
@@ -3,8 +3,11 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Models\TeamInvitation;
 use App\Models\User;
+use App\Services\TeamInvitationService;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Socialite\Facades\Socialite;
 
@@ -13,8 +16,14 @@ class GoogleAuthController extends Controller
     /**
      * Redirect the user to the Google authentication page.
      */
-    public function redirect(): RedirectResponse
+    public function redirect(Request $request): RedirectResponse
     {
+        // Preserve a team invitation token across the OAuth round-trip so the
+        // user can be auto-joined to the team after signing up with Google.
+        if ($request->filled('invitation')) {
+            session(['invitation_token' => $request->string('invitation')->toString()]);
+        }
+
         return Socialite::driver('google')->redirect();
     }
 
@@ -61,11 +70,36 @@ class GoogleAuthController extends Controller
             // Log the user in directly if no 2FA
             Auth::login($user);
 
+            $this->acceptPendingInvitation($user);
+
             return redirect()->intended('/teams');
         } catch (\Exception $e) {
             return redirect('/login')->withErrors([
                 'email' => 'Unable to login with Google. Please try again.',
             ]);
+        }
+    }
+
+    /**
+     * Auto-join the user to a team if a valid invitation token was carried
+     * through the OAuth flow, and queue the team page as the intended
+     * destination so onboarding redirects there.
+     */
+    private function acceptPendingInvitation(User $user): void
+    {
+        $token = session()->pull('invitation_token');
+
+        if (! $token) {
+            return;
+        }
+
+        $invitation = TeamInvitation::where('token', $token)
+            ->where('status', 'pending')
+            ->first();
+
+        if ($invitation && $invitation->isValid()) {
+            app(TeamInvitationService::class)->acceptInvitation($invitation, $user);
+            session(['url.intended' => route('teams.invitation.show', $invitation->token)]);
         }
     }
 }

--- a/app/Http/Controllers/OnboardingController.php
+++ b/app/Http/Controllers/OnboardingController.php
@@ -38,7 +38,7 @@ class OnboardingController extends Controller
         ]);
 
         return redirect()
-            ->route('teams.index')
+            ->intended(route('teams.index'))
             ->with('success', '¡Bienvenido a Veltro!');
     }
 
@@ -52,7 +52,7 @@ class OnboardingController extends Controller
         ]);
 
         return redirect()
-            ->route('teams.index')
+            ->intended(route('teams.index'))
             ->with('success', '¡Bienvenido a Veltro! Puedes agregar tu número de teléfono más tarde en configuración.');
     }
 }

--- a/app/Http/Controllers/TeamInvitationController.php
+++ b/app/Http/Controllers/TeamInvitationController.php
@@ -6,19 +6,22 @@ namespace App\Http\Controllers;
 
 use App\Models\Team;
 use App\Models\TeamInvitation;
-use App\Models\TeamMember;
 use App\Models\User;
 use App\Notifications\TeamInvitationNotification;
+use App\Services\TeamInvitationService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 
 final class TeamInvitationController extends Controller
 {
+    public function __construct(
+        private readonly TeamInvitationService $invitationService,
+    ) {}
+
     /**
      * Generate a new invitation
      */
@@ -134,8 +137,21 @@ final class TeamInvitationController extends Controller
             ]);
         }
 
-        // Redirect to register with invitation token
-        return redirect()->route('register', ['invitation' => $token]);
+        // Guest: show a branded landing page so they can sign up or log in.
+        // Store the invitation URL as the intended destination so that after
+        // authentication (and onboarding) the user is brought back here and
+        // routed into the team.
+        session(['url.intended' => route('teams.invitation.show', $invitation->token)]);
+
+        return Inertia::render('teams/invitation-guest', [
+            'team' => $invitation->team,
+            'inviter' => $invitation->inviter->only(['id', 'name']),
+            'invitation' => [
+                'token' => $invitation->token,
+                'role' => $invitation->role,
+                'expires_at' => $invitation->expires_at->toIso8601String(),
+            ],
+        ]);
     }
 
     /**
@@ -164,27 +180,9 @@ final class TeamInvitationController extends Controller
                 ->with('info', 'Ya eres miembro de este equipo');
         }
 
-        // Check if team is at capacity
-        if ($invitation->team->isFull()) {
+        if (! $this->invitationService->acceptInvitation($invitation, $user)) {
             return back()->with('error', 'El equipo ha alcanzado su capacidad máxima y no puede aceptar más miembros');
         }
-
-        DB::transaction(function () use ($invitation, $user) {
-            // Add user to team
-            TeamMember::create([
-                'team_id' => $invitation->team_id,
-                'user_id' => $user->id,
-                'role' => $invitation->role,
-                'status' => 'active',
-            ]);
-
-            // Mark invitation as accepted
-            $invitation->update([
-                'status' => 'accepted',
-                'accepted_by' => $user->id,
-                'accepted_at' => now(),
-            ]);
-        });
 
         return redirect()->route('teams.show', $invitation->team_id)
             ->with('success', '¡Te has unido al equipo exitosamente!');

--- a/app/Services/TeamInvitationService.php
+++ b/app/Services/TeamInvitationService.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\TeamInvitation;
+use App\Models\TeamMember;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+final class TeamInvitationService
+{
+    /**
+     * Accept a team invitation for the given user.
+     *
+     * Idempotent: if the user is already a member the invitation is left
+     * untouched and the call succeeds. Returns false only when the team is
+     * full and the user could not be added.
+     */
+    public function acceptInvitation(TeamInvitation $invitation, User $user): bool
+    {
+        // Already a member: nothing to do, treat as success.
+        $isMember = $invitation->team->teamMembers()
+            ->where('user_id', $user->id)
+            ->exists();
+
+        if ($isMember) {
+            return true;
+        }
+
+        // Respect team capacity.
+        if ($invitation->team->isFull()) {
+            return false;
+        }
+
+        DB::transaction(function () use ($invitation, $user) {
+            TeamMember::create([
+                'team_id' => $invitation->team_id,
+                'user_id' => $user->id,
+                'role' => $invitation->role,
+                'status' => 'active',
+            ]);
+
+            $invitation->update([
+                'status' => 'accepted',
+                'accepted_by' => $user->id,
+                'accepted_at' => now(),
+            ]);
+        });
+
+        return true;
+    }
+}

--- a/resources/js/components/invite-team-member-modal.tsx
+++ b/resources/js/components/invite-team-member-modal.tsx
@@ -16,6 +16,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { csrfHeaders } from '@/lib/csrf';
 import teams from '@/routes/teams';
 import { router } from '@inertiajs/react';
 import { Check, Copy, Link as LinkIcon, UserPlus } from 'lucide-react';
@@ -44,10 +45,7 @@ export function InviteTeamMemberModal({ teamId, teamName }: Props) {
                 headers: {
                     'Content-Type': 'application/json',
                     Accept: 'application/json',
-                    'X-CSRF-TOKEN':
-                        document.querySelector<HTMLMetaElement>(
-                            'meta[name="csrf-token"]',
-                        )?.content || '',
+                    ...csrfHeaders(),
                 },
                 body: JSON.stringify({
                     team_id: teamId,

--- a/resources/js/lib/csrf.ts
+++ b/resources/js/lib/csrf.ts
@@ -1,0 +1,27 @@
+/**
+ * Build headers carrying Laravel's CSRF token for manual `fetch` requests.
+ *
+ * Inertia navigates as a SPA, so the server-rendered `<meta name="csrf-token">`
+ * is only set on the initial full page load and goes stale whenever the session
+ * token rotates (e.g. after login/logout). The `XSRF-TOKEN` cookie, however, is
+ * refreshed by Laravel on every response, so we read it first and fall back to
+ * the meta tag. Laravel's VerifyCsrfToken middleware accepts the (encrypted)
+ * cookie value via the `X-XSRF-TOKEN` header and the raw token via `X-CSRF-TOKEN`.
+ */
+export function csrfHeaders(): Record<string, string> {
+    const xsrfCookie = document.cookie
+        .split('; ')
+        .find((row) => row.startsWith('XSRF-TOKEN='));
+
+    if (xsrfCookie) {
+        return {
+            'X-XSRF-TOKEN': decodeURIComponent(xsrfCookie.split('=')[1]),
+        };
+    }
+
+    const metaToken =
+        document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')
+            ?.content ?? '';
+
+    return { 'X-CSRF-TOKEN': metaToken };
+}

--- a/resources/js/pages/auth/register.tsx
+++ b/resources/js/pages/auth/register.tsx
@@ -143,7 +143,12 @@ export default function Register() {
                     variant="outline"
                     className="w-full"
                     onClick={() =>
-                        window.location.assign('/auth/google/redirect')
+                        window.location.assign(
+                            '/auth/google/redirect' +
+                                (formData.invitation_token
+                                    ? `?invitation=${encodeURIComponent(formData.invitation_token)}`
+                                    : ''),
+                        )
                     }
                 >
                     <svg

--- a/resources/js/pages/teams/invitation-guest.tsx
+++ b/resources/js/pages/teams/invitation-guest.tsx
@@ -1,0 +1,113 @@
+import { TeamAvatar } from '@/components/team-avatar';
+import { Button } from '@/components/ui/button';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import { VariantBadge } from '@/components/variant-badge';
+import { Head, Link } from '@inertiajs/react';
+
+interface Team {
+    id: number;
+    name: string;
+    variant: string;
+    logo_url?: string;
+    description?: string;
+}
+
+interface User {
+    id: number;
+    name: string;
+}
+
+interface Invitation {
+    token: string;
+    role: string;
+    expires_at: string;
+}
+
+interface Props {
+    invitation: Invitation;
+    team: Team;
+    inviter: User;
+}
+
+export default function InvitationGuest({ invitation, team, inviter }: Props) {
+    const registerHref = `/register?invitation=${encodeURIComponent(invitation.token)}`;
+
+    return (
+        <div className="flex min-h-screen items-center justify-center bg-muted/30 p-4">
+            <Head title={`Invitación a ${team.name}`} />
+
+            <Card className="w-full max-w-lg">
+                <CardHeader className="text-center">
+                    <div className="mb-4 flex justify-center">
+                        <TeamAvatar
+                            name={team.name}
+                            logoUrl={team.logo_url}
+                            size="xl"
+                        />
+                    </div>
+                    <CardTitle className="text-2xl">
+                        ¡Has sido invitado a unirte!
+                    </CardTitle>
+                    <CardDescription>
+                        {inviter.name} te ha invitado a unirte a {team.name}.
+                        Crea tu cuenta para sumarte al equipo.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                    <div className="space-y-4">
+                        <div>
+                            <h3 className="mb-2 font-semibold">Equipo</h3>
+                            <div className="flex items-center gap-3">
+                                <TeamAvatar
+                                    name={team.name}
+                                    logoUrl={team.logo_url}
+                                />
+                                <div>
+                                    <p className="font-medium">{team.name}</p>
+                                    <VariantBadge variant={team.variant} />
+                                </div>
+                            </div>
+                        </div>
+
+                        {team.description && (
+                            <div>
+                                <h3 className="mb-2 font-semibold">
+                                    Descripción
+                                </h3>
+                                <p className="text-sm text-muted-foreground">
+                                    {team.description}
+                                </p>
+                            </div>
+                        )}
+
+                        <div>
+                            <h3 className="mb-2 font-semibold">Tu rol</h3>
+                            <p className="text-sm text-muted-foreground">
+                                {invitation.role === 'player'
+                                    ? 'Jugador'
+                                    : 'Vice-Capitán'}
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="flex flex-col gap-3">
+                        <Button asChild className="w-full">
+                            <Link href={registerHref}>
+                                Crear cuenta para unirme
+                            </Link>
+                        </Button>
+                        <Button asChild variant="outline" className="w-full">
+                            <Link href="/login">Ya tengo cuenta</Link>
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/tests/Feature/TeamInvitationTest.php
+++ b/tests/Feature/TeamInvitationTest.php
@@ -238,3 +238,80 @@ test('non-member cannot revoke an invitation', function () {
 
     expect($invitation->fresh()->status)->toBe('pending');
 });
+
+// ============================================================
+// Guest invite link → sign up → land on team
+// ============================================================
+
+test('guest visiting an invite link sees the branded landing page', function () {
+    $invitation = makeInvitation();
+
+    $this->get(route('teams.invitation.show', $invitation->token))
+        ->assertSuccessful()
+        ->assertInertia(fn ($page) => $page
+            ->component('teams/invitation-guest')
+            ->where('team.id', $this->team->id)
+            ->where('invitation.token', $invitation->token)
+            ->where('invitation.role', 'player')
+        );
+});
+
+test('guest invite link stores the invitation as the intended destination', function () {
+    $invitation = makeInvitation();
+
+    $this->get(route('teams.invitation.show', $invitation->token));
+
+    expect(session('url.intended'))
+        ->toBe(route('teams.invitation.show', $invitation->token));
+});
+
+test('registering with an invitation token auto-joins the team', function () {
+    $invitation = makeInvitation(['email' => null]);
+
+    $this->post(route('register.store'), [
+        'name' => 'New Friend',
+        'email' => 'friend@example.com',
+        'password' => 'password123',
+        'password_confirmation' => 'password123',
+        'invitation_token' => $invitation->token,
+    ]);
+
+    $newUser = User::where('email', 'friend@example.com')->first();
+
+    expect($newUser)->not->toBeNull();
+    expect($this->team->fresh()->hasMember($newUser->id))->toBeTrue();
+    expect($invitation->fresh()->status)->toBe('accepted');
+    expect($invitation->fresh()->accepted_by)->toBe($newUser->id);
+});
+
+test('completing onboarding redirects to the intended team after invite signup', function () {
+    $invitation = makeInvitation();
+    $newUser = User::factory()->create(['onboarding_completed' => false]);
+
+    $this->actingAs($newUser)
+        ->withSession(['url.intended' => route('teams.invitation.show', $invitation->token)])
+        ->post(route('onboarding.update'), ['phone_number' => '+59899123456'])
+        ->assertRedirect(route('teams.invitation.show', $invitation->token));
+});
+
+test('an authenticated member visiting the invite link is redirected to the team', function () {
+    $invitation = makeInvitation();
+
+    $this->actingAs($this->player)
+        ->get(route('teams.invitation.show', $invitation->token))
+        ->assertRedirect(route('teams.show', $this->team->id));
+});
+
+test('invitation is not accepted when the team is full', function () {
+    $this->team->update(['max_members' => 2]); // captain + player already fill it
+    $invitation = makeInvitation();
+
+    $this->actingAs($this->outsider)
+        ->from(route('teams.invitation.show', $invitation->token))
+        ->post(route('teams.invitation.accept', $invitation->token))
+        ->assertRedirect(route('teams.invitation.show', $invitation->token))
+        ->assertSessionHas('error');
+
+    expect($this->team->fresh()->hasMember($this->outsider->id))->toBeFalse();
+    expect($invitation->fresh()->status)->toBe('pending');
+});


### PR DESCRIPTION
## Context

Sharing a team invite link to a friend **who isn't in the app yet** was broken end-to-end: the link redirected to a context-less register page, signups never landed on the team they joined (they ended up on the teams list after onboarding), Google sign-up silently dropped the invitation, and generating a link returned a 419.

This PR makes the flow work: **open link → branded landing page → sign up (email or Google) → onboarding → land inside the team.**

## Changes

- **`TeamInvitationService`** — centralizes the join logic (capacity check, idempotent membership, mark accepted) that was duplicated across `CreateNewUser` and `TeamInvitationController::accept()`.
- **Branded guest landing page** (`invitation-guest.tsx`) shown to logged-out visitors with team/inviter/role and "Crear cuenta" / "Ya tengo cuenta" CTAs, instead of a blind redirect. The invite URL is stored as the session **intended destination**.
- **Land on the team after onboarding** — `OnboardingController::update()/skip()` now honor `redirect()->intended()`, so invited signups are routed into the team page once onboarding completes.
- **Google sign-up** carries the invitation token through the OAuth round-trip and auto-joins on callback.
- **Fix 419 on invite-link generation** — the modal read a stale server-rendered `<meta csrf-token>` (never refreshed across Inertia SPA navigations / session rotation). New `csrfHeaders()` helper reads the always-fresh `XSRF-TOKEN` cookie instead.

## Behavior notes

- New signups get a seamless auto-join; existing logged-out users go through the explicit accept page (correct confirmation UX).
- `User` does not implement `MustVerifyEmail`, so the `verified` middleware doesn't block new users.

## Testing

- `php artisan test tests/Feature/TeamInvitationTest.php` → **19 passed** (6 new: guest landing, intended-URL storage, register auto-join, onboarding→team redirect, member redirect, team-full guard).
- Broader auth/onboarding/google/register/team suite → **64 passed**.
- `bun run types` clean; Pint + Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)