### PR TITLE
fix: collapsed sidebar shows only the centered Veltro hexagon

### DIFF
--- a/resources/js/components/app-logo.tsx
+++ b/resources/js/components/app-logo.tsx
@@ -3,8 +3,10 @@ import AppLogoIcon from './app-logo-icon';
 export default function AppLogo() {
     return (
         <>
-            <AppLogoIcon className="size-7 shrink-0 text-primary" />
-            <div className="ml-1 grid flex-1 text-left text-sm">
+            <div className="flex aspect-square size-8 shrink-0 items-center justify-center">
+                <AppLogoIcon className="size-7! text-primary" />
+            </div>
+            <div className="ml-1 grid flex-1 text-left text-sm group-data-[collapsible=icon]:hidden">
                 <span className="mb-0.5 truncate leading-tight font-semibold">
                     Veltro
                 </span>


### PR DESCRIPTION
## Problem

With the dashboard sidebar collapsed to icon-only mode, the logo rendered both the hexagon **and** the "Veltro" wordmark. The collapsed menu button is forced to `size-8! p-0!` with `overflow-hidden`, so the wordmark spilled/clipped and the hexagon was pushed off-center (broken-looking).

## Fix

In `resources/js/components/app-logo.tsx`:
- Hide the wordmark when collapsed using the shadcn `group-data-[collapsible=icon]:hidden` utility (the same convention used throughout `ui/sidebar.tsx`). It's a no-op outside a collapsed sidebar, so the lockup is unchanged everywhere else.
- Wrap `AppLogoIcon` in a fixed `size-8` flex-center box so the hexagon stays centered in the rail; `size-7!` keeps it from being shrunk by the button's `[&_svg]:size-4` rule.

Expanded sidebar (icon + wordmark) is visually unchanged.

`bun run types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)