### PR TITLE
feat: input validation on names + branded error pages

### DIFF
--- a/app/Http/Controllers/MatchController.php
+++ b/app/Http/Controllers/MatchController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers;
 use App\Models\FootballMatch;
 use App\Models\MatchRequest;
 use App\Models\Team;
+use App\Rules\CleanText;
 use App\Services\MatchService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -63,7 +64,7 @@ final class MatchController extends Controller
         $validated = $request->validate([
             'team_id' => ['required', 'integer', 'exists:teams,id'],
             'scheduled_at' => ['required', 'date', 'after_or_equal:now'],
-            'location' => ['required', 'string', 'max:255'],
+            'location' => ['required', 'string', 'max:255', new CleanText],
             'location_coords' => ['nullable', 'string', 'max:255'],
             'match_type' => ['required', 'in:friendly,competitive'],
             'notes' => ['nullable', 'string', 'max:1000'],
@@ -327,7 +328,7 @@ final class MatchController extends Controller
 
         $validated = $request->validate([
             'scheduled_at' => ['required', 'date', 'after_or_equal:now'],
-            'location' => ['required', 'string', 'max:255'],
+            'location' => ['required', 'string', 'max:255', new CleanText],
             'location_coords' => ['nullable', 'string', 'max:255'],
             'match_type' => ['required', 'in:friendly,competitive'],
             'notes' => ['nullable', 'string', 'max:1000'],

--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Team;
 use App\Models\TeamInvitation;
+use App\Rules\CleanText;
 use App\Services\TeamService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -51,7 +52,7 @@ final class TeamController extends Controller
     public function store(Request $request)
     {
         $validated = $request->validate([
-            'name' => ['required', 'string', 'max:255'],
+            'name' => ['required', 'string', 'max:255', new CleanText],
             'variant' => ['required', 'in:football_11,football_7,football_5,futsal'],
             'description' => ['nullable', 'string', 'max:1000'],
         ]);
@@ -114,7 +115,7 @@ final class TeamController extends Controller
         }
 
         $validated = $request->validate([
-            'name' => ['required', 'string', 'max:255'],
+            'name' => ['required', 'string', 'max:255', new CleanText],
             'variant' => ['required', 'in:football_11,football_7,football_5,futsal'],
             'description' => ['nullable', 'string', 'max:1000'],
         ]);

--- a/app/Http/Controllers/TournamentController.php
+++ b/app/Http/Controllers/TournamentController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Team;
 use App\Models\Tournament;
+use App\Rules\CleanText;
 use App\Services\StandingsService;
 use App\Services\TournamentService;
 use Illuminate\Http\Request;
@@ -281,7 +282,7 @@ final class TournamentController extends Controller
         $format = $request->input('format', 'single_elimination');
 
         $rules = [
-            'name' => ['required', 'string', 'max:255'],
+            'name' => ['required', 'string', 'max:255', new CleanText],
             'description' => ['nullable', 'string', 'max:5000'],
             'logo' => ['nullable', 'image', 'mimes:jpg,jpeg,png,webp', 'max:2048'],
             'visibility' => ['required', 'in:public,invite_only'],

--- a/app/Http/Requests/Settings/ProfileUpdateRequest.php
+++ b/app/Http/Requests/Settings/ProfileUpdateRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Settings;
 
 use App\Models\User;
+use App\Rules\CleanText;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -17,7 +18,7 @@ class ProfileUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:255'],
+            'name' => ['required', 'string', 'max:255', new CleanText],
 
             'email' => [
                 'required',
@@ -46,6 +47,7 @@ class ProfileUpdateRequest extends FormRequest
                 'nullable',
                 'string',
                 'max:100',
+                new CleanText,
             ],
 
             'date_of_birth' => [

--- a/app/Rules/CleanText.php
+++ b/app/Rules/CleanText.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Rejects text that looks like code or an injection attempt.
+ *
+ * Purely cosmetic / UX: inputs are already safe against SQL injection via
+ * Eloquent's parameterized queries. This rule keeps strings like
+ * `' OR '1'='1` or `' AND 1=CONVERT(int,'a') --` out of identifier-style
+ * fields (team/tournament names, locations) where they would just look bad.
+ *
+ * It is permissive toward normal text (accents, emoji, single apostrophes,
+ * single dashes); it only flags the structural signatures of code/injection.
+ */
+class CleanText implements ValidationRule
+{
+    /**
+     * Patterns whose presence marks the value as code-like.
+     *
+     * @var array<int, string>
+     */
+    private const SIGNATURES = [
+        // SQL comment / statement-terminator sequences.
+        '/--/',
+        '/;/',
+        '/\/\*|\*\//',
+        '/#/',
+        // Angle brackets / HTML & script tags.
+        '/[<>]/',
+        // Comparison operator.
+        '/=/',
+        // Quote paired with a boolean operator or comparison (classic injection shape).
+        '/[\'"`].*(\bor\b|\band\b|=)/i',
+        // Function-call shape used in payloads, e.g. CONVERT(, CHAR(, CAST(.
+        '/\b(convert|cast|char|concat|exec|select|union|declare)\s*\(/i',
+    ];
+
+    /**
+     * Run the validation rule.
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value)) {
+            return;
+        }
+
+        foreach (self::SIGNATURES as $pattern) {
+            if (preg_match($pattern, $value) === 1) {
+                $fail('El texto contiene caracteres o palabras no permitidos.');
+
+                return;
+            }
+        }
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,6 +6,9 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Symfony\Component\HttpFoundation\Response;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -29,5 +32,34 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
-        //
+        // Render branded Inertia error pages instead of Laravel's default
+        // exception views. Tests are skipped so feature tests can assert raw
+        // 4xx/5xx statuses. Server errors (500/503) keep Laravel's detailed
+        // exception page while debugging (APP_DEBUG=true); client errors
+        // (403/404) are always branded since they never carry a stack trace.
+        $exceptions->respond(function (Response $response, \Throwable $exception, Request $request) {
+            if (app()->environment('testing')) {
+                return $response;
+            }
+
+            $status = $response->getStatusCode();
+
+            // A stale CSRF token: bounce back rather than show a full error page.
+            if ($status === 419) {
+                return back()->with('error', 'La sesión expiró, intentá de nuevo.');
+            }
+
+            // Keep the detailed exception page for server errors while debugging.
+            if (in_array($status, [500, 503], true) && config('app.debug')) {
+                return $response;
+            }
+
+            if (in_array($status, [403, 404, 500, 503], true)) {
+                return Inertia::render('errors/error', ['status' => $status])
+                    ->toResponse($request)
+                    ->setStatusCode($status);
+            }
+
+            return $response;
+        });
     })->create();

--- a/resources/js/pages/errors/error.tsx
+++ b/resources/js/pages/errors/error.tsx
@@ -1,0 +1,138 @@
+import AppLogoIcon from '@/components/app-logo-icon';
+import { Button } from '@/components/ui/button';
+import { home } from '@/routes';
+import { Head, Link } from '@inertiajs/react';
+import { ArrowLeft, Home } from 'lucide-react';
+
+interface Props {
+    status: number;
+}
+
+interface ErrorCopy {
+    title: string;
+    heading: string;
+    description: string;
+}
+
+const COPY: Record<number, ErrorCopy> = {
+    404: {
+        title: 'Página no encontrada',
+        heading: 'Esta cancha no existe',
+        description:
+            'La página que buscás no existe o fue movida. Revisá la dirección o volvé al inicio.',
+    },
+    403: {
+        title: 'Acceso denegado',
+        heading: 'No tenés permiso',
+        description:
+            'No estás autorizado para ver esta página. Si creés que es un error, contactá al capitán de tu equipo.',
+    },
+    419: {
+        title: 'La sesión expiró',
+        heading: 'Se venció la sesión',
+        description:
+            'Por seguridad, tu sesión expiró. Actualizá la página e intentá de nuevo.',
+    },
+    500: {
+        title: 'Error del servidor',
+        heading: 'Algo salió mal',
+        description:
+            'Tuvimos un problema de nuestro lado. Ya estamos trabajando para solucionarlo. Probá de nuevo en unos minutos.',
+    },
+    503: {
+        title: 'En mantenimiento',
+        heading: 'Volvemos enseguida',
+        description:
+            'Estamos haciendo mejoras en Veltro. Volvé en un rato. Gracias por la paciencia.',
+    },
+};
+
+const FALLBACK: ErrorCopy = {
+    title: 'Algo salió mal',
+    heading: 'Algo salió mal',
+    description:
+        'Ocurrió un error inesperado. Volvé al inicio o intentá de nuevo más tarde.',
+};
+
+/** Subtle pitch-line motif, mirroring the landing-page backdrop. */
+const PitchLines = () => (
+    <svg
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 h-full w-full text-foreground"
+        viewBox="0 0 1200 700"
+        preserveAspectRatio="xMidYMid slice"
+        style={{ opacity: 0.04 }}
+    >
+        <g fill="none" stroke="currentColor" strokeWidth="1.4">
+            <rect x="90" y="70" width="1020" height="560" rx="8" />
+            <line x1="600" y1="70" x2="600" y2="630" />
+            <circle cx="600" cy="350" r="96" />
+            <circle cx="600" cy="350" r="4" fill="currentColor" stroke="none" />
+            <rect x="90" y="215" width="164" height="270" rx="4" />
+            <rect x="946" y="215" width="164" height="270" rx="4" />
+        </g>
+    </svg>
+);
+
+export default function ErrorPage({ status }: Props) {
+    const copy = COPY[status] ?? FALLBACK;
+
+    return (
+        <>
+            <Head title={`${status} — ${copy.title}`} />
+
+            <main className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-background px-6 py-16 text-center">
+                {/* Atmospheric backdrop: brand glow + pitch motif + film grain. */}
+                <div
+                    aria-hidden="true"
+                    className="pointer-events-none absolute inset-0"
+                >
+                    <div className="bg-pitch-glow absolute inset-0" />
+                    <PitchLines />
+                    <div className="bg-grain absolute inset-0 opacity-[0.035] mix-blend-soft-light" />
+                </div>
+
+                <div className="relative z-10 flex w-full max-w-md flex-col items-center">
+                    <Link
+                        href={home().url}
+                        className="mb-10 flex items-center gap-2"
+                    >
+                        <AppLogoIcon className="size-8 text-primary" />
+                        <span className="text-lg font-semibold tracking-tight">
+                            Veltro
+                        </span>
+                    </Link>
+
+                    <p className="text-display text-7xl text-primary sm:text-8xl">
+                        {status}
+                    </p>
+
+                    <h1 className="mt-4 text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+                        {copy.heading}
+                    </h1>
+
+                    <p className="mt-3 text-base leading-relaxed text-muted-foreground">
+                        {copy.description}
+                    </p>
+
+                    <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row">
+                        <Button size="lg" asChild>
+                            <Link href={home().url}>
+                                <Home className="size-4" />
+                                Volver al inicio
+                            </Link>
+                        </Button>
+                        <Button
+                            size="lg"
+                            variant="outline"
+                            onClick={() => window.history.back()}
+                        >
+                            <ArrowLeft className="size-4" />
+                            Volver atrás
+                        </Button>
+                    </div>
+                </div>
+            </main>
+        </>
+    );
+}

--- a/tests/Feature/TeamTest.php
+++ b/tests/Feature/TeamTest.php
@@ -106,6 +106,15 @@ test('team creation accepts all valid variants', function (string $variant) {
     $this->assertDatabaseHas('teams', ['variant' => $variant]);
 })->with(['football_11', 'football_7', 'football_5', 'futsal']);
 
+test('team creation rejects injection-looking names', function () {
+    $this->actingAs($this->outsider)
+        ->post(route('teams.store'), [
+            'name' => "' OR '1'='1",
+            'variant' => 'football_11',
+        ])
+        ->assertSessionHasErrors('name');
+});
+
 test('team description cannot exceed 1000 characters', function () {
     $this->actingAs($this->outsider)
         ->post(route('teams.store'), [

--- a/tests/Unit/CleanTextRuleTest.php
+++ b/tests/Unit/CleanTextRuleTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Rules\CleanText;
+
+function cleanTextFails(string $value): bool
+{
+    $failed = false;
+
+    (new CleanText)->validate('field', $value, function () use (&$failed) {
+        $failed = true;
+    });
+
+    return $failed;
+}
+
+test('rejects injection-looking strings', function (string $value) {
+    expect(cleanTextFails($value))->toBeTrue();
+})->with([
+    "' OR '1'='1",
+    "' AND 1=CONVERT(int,'a') --",
+    '; DROP TABLE teams',
+    '<script>alert(1)</script>',
+    'SELECT(*) FROM users',
+    'a=b',
+    'foo; delete from users',
+]);
+
+test('accepts normal identifier text', function (string $value) {
+    expect(cleanTextFails($value))->toBeFalse();
+})->with([
+    'Los Tigres',
+    'Peñarol FC',
+    'Cancha 5 - Parque Rodó',
+    "O'Higgins",
+    'Fútbol 5',
+    'Defensor 🦊',
+    'Co-Captain Update',
+    'Select FC',
+]);


### PR DESCRIPTION
## Summary

Two UX/polish improvements:

### 1. Reject injection-looking text on name fields
Adds a reusable `CleanText` validation rule (`app/Rules/CleanText.php`) that flags code/injection-shaped strings — SQL comments, `;` `=` `<>` sequences, quote+operator patterns (e.g. `' OR '1'='1`), and function-call shapes. Applied to short identifier fields: **team name, tournament name, user name + location, match location**.

Purely cosmetic — inputs were already safe via Eloquent's parameterized queries, but values like `' OR '1'='1` looked bad once stored and displayed. The rule stays permissive toward normal text (accents, emoji, single apostrophes like `O'Higgins`, single dashes) to avoid false positives on legitimate names. Descriptions/bios/notes/comments are intentionally left untouched.

### 2. Branded Inertia error pages
Renders a Veltro-branded error page (`resources/js/pages/errors/error.tsx`) for **403/404/500/503** instead of Laravel's default views, matching the landing-page aesthetic (hexagon mark, pitch-line motif, brand glow) with Rioplatense copy per status and CTAs back home.

Wired via `withExceptions` in `bootstrap/app.php`:
- Client errors (403/404) are **always** branded (no stack trace to lose).
- Server errors (500/503) keep Laravel's detailed exception page while `APP_DEBUG=true`.
- 419 (expired CSRF) bounces back with a flash message.
- The `testing` env passes through so feature tests assert raw statuses.

## Testing
- New `tests/Unit/CleanTextRuleTest.php` (reject/accept cases, incl. the real payloads).
- New feature test in `tests/Feature/TeamTest.php` asserting injection-looking team names are rejected.
- Full suite green (364 passed); `bun run types` and Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)