### PR TITLE
feat: high-value notifications with real-time panel

### DIFF
--- a/app/Notifications/CaptaincyTransferredNotification.php
+++ b/app/Notifications/CaptaincyTransferredNotification.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\Team;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class CaptaincyTransferredNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public Team $team
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['database', 'broadcast'];
+    }
+
+    public function toDatabase(object $notifiable): array
+    {
+        $teamName = $this->team->name;
+
+        return [
+            'type' => 'captaincy_transferred',
+            'title' => "Ahora sos capitán de {$teamName}",
+            'message' => "Te transfirieron la capitanía de {$teamName}",
+            'action_url' => route('teams.show', $this->team->id),
+            'icon' => 'Crown',
+            'related_model' => [
+                'team_id' => $this->team->id,
+            ],
+            'created_at' => now()->toISOString(),
+        ];
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return $this->toDatabase($notifiable);
+    }
+}

--- a/app/Notifications/JoinRequestCreatedNotification.php
+++ b/app/Notifications/JoinRequestCreatedNotification.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\JoinRequest;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class JoinRequestCreatedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public JoinRequest $joinRequest
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['database', 'broadcast'];
+    }
+
+    public function toDatabase(object $notifiable): array
+    {
+        $userName = $this->joinRequest->user->name;
+        $teamName = $this->joinRequest->team->name;
+
+        return [
+            'type' => 'join_request_created',
+            'title' => "Nueva solicitud para unirse a {$teamName}",
+            'message' => "{$userName} quiere unirse a tu equipo",
+            'action_url' => route('teams.show', $this->joinRequest->team_id),
+            'icon' => 'UserPlus',
+            'related_model' => [
+                'team_id' => $this->joinRequest->team_id,
+                'join_request_id' => $this->joinRequest->id,
+            ],
+            'created_at' => now()->toISOString(),
+        ];
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return $this->toDatabase($notifiable);
+    }
+}

--- a/app/Notifications/MatchConfirmedNotification.php
+++ b/app/Notifications/MatchConfirmedNotification.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\FootballMatch;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class MatchConfirmedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public FootballMatch $match
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['database', 'broadcast'];
+    }
+
+    public function toDatabase(object $notifiable): array
+    {
+        $opponentName = $this->match->awayTeam?->name ?? 'el rival';
+
+        return [
+            'type' => 'match_confirmed',
+            'title' => '¡Partido confirmado!',
+            'message' => "Tu partido contra {$opponentName} quedó confirmado",
+            'action_url' => route('matches.show', $this->match->id),
+            'icon' => 'CalendarCheck',
+            'related_model' => [
+                'match_id' => $this->match->id,
+                'team_id' => $this->match->away_team_id,
+            ],
+            'created_at' => now()->toISOString(),
+        ];
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return $this->toDatabase($notifiable);
+    }
+}

--- a/app/Notifications/TeamInvitationAcceptedNotification.php
+++ b/app/Notifications/TeamInvitationAcceptedNotification.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class TeamInvitationAcceptedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public TeamInvitation $invitation,
+        public User $acceptedBy
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['database', 'broadcast'];
+    }
+
+    public function toDatabase(object $notifiable): array
+    {
+        $teamName = $this->invitation->team->name;
+
+        return [
+            'type' => 'team_invitation_accepted',
+            'title' => "{$this->acceptedBy->name} aceptó tu invitación",
+            'message' => "{$this->acceptedBy->name} se unió a {$teamName}",
+            'action_url' => route('teams.show', $this->invitation->team_id),
+            'icon' => 'UserCheck',
+            'related_model' => [
+                'team_id' => $this->invitation->team_id,
+                'invitation_id' => $this->invitation->id,
+            ],
+            'created_at' => now()->toISOString(),
+        ];
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return $this->toDatabase($notifiable);
+    }
+}

