### PR TITLE
fix: prevent blank page when Reverb key is missing in the build

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -8,9 +8,19 @@ import { createRoot } from 'react-dom/client';
 import { TooltipProvider } from './components/ui/tooltip';
 import { initializeTheme } from './hooks/use-appearance';
 
-configureEcho({
-    broadcaster: 'reverb',
-});
+// Only enable real-time broadcasting when a Reverb key was baked into the
+// build. Otherwise use the no-op `null` broadcaster so the app degrades to the
+// polling fallback in use-notifications.ts instead of crashing (Pusher throws
+// "You must pass your app key" when instantiated without a key).
+if (import.meta.env.VITE_REVERB_APP_KEY) {
+    configureEcho({
+        broadcaster: 'reverb',
+    });
+} else {
+    configureEcho({
+        broadcaster: 'null',
+    });
+}
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 


### PR DESCRIPTION
## Problem

In production, signing in produced a **blank page** with:

> Uncaught You must pass your app key when you instantiate Pusher.

## Root cause

`resources/js/app.tsx` called `configureEcho({ broadcaster: 'reverb' })`, whose default reverb config takes its key from `import.meta.env.VITE_REVERB_APP_KEY`. Vite **inlines `import.meta.env.VITE_*` at build time**, and the production bundle was built **without** `VITE_REVERB_APP_KEY`. After sign-in the notification bell mounts → `useEchoNotification` → Echo lazily instantiates the Pusher client with an empty key → Pusher throws → the uncaught error crashes React → blank page. (Local dev works because `.env` has the var at build time.)

## Fix

Guard the Echo config: use `reverb` only when a key was baked into the build, otherwise use the no-op **`null` broadcaster** (a real Laravel Echo connector — instantiates no Pusher client). Real-time then degrades gracefully to the existing **polling fallback** in `use-notifications.ts` (2-min interval) instead of crashing. No behaviour change when the key is present.

```ts
if (import.meta.env.VITE_REVERB_APP_KEY) {
    configureEcho({ broadcaster: 'reverb' });
} else {
    configureEcho({ broadcaster: 'null' });
}
```

## To actually enable real-time in prod (separate, optional)

The crash is fixed regardless. To make broadcasting *work* in production, the deploy must also set `VITE_REVERB_APP_KEY`/`VITE_REVERB_HOST`/`VITE_REVERB_PORT`/`VITE_REVERB_SCHEME` **at asset-build time** and run a reachable Reverb server over `wss`.

## Testing

- `bun run types` clean (the `null` broadcaster is a valid `BroadcastDriver`).
- Verified against the `@laravel/echo-react` connector internals that `broadcaster: 'null'` uses the NullConnector and never constructs Pusher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)