### PR TITLE
fix: landing header logo — green hexagon, no green background

### DIFF
--- a/resources/js/pages/landing-page.tsx
+++ b/resources/js/pages/landing-page.tsx
@@ -226,9 +226,7 @@ export default function LandingPage({
                             href={home().url}
                             className="flex items-center gap-3"
                         >
-                            <span className="flex size-8 items-center justify-center rounded-md bg-[#48d17a]">
-                                <AppLogoIcon className="size-5 fill-[#07110b]" />
-                            </span>
+                            <AppLogoIcon className="size-7 text-primary" />
                             <span className="text-sm font-semibold tracking-wide text-white">
                                 Veltro
                             </span>


### PR DESCRIPTION
Removes the green background chip behind the **Veltro** mark in the landing page header and renders the hexagon icon in brand green (`text-primary`), so it matches the dashboard/sidebar logo treatment.

Before: `bg-[#48d17a]` chip with a dark `fill-[#07110b]` hexagon.
After: `<AppLogoIcon className="size-7 text-primary" />` — green hexagon on the transparent header, consistent with the rest of the app.

Single-line change; `bun run types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)