--- a/app/Notifications/TournamentRegistrationReviewedNotification.php
+++ b/app/Notifications/TournamentRegistrationReviewedNotification.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\TournamentTeam;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class TournamentRegistrationReviewedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public TournamentTeam $registration,
+        public bool $approved
+    ) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['database', 'broadcast'];
+    }
+
+    public function toDatabase(object $notifiable): array
+    {
+        $tournamentName = $this->registration->tournament->name;
+
+        $title = $this->approved
+            ? "¡Aceptaron a tu equipo en {$tournamentName}!"
+            : "Rechazaron tu inscripción en {$tournamentName}";
+
+        $message = $this->approved
+            ? "Tu inscripción en {$tournamentName} fue aprobada"
+            : "Tu inscripción en {$tournamentName} fue rechazada";
+
+        return [
+            'type' => 'tournament_registration_reviewed',
+            'title' => $title,
+            'message' => $message,
+            'action_url' => route('tournaments.show', $this->registration->tournament),
+            'icon' => $this->approved ? 'Trophy' : 'XCircle',
+            'related_model' => [
+                'tournament_id' => $this->registration->tournament_id,
+                'team_id' => $this->registration->team_id,
+                'approved' => $this->approved,
+            ],
+            'created_at' => now()->toISOString(),
+        ];
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return $this->toDatabase($notifiable);
+    }
+}

--- a/app/Services/MatchService.php
+++ b/app/Services/MatchService.php
@@ -11,6 +11,7 @@ use App\Models\MatchRequest;
 use App\Models\Team;
 use App\Models\User;
 use App\Notifications\MatchCancelledNotification;
+use App\Notifications\MatchConfirmedNotification;
 use App\Notifications\MatchRequestAcceptedNotification;
 use App\Notifications\MatchRequestReceivedNotification;
 use App\Notifications\MatchRequestRejectedNotification;
@@ -202,6 +203,13 @@ final class MatchService
             Notification::send(
                 $requestingTeamLeaders,
                 new MatchRequestAcceptedNotification($match, $matchRequest)
+            );
+
+            // Notify home team leaders that their match is now confirmed
+            $homeTeamLeaders = $match->homeTeam->getLeaders()->get()->pluck('user');
+            Notification::send(
+                $homeTeamLeaders,
+                new MatchConfirmedNotification($match)
             );
 
             // Notify other rejected teams

--- a/app/Services/TeamInvitationService.php
+++ b/app/Services/TeamInvitationService.php
@@ -7,6 +7,7 @@ namespace App\Services;
 use App\Models\TeamInvitation;
 use App\Models\TeamMember;
 use App\Models\User;
+use App\Notifications\TeamInvitationAcceptedNotification;
 use Illuminate\Support\Facades\DB;
 
 final class TeamInvitationService
@@ -48,6 +49,12 @@ final class TeamInvitationService
                 'accepted_at' => now(),
             ]);
         });
+
+        // Notify the inviter that their invitation was accepted
+        $inviter = $invitation->inviter;
+        if ($inviter) {
+            $inviter->notify(new TeamInvitationAcceptedNotification($invitation, $user));
+        }
 
         return true;
     }

--- a/app/Services/TeamService.php
+++ b/app/Services/TeamService.php
@@ -10,10 +10,13 @@ use App\Models\MatchEvent;
 use App\Models\Team;
 use App\Models\TeamMember;
 use App\Models\User;
+use App\Notifications\CaptaincyTransferredNotification;
 use App\Notifications\JoinRequestAcceptedNotification;
+use App\Notifications\JoinRequestCreatedNotification;
 use App\Notifications\JoinRequestRejectedNotification;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Notification;
 
 final class TeamService
 {
@@ -142,7 +145,7 @@ final class TeamService
      */
     public function transferCaptaincy(Team $team, int $currentCaptainId, int $newCaptainId): bool
     {
-        return DB::transaction(function () use ($team, $currentCaptainId, $newCaptainId) {
+        DB::transaction(function () use ($team, $currentCaptainId, $newCaptainId) {
             // Demote current captain to player
             $team->teamMembers()
                 ->where('user_id', $currentCaptainId)
@@ -152,9 +155,15 @@ final class TeamService
             $team->teamMembers()
                 ->where('user_id', $newCaptainId)
                 ->update(['role' => 'captain']);
-
-            return true;
         });
+
+        // Notify the new captain of their promotion
+        $newCaptain = User::find($newCaptainId);
+        if ($newCaptain) {
+            $newCaptain->notify(new CaptaincyTransferredNotification($team));
+        }
+
+        return true;
     }
 
     /**
@@ -175,12 +184,18 @@ final class TeamService
             ->whereIn('status', ['accepted', 'rejected'])
             ->delete();
 
-        return JoinRequest::create([
+        $joinRequest = JoinRequest::create([
             'user_id' => $userId,
             'team_id' => $teamId,
             'status' => 'pending',
             'message' => $message,
         ]);
+
+        // Notify the team leaders that someone wants to join
+        $leaders = $team->getLeaders()->get()->pluck('user');
+        Notification::send($leaders, new JoinRequestCreatedNotification($joinRequest));
+
+        return $joinRequest;
     }
 
     /**

--- a/app/Services/Tournament/TournamentRegistrationService.php
+++ b/app/Services/Tournament/TournamentRegistrationService.php
@@ -8,6 +8,8 @@ use App\Models\Team;
 use App\Models\Tournament;
 use App\Models\TournamentTeam;
 use App\Models\User;
+use App\Notifications\TournamentRegistrationReviewedNotification;
+use Illuminate\Support\Facades\Notification;
 
 final class TournamentRegistrationService
 {
@@ -81,6 +83,8 @@ final class TournamentRegistrationService
             'status' => 'approved',
             'approved_at' => now(),
         ]);
+
+        $this->notifyRegistrationReviewed($registration, true);
     }
 
     public function rejectTeam(TournamentTeam $registration): void
@@ -92,6 +96,20 @@ final class TournamentRegistrationService
         $registration->update([
             'status' => 'rejected',
         ]);
+
+        $this->notifyRegistrationReviewed($registration, false);
+    }
+
+    /**
+     * Notify the registering team's leaders of the review decision.
+     */
+    private function notifyRegistrationReviewed(TournamentTeam $registration, bool $approved): void
+    {
+        $leaders = $registration->team->getLeaders()->get()->pluck('user');
+        Notification::send(
+            $leaders,
+            new TournamentRegistrationReviewedNotification($registration, $approved)
+        );
     }
 
     public function withdrawTeam(TournamentTeam $registration): void

--- a/resources/js/components/notification-bell.tsx
+++ b/resources/js/components/notification-bell.tsx
@@ -32,7 +32,7 @@ export function NotificationBell() {
                 >
                     <Bell className="h-5 w-5" />
                     {unreadCount > 0 && (
-                        <span className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-foreground text-[10px] font-bold text-background ring-2 ring-background">
+                        <span className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground ring-2 ring-background">
                             {unreadCount > 9 ? '9+' : unreadCount}
                         </span>
                     )}

--- a/resources/js/components/notification-item.tsx
+++ b/resources/js/components/notification-item.tsx
@@ -3,12 +3,16 @@ import { formatDistanceToNow } from 'date-fns';
 import { es } from 'date-fns/locale';
 import {
     Award,
+    CalendarCheck,
     CheckCircle,
     Clock,
+    Crown,
     MessageCircle,
     Target,
     Trash2,
     Trophy,
+    UserCheck,
+    UserPlus,
     Users,
     X,
     XCircle,
@@ -41,30 +45,54 @@ const iconMap: Record<string, ComponentType<{ className?: string }>> = {
     Users,
     Award,
     MessageCircle,
+    UserPlus,
+    UserCheck,
+    Crown,
+    CalendarCheck,
 };
 
 const iconColorMap: Record<string, string> = {
+    // Positive / affirmative events lean into the brand green family.
     match_request_received: 'text-emerald-600 dark:text-emerald-500',
     match_request_accepted: 'text-green-600 dark:text-green-500',
-    match_request_rejected: 'text-red-600 dark:text-red-500',
-    match_cancelled: 'text-orange-600 dark:text-orange-500',
-    match_score_updated: 'text-amber-600 dark:text-amber-500',
+    match_confirmed: 'text-green-600 dark:text-green-500',
+    join_request_accepted: 'text-green-600 dark:text-green-500',
+    team_invitation_accepted: 'text-green-600 dark:text-green-500',
+    join_request_created: 'text-teal-600 dark:text-teal-500',
+    team_invitation: 'text-teal-600 dark:text-teal-500',
+    captaincy_transferred: 'text-emerald-600 dark:text-emerald-500',
+    tournament_registration_reviewed: 'text-emerald-600 dark:text-emerald-500',
+    match_score_updated: 'text-lime-600 dark:text-lime-500',
+    // Reminders & social keep distinct accents.
     availability_reminder: 'text-sky-600 dark:text-sky-500',
-    team_invitation: 'text-violet-600 dark:text-violet-500',
-    commendation_received: 'text-yellow-600 dark:text-yellow-500',
+    commendation_received: 'text-amber-600 dark:text-amber-500',
     profile_comment: 'text-indigo-600 dark:text-indigo-500',
+    // Negative outcomes stay semantically red / orange.
+    match_request_rejected: 'text-red-600 dark:text-red-500',
+    join_request_rejected: 'text-red-600 dark:text-red-500',
+    match_cancelled: 'text-orange-600 dark:text-orange-500',
 };
 
 const iconBgMap: Record<string, string> = {
+    // Positive / affirmative events lean into the brand green family.
     match_request_received: 'bg-emerald-50 dark:bg-emerald-950/20',
     match_request_accepted: 'bg-green-50 dark:bg-green-950/20',
-    match_request_rejected: 'bg-red-50 dark:bg-red-950/20',
-    match_cancelled: 'bg-orange-50 dark:bg-orange-950/20',
-    match_score_updated: 'bg-amber-50 dark:bg-amber-950/20',
+    match_confirmed: 'bg-green-50 dark:bg-green-950/20',
+    join_request_accepted: 'bg-green-50 dark:bg-green-950/20',
+    team_invitation_accepted: 'bg-green-50 dark:bg-green-950/20',
+    join_request_created: 'bg-teal-50 dark:bg-teal-950/20',
+    team_invitation: 'bg-teal-50 dark:bg-teal-950/20',
+    captaincy_transferred: 'bg-emerald-50 dark:bg-emerald-950/20',
+    tournament_registration_reviewed: 'bg-emerald-50 dark:bg-emerald-950/20',
+    match_score_updated: 'bg-lime-50 dark:bg-lime-950/20',
+    // Reminders & social keep distinct accents.
     availability_reminder: 'bg-sky-50 dark:bg-sky-950/20',
-    team_invitation: 'bg-violet-50 dark:bg-violet-950/20',
-    commendation_received: 'bg-yellow-50 dark:bg-yellow-950/20',
+    commendation_received: 'bg-amber-50 dark:bg-amber-950/20',
     profile_comment: 'bg-indigo-50 dark:bg-indigo-950/20',
+    // Negative outcomes stay semantically red / orange.
+    match_request_rejected: 'bg-red-50 dark:bg-red-950/20',
+    join_request_rejected: 'bg-red-50 dark:bg-red-950/20',
+    match_cancelled: 'bg-orange-50 dark:bg-orange-950/20',
 };
 
 export function NotificationItem({
@@ -92,7 +120,7 @@ export function NotificationItem({
             className={cn(
                 'group relative flex items-start gap-3.5 border-b px-4 py-3.5 transition-all hover:bg-muted/40',
                 isUnread
-                    ? 'border-l-2 border-l-foreground bg-muted/30 hover:bg-muted/50'
+                    ? 'border-l-2 border-l-primary bg-primary/5 hover:bg-primary/10'
                     : 'border-l-2 border-l-transparent',
             )}
         >
@@ -143,7 +171,7 @@ export function NotificationItem({
                         </p>
                     </div>
                     {isUnread && (
-                        <div className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-foreground ring-2 ring-background" />
+                        <div className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-primary ring-2 ring-background" />
                     )}
                 </div>
             </button>

--- a/resources/js/components/notification-list.tsx
+++ b/resources/js/components/notification-list.tsx
@@ -1,3 +1,4 @@
+import { isToday, isYesterday } from 'date-fns';
 import { Bell, Check, Loader2, Trash2 } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 
@@ -8,6 +9,33 @@ import {
     DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu';
 import type { Notification } from '@/types';
+
+type DateBucket = {
+    label: string;
+    items: Notification[];
+};
+
+// Split notifications into Hoy / Ayer / Anteriores while preserving order.
+function groupByDate(notifications: Notification[]): DateBucket[] {
+    const buckets: DateBucket[] = [
+        { label: 'Hoy', items: [] },
+        { label: 'Ayer', items: [] },
+        { label: 'Anteriores', items: [] },
+    ];
+
+    for (const notification of notifications) {
+        const date = new Date(notification.created_at);
+        if (isToday(date)) {
+            buckets[0].items.push(notification);
+        } else if (isYesterday(date)) {
+            buckets[1].items.push(notification);
+        } else {
+            buckets[2].items.push(notification);
+        }
+    }
+
+    return buckets.filter((bucket) => bucket.items.length > 0);
+}
 
 interface NotificationListProps {
     notifications: Notification[];
@@ -34,6 +62,7 @@ export function NotificationList({
 }: NotificationListProps) {
     const hasOpenedRef = useRef(false);
     const hasUnread = notifications.some((n) => !n.read_at);
+    const groups = groupByDate(notifications);
 
     useEffect(() => {
         if (!hasOpenedRef.current && notifications.length === 0) {
@@ -97,13 +126,20 @@ export function NotificationList({
                     </div>
                 )}
 
-                {notifications.map((notification) => (
-                    <NotificationItem
-                        key={notification.id}
-                        notification={notification}
-                        onMarkAsRead={markAsRead}
-                        onDelete={deleteNotification}
-                    />
+                {groups.map((group) => (
+                    <div key={group.label}>
+                        <div className="sticky top-0 z-10 bg-background/95 px-4 py-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase backdrop-blur">
+                            {group.label}
+                        </div>
+                        {group.items.map((notification) => (
+                            <NotificationItem
+                                key={notification.id}
+                                notification={notification}
+                                onMarkAsRead={markAsRead}
+                                onDelete={deleteNotification}
+                            />
+                        ))}
+                    </div>
                 ))}
 
                 {isLoading && (

--- a/resources/js/hooks/use-notifications.ts
+++ b/resources/js/hooks/use-notifications.ts
@@ -23,6 +23,63 @@ interface UseNotificationsReturn {
 // WebSockets carry the real-time load; polling is now just a safety-net fallback.
 const POLLING_INTERVAL = 120000; // 2 minutes
 
+// Build headers for notification writes. We read the live `XSRF-TOKEN` cookie
+// (which Laravel refreshes on every response) rather than the
+// `<meta name="csrf-token">` tag — that tag is only rendered on the initial
+// document load and goes stale in the SPA once the session token rotates
+// (e.g. on login), which caused 419 token-mismatch errors on every write.
+function mutationHeaders(): HeadersInit {
+    const xsrfToken = document.cookie
+        .split('; ')
+        .find((row) => row.startsWith('XSRF-TOKEN='))
+        ?.split('=')[1];
+
+    return {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-XSRF-TOKEN': xsrfToken ? decodeURIComponent(xsrfToken) : '',
+    };
+}
+
+let audioContext: AudioContext | null = null;
+
+// Short, subtle two-tone chime synthesized via the Web Audio API. Avoids
+// shipping a binary audio asset and degrades silently when blocked by autoplay
+// policies or unsupported browsers.
+function playNotificationSound(): void {
+    try {
+        if (typeof window === 'undefined') return;
+
+        const Ctx =
+            window.AudioContext ||
+            (window as unknown as { webkitAudioContext?: typeof AudioContext })
+                .webkitAudioContext;
+        if (!Ctx) return;
+
+        audioContext ??= new Ctx();
+        const ctx = audioContext;
+        if (ctx.state === 'suspended') void ctx.resume();
+
+        const now = ctx.currentTime;
+        const gain = ctx.createGain();
+        gain.connect(ctx.destination);
+        gain.gain.setValueAtTime(0.0001, now);
+        gain.gain.exponentialRampToValueAtTime(0.08, now + 0.02);
+        gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.35);
+
+        const osc = ctx.createOscillator();
+        osc.type = 'sine';
+        osc.frequency.setValueAtTime(880, now);
+        osc.frequency.setValueAtTime(1175, now + 0.12);
+        osc.connect(gain);
+        osc.start(now);
+        osc.stop(now + 0.35);
+    } catch {
+        // Autoplay restrictions or unsupported API — silently skip.
+    }
+}
+
 export function useNotifications(): UseNotificationsReturn {
     const page = usePage<SharedData>();
     const user = page.props.auth?.user;
@@ -112,15 +169,7 @@ export function useNotifications(): UseNotificationsReturn {
                 notificationsRoute.markAsRead(id).url,
                 {
                     method: 'POST',
-                    headers: {
-                        Accept: 'application/json',
-                        'Content-Type': 'application/json',
-                        'X-Requested-With': 'XMLHttpRequest',
-                        'X-CSRF-TOKEN':
-                            document
-                                .querySelector('meta[name="csrf-token"]')
-                                ?.getAttribute('content') || '',
-                    },
+                    headers: mutationHeaders(),
                 },
             );
 
@@ -144,15 +193,7 @@ export function useNotifications(): UseNotificationsReturn {
         try {
             const response = await fetch(notificationsRoute.markAllRead().url, {
                 method: 'POST',
-                headers: {
-                    Accept: 'application/json',
-                    'Content-Type': 'application/json',
-                    'X-Requested-With': 'XMLHttpRequest',
-                    'X-CSRF-TOKEN':
-                        document
-                            .querySelector('meta[name="csrf-token"]')
-                            ?.getAttribute('content') || '',
-                },
+                headers: mutationHeaders(),
             });
 
             if (response.ok) {
@@ -175,15 +216,7 @@ export function useNotifications(): UseNotificationsReturn {
         try {
             const response = await fetch(notificationsRoute.destroy(id).url, {
                 method: 'DELETE',
-                headers: {
-                    Accept: 'application/json',
-                    'Content-Type': 'application/json',
-                    'X-Requested-With': 'XMLHttpRequest',
-                    'X-CSRF-TOKEN':
-                        document
-                            .querySelector('meta[name="csrf-token"]')
-                            ?.getAttribute('content') || '',
-                },
+                headers: mutationHeaders(),
             });
 
             if (response.ok) {
@@ -200,15 +233,7 @@ export function useNotifications(): UseNotificationsReturn {
         try {
             const response = await fetch(notificationsRoute.clearRead().url, {
                 method: 'POST',
-                headers: {
-                    Accept: 'application/json',
-                    'Content-Type': 'application/json',
-                    'X-Requested-With': 'XMLHttpRequest',
-                    'X-CSRF-TOKEN':
-                        document
-                            .querySelector('meta[name="csrf-token"]')
-                            ?.getAttribute('content') || '',
-                },
+                headers: mutationHeaders(),
             });
 
             if (response.ok) {
@@ -231,11 +256,23 @@ export function useNotifications(): UseNotificationsReturn {
     useEchoNotification(
         `App.Models.User.${user?.id ?? ''}`,
         () => {
+            // A genuinely new push arrived — cue the sound and re-sync. Sound is
+            // only played here, never in the polling fallback, so it can't fire
+            // on every tab focus.
+            playNotificationSound();
             void refresh();
         },
         undefined,
         [refresh],
     );
+
+    // Reflect the unread count in the browser tab title. Strip any existing
+    // count prefix first so it stays correct across Inertia title changes.
+    useEffect(() => {
+        const baseTitle = document.title.replace(/^\(\d+\)\s*/, '');
+        document.title =
+            unreadCount > 0 ? `(${unreadCount}) ${baseTitle}` : baseTitle;
+    }, [unreadCount]);
 
     // Setup polling for unread count (only when authenticated)
     useEffect(() => {

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -180,7 +180,12 @@ export type NotificationType =
     | 'commendation_received'
     | 'profile_comment'
     | 'join_request_accepted'
-    | 'join_request_rejected';
+    | 'join_request_rejected'
+    | 'join_request_created'
+    | 'team_invitation_accepted'
+    | 'captaincy_transferred'
+    | 'match_confirmed'
+    | 'tournament_registration_reviewed';
 
 export interface NotificationData {
     type: NotificationType;
@@ -193,6 +198,10 @@ export interface NotificationData {
         team_id?: number;
         match_request_id?: number;
         invited_by_id?: number;
+        join_request_id?: number;
+        invitation_id?: number;
+        tournament_id?: number;
+        approved?: boolean;
     };
     created_at: string;
 }

--- a/tests/Feature/NewNotificationsTest.php
+++ b/tests/Feature/NewNotificationsTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\FootballMatch;
+use App\Models\MatchRequest;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\TeamMember;
+use App\Models\Tournament;
+use App\Models\TournamentTeam;
+use App\Models\User;
+use App\Notifications\CaptaincyTransferredNotification;
+use App\Notifications\JoinRequestCreatedNotification;
+use App\Notifications\MatchConfirmedNotification;
+use App\Notifications\MatchRequestAcceptedNotification;
+use App\Notifications\TeamInvitationAcceptedNotification;
+use App\Notifications\TournamentRegistrationReviewedNotification;
+use App\Services\MatchService;
+use App\Services\TeamInvitationService;
+use App\Services\TeamService;
+use App\Services\Tournament\TournamentRegistrationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Create a team with the given user as active captain.
+ */
+function teamWithCaptain(User $captain): Team
+{
+    $team = Team::factory()->create(['created_by' => $captain->id]);
+
+    TeamMember::create([
+        'user_id' => $captain->id,
+        'team_id' => $team->id,
+        'role' => 'captain',
+        'status' => 'active',
+    ]);
+
+    return $team;
+}
+
+// ============================================================
+// 1. Join request created -> team leaders
+// ============================================================
+
+test('creating a join request notifies team leaders, not the requester', function () {
+    Notification::fake();
+
+    $captain = User::factory()->create();
+    $team = teamWithCaptain($captain);
+    $requester = User::factory()->create();
+
+    app(TeamService::class)->createJoinRequest($requester->id, $team->id);
+
+    Notification::assertSentTo($captain, JoinRequestCreatedNotification::class);
+    Notification::assertNotSentTo($requester, JoinRequestCreatedNotification::class);
+});
+
+// ============================================================
+// 2. Captaincy transferred -> new captain
+// ============================================================
+
+test('transferring captaincy notifies the new captain', function () {
+    Notification::fake();
+
+    $captain = User::factory()->create();
+    $team = teamWithCaptain($captain);
+    $player = User::factory()->create();
+
+    TeamMember::create([
+        'user_id' => $player->id,
+        'team_id' => $team->id,
+        'role' => 'player',
+        'status' => 'active',
+    ]);
+
+    app(TeamService::class)->transferCaptaincy($team, $captain->id, $player->id);
+
+    Notification::assertSentTo($player, CaptaincyTransferredNotification::class);
+});
+
+// ============================================================
+// 3. Team invitation accepted -> inviter
+// ============================================================
+
+test('accepting an invitation notifies the inviter', function () {
+    Notification::fake();
+
+    $captain = User::factory()->create();
+    $team = teamWithCaptain($captain);
+    $invitee = User::factory()->create();
+
+    $invitation = TeamInvitation::create([
+        'team_id' => $team->id,
+        'invited_by' => $captain->id,
+        'email' => $invitee->email,
+        'token' => TeamInvitation::generateToken(),
+        'role' => 'player',
+        'status' => 'pending',
+        'expires_at' => now()->addDays(7),
+    ]);
+
+    app(TeamInvitationService::class)->acceptInvitation($invitation, $invitee);
+
+    Notification::assertSentTo($captain, TeamInvitationAcceptedNotification::class);
+});
+
+test('accepting an invitation when already a member notifies no one', function () {
+    Notification::fake();
+
+    $captain = User::factory()->create();
+    $team = teamWithCaptain($captain);
+    $invitee = User::factory()->create();
+
+    TeamMember::create([
+        'user_id' => $invitee->id,
+        'team_id' => $team->id,
+        'role' => 'player',
+        'status' => 'active',
+    ]);
+
+    $invitation = TeamInvitation::create([
+        'team_id' => $team->id,
+        'invited_by' => $captain->id,
+        'email' => $invitee->email,
+        'token' => TeamInvitation::generateToken(),
+        'role' => 'player',
+        'status' => 'pending',
+        'expires_at' => now()->addDays(7),
+    ]);
+
+    app(TeamInvitationService::class)->acceptInvitation($invitation, $invitee);
+
+    Notification::assertNotSentTo($captain, TeamInvitationAcceptedNotification::class);
+});
+
+// ============================================================
+// 4. Match confirmed -> home team leaders (away team gets accepted)
+// ============================================================
+
+test('accepting a match request confirms the match for the home team', function () {
+    Notification::fake();
+
+    $homeCaptain = User::factory()->create();
+    $awayCaptain = User::factory()->create();
+    $homeTeam = teamWithCaptain($homeCaptain);
+    $awayTeam = teamWithCaptain($awayCaptain);
+
+    $match = FootballMatch::factory()->create([
+        'home_team_id' => $homeTeam->id,
+        'away_team_id' => null,
+        'status' => 'available',
+        'created_by' => $homeCaptain->id,
+    ]);
+
+    $request = MatchRequest::create([
+        'match_id' => $match->id,
+        'requesting_team_id' => $awayTeam->id,
+        'status' => 'pending',
+    ]);
+
+    app(MatchService::class)->acceptMatchRequest($request, $homeCaptain->id);
+
+    Notification::assertSentTo($homeCaptain, MatchConfirmedNotification::class);
+    Notification::assertSentTo($awayCaptain, MatchRequestAcceptedNotification::class);
+});
+
+// ============================================================
+// 5. Tournament registration reviewed -> registering team leaders
+// ============================================================
+
+test('approving a tournament registration notifies the team leaders', function () {
+    Notification::fake();
+
+    $captain = User::factory()->create();
+    $team = teamWithCaptain($captain);
+    $tournament = Tournament::factory()->create();
+
+    $registration = TournamentTeam::factory()->create([
+        'tournament_id' => $tournament->id,
+        'team_id' => $team->id,
+        'status' => 'pending',
+    ]);
+
+    app(TournamentRegistrationService::class)->approveTeam($registration);
+
+    Notification::assertSentTo(
+        $captain,
+        TournamentRegistrationReviewedNotification::class,
+        fn ($notification) => $notification->approved === true
+    );
+});
+
+test('rejecting a tournament registration notifies the team leaders', function () {
+    Notification::fake();
+
+    $captain = User::factory()->create();
+    $team = teamWithCaptain($captain);
+    $tournament = Tournament::factory()->create();
+
+    $registration = TournamentTeam::factory()->create([
+        'tournament_id' => $tournament->id,
+        'team_id' => $team->id,
+        'status' => 'pending',
+    ]);
+
+    app(TournamentRegistrationService::class)->rejectTeam($registration);
+
+    Notification::assertSentTo(
+        $captain,
+        TournamentRegistrationReviewedNotification::class,
+        fn ($notification) => $notification->approved === false
+    );
+});


### PR DESCRIPTION
## Summary

Adds a notifications feature on top of the existing bell/panel, rebased cleanly onto `dev` (post #119, so it does **not** touch the landing/auth redesign).

### Backend — five new notifications
- **Captaincy transferred** → notifies the new captain
- **Join request created** → notifies team leaders (not the requester)
- **Match confirmed** → notifies the home team when a request is accepted
- **Team invitation accepted** → notifies the inviter
- **Tournament registration reviewed** → notifies team leaders on approve/reject

Wired into `MatchService`, `TeamService`, `TeamInvitationService`, and `TournamentRegistrationService`.

### Frontend — real-time panel polish
- Real-time notification **sound** + **tab-title badge** for unread counts
- XSRF write fix for mark-as-read actions
- Notification panel **date grouping** and brand-green accent colors

### Tests
- `tests/Feature/NewNotificationsTest.php` — 7 passing tests (9 assertions) covering who gets notified (and who doesn't) for each event.

## Checks
- `bun run types` ✅
- `bun run lint` ✅
- `bun run format:check` ✅ (JS) / `pint` ✅ (PHP)
- `php artisan test tests/Feature/NewNotificationsTest.php` ✅ 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)