### PR TITLE
feat: brand transactional emails + database schema docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ yarn-error.log
 project.md
 diseño_tecnico.md
 package-lock.json
+
+# DBML generator error log
+docs/dbml-error.log

--- a/docs/database-schema.dbml
+++ b/docs/database-schema.dbml
@@ -1,0 +1,471 @@
+// Veltro — Database structure (Modelo Entidad-Relación)
+// Use DBML to define your database structure
+// Docs: https://dbml.dbdiagram.io/docs
+//
+// Domain tables only. Laravel infrastructure tables (cache, jobs, sessions,
+// password_reset_tokens, failed_jobs, job_batches, cache_locks) are omitted.
+// Note: the `matches` table is mapped by the `FootballMatch` Eloquent model.
+
+Project veltro {
+  database_type: 'MySQL'
+  Note: 'Amateur football platform — teams, matches, tournaments, statistics.'
+}
+
+//
+// Enums
+//
+
+Enum team_variant {
+  football_11
+  football_7
+  football_5
+  futsal
+}
+
+Enum team_member_role {
+  captain
+  co_captain
+  player
+}
+
+Enum player_position {
+  goalkeeper
+  defender
+  midfielder
+  forward
+}
+
+Enum membership_status {
+  active
+  inactive
+}
+
+Enum request_status {
+  pending
+  accepted
+  rejected
+}
+
+Enum invitation_role {
+  player
+  co_captain
+}
+
+Enum invitation_status {
+  pending
+  accepted
+  expired
+  revoked
+}
+
+Enum match_type {
+  friendly
+  competitive
+}
+
+Enum match_status {
+  available
+  pending
+  confirmed
+  in_progress
+  completed
+  cancelled
+}
+
+Enum availability_status {
+  pending
+  available
+  maybe
+  unavailable
+}
+
+Enum match_event_type {
+  goal
+  assist
+  yellow_card
+  red_card
+  substitution_in
+  substitution_out
+}
+
+Enum commendation_category {
+  friendly
+  skilled
+  teamwork
+  leadership
+}
+
+Enum tournament_visibility {
+  public
+  invite_only
+}
+
+Enum tournament_status {
+  draft
+  registration_open
+  in_progress
+  completed
+  cancelled
+}
+
+Enum tournament_format {
+  single_elimination
+  league
+  group_stage_knockout
+}
+
+Enum tournament_phase {
+  not_started
+  league
+  group_stage
+  knockout
+  completed
+}
+
+Enum tournament_team_status {
+  pending
+  approved
+  rejected
+  withdrawn
+}
+
+//
+// Tables
+//
+
+Table users {
+  id bigint [pk, increment]
+  name varchar
+  email varchar [unique, not null]
+  phone_number varchar(20) [null]
+  email_verified_at timestamp [null]
+  password varchar [null, note: 'nullable for Google OAuth users']
+  remember_token varchar(100) [null]
+  google_id varchar [unique, null]
+  google_token text [null]
+  google_avatar_url varchar [null]
+  two_factor_secret text [null]
+  two_factor_recovery_codes text [null]
+  two_factor_confirmed_at timestamp [null]
+  bio text [null]
+  location varchar(100) [null]
+  date_of_birth date [null]
+  avatar_path varchar [null]
+  onboarding_completed boolean [not null, default: false]
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    phone_number
+  }
+}
+
+Table teams {
+  id bigint [pk, increment]
+  name varchar
+  variant team_variant [not null]
+  logo_url varchar [null, note: 'legacy']
+  logo_path varchar [null]
+  description text [null]
+  max_members int [null]
+  created_by bigint [ref: > users.id, null, note: 'SET NULL on delete']
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    variant
+  }
+}
+
+Table team_members {
+  id bigint [pk, increment]
+  user_id bigint [ref: > users.id, not null, note: 'cascade']
+  team_id bigint [ref: > teams.id, not null, note: 'cascade']
+  role team_member_role [not null, default: 'player']
+  position player_position [null]
+  joined_at timestamp
+  status membership_status [not null, default: 'active']
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    (user_id, team_id) [unique]
+    (team_id, role, status)
+    (team_id, status)
+    (user_id, status)
+  }
+}
+
+Table join_requests {
+  id bigint [pk, increment]
+  user_id bigint [ref: > users.id, not null, note: 'cascade']
+  team_id bigint [ref: > teams.id, not null, note: 'cascade']
+  status request_status [not null, default: 'pending']
+  message text [null]
+  reviewed_at timestamp [null]
+  reviewed_by bigint [ref: > users.id, null, note: 'SET NULL on delete']
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    (user_id, team_id) [unique]
+    (team_id, status)
+    (user_id, status)
+  }
+}
+
+Table team_invitations {
+  id bigint [pk, increment]
+  team_id bigint [ref: > teams.id, not null, note: 'cascade']
+  invited_by bigint [ref: > users.id, not null, note: 'cascade']
+  email varchar [null]
+  token varchar [unique, not null]
+  role invitation_role [not null, default: 'player']
+  status invitation_status [not null, default: 'pending']
+  expires_at timestamp
+  accepted_by bigint [ref: > users.id, null, note: 'SET NULL on delete']
+  accepted_at timestamp [null]
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    (token, status)
+    (team_id, email)
+  }
+}
+
+Table matches {
+  id bigint [pk, increment]
+  home_team_id bigint [ref: > teams.id, null, note: 'cascade']
+  away_team_id bigint [ref: > teams.id, null, note: 'cascade']
+  tournament_id bigint [ref: > tournaments.id, null, note: 'cascade']
+  tournament_round_id bigint [ref: > tournament_rounds.id, null, note: 'SET NULL on delete']
+  tournament_group_id bigint [ref: > tournament_groups.id, null, note: 'SET NULL on delete']
+  bracket_position int [null]
+  matchday smallint [null]
+  variant team_variant [not null]
+  scheduled_at datetime [null]
+  location varchar [null]
+  location_coords varchar [null]
+  match_type match_type [not null, default: 'friendly']
+  status match_status [not null, default: 'available']
+  home_score int [null]
+  away_score int [null]
+  notes text [null]
+  created_by bigint [ref: > users.id, not null, note: 'cascade']
+  confirmed_at timestamp [null]
+  started_at timestamp [null]
+  completed_at timestamp [null]
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    status
+    variant
+    scheduled_at
+    (home_team_id, status)
+    (away_team_id, status)
+    tournament_id
+    tournament_round_id
+    tournament_group_id
+    (tournament_id, matchday)
+  }
+
+  Note: 'Mapped by the FootballMatch model'
+}
+
+Table match_requests {
+  id bigint [pk, increment]
+  match_id bigint [ref: > matches.id, not null, note: 'cascade']
+  requesting_team_id bigint [ref: > teams.id, not null, note: 'cascade']
+  status request_status [not null, default: 'pending']
+  message text [null]
+  reviewed_at timestamp [null]
+  reviewed_by bigint [ref: > users.id, null, note: 'SET NULL on delete']
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    status
+  }
+}
+
+Table match_lineups {
+  id bigint [pk, increment]
+  match_id bigint [ref: > matches.id, not null, note: 'cascade']
+  team_id bigint [ref: > teams.id, not null, note: 'cascade']
+  user_id bigint [ref: > users.id, not null, note: 'cascade']
+  position player_position [null]
+  is_starter boolean [not null, default: true]
+  is_substitute boolean [not null, default: false]
+  minutes_played int [not null, default: 0]
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    (match_id, team_id, user_id) [unique]
+  }
+}
+
+Table match_events {
+  id bigint [pk, increment]
+  match_id bigint [ref: > matches.id, not null, note: 'cascade']
+  team_id bigint [ref: > teams.id, not null, note: 'cascade']
+  user_id bigint [ref: > users.id, null, note: 'cascade']
+  event_type match_event_type [not null]
+  minute int [null]
+  description text [null]
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    (match_id, event_type)
+  }
+}
+
+Table match_availability {
+  id bigint [pk, increment]
+  match_id bigint [ref: > matches.id, not null, note: 'cascade']
+  user_id bigint [ref: > users.id, not null, note: 'cascade']
+  team_id bigint [ref: > teams.id, not null, note: 'cascade']
+  status availability_status [not null, default: 'pending']
+  confirmed_at timestamp [null]
+  reminded_at timestamp [null]
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    (match_id, user_id, team_id) [unique]
+    status
+  }
+}
+
+Table tournaments {
+  id bigint [pk, increment]
+  name varchar
+  description text [null]
+  logo_url varchar [null, note: 'legacy']
+  logo_path varchar [null]
+  organizer_id bigint [ref: > users.id, not null, note: 'cascade']
+  visibility tournament_visibility [not null, default: 'public']
+  status tournament_status [not null, default: 'draft']
+  variant team_variant [not null]
+  format tournament_format [not null, default: 'single_elimination']
+  phase tournament_phase [not null, default: 'not_started']
+  group_count smallint [null]
+  group_size smallint [null]
+  max_teams int [not null, default: 8]
+  min_teams int [not null, default: 4]
+  registration_deadline timestamp [null]
+  starts_at timestamp [null]
+  ends_at timestamp [null]
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    organizer_id
+    status
+    visibility
+    variant
+    starts_at
+    format
+  }
+}
+
+Table tournament_teams {
+  id bigint [pk, increment]
+  tournament_id bigint [ref: > tournaments.id, not null, note: 'cascade']
+  team_id bigint [ref: > teams.id, not null, note: 'cascade']
+  status tournament_team_status [not null, default: 'pending']
+  seed int [null]
+  tournament_group_id bigint [ref: > tournament_groups.id, null, note: 'SET NULL on delete']
+  registered_by bigint [ref: > users.id, not null, note: 'cascade']
+  registered_at timestamp
+  approved_at timestamp [null]
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    (tournament_id, team_id) [unique]
+    tournament_id
+    team_id
+    status
+    seed
+    tournament_group_id
+  }
+}
+
+Table tournament_rounds {
+  id bigint [pk, increment]
+  tournament_id bigint [ref: > tournaments.id, not null, note: 'cascade']
+  round_number int [not null]
+  name varchar
+  starts_at timestamp [null]
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    tournament_id
+    round_number
+    (tournament_id, round_number) [unique]
+  }
+}
+
+Table tournament_groups {
+  id bigint [pk, increment]
+  tournament_id bigint [ref: > tournaments.id, not null, note: 'cascade']
+  name varchar(8) [not null, note: 'group label, e.g. A, B']
+  position smallint [not null]
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    (tournament_id, name) [unique]
+    (tournament_id, position) [unique]
+    tournament_id
+  }
+}
+
+Table profile_comments {
+  id bigint [pk, increment]
+  user_id bigint [ref: > users.id, null, note: 'author, SET NULL on delete']
+  profile_user_id bigint [ref: > users.id, null, note: 'profile owner, SET NULL on delete']
+  comment text [not null]
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    (profile_user_id, created_at)
+  }
+}
+
+Table user_commendations {
+  id bigint [pk, increment]
+  from_user_id bigint [ref: > users.id, null, note: 'SET NULL on delete']
+  to_user_id bigint [ref: > users.id, null, note: 'SET NULL on delete']
+  category commendation_category [not null]
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    (from_user_id, to_user_id, category) [unique]
+    from_user_id
+    to_user_id
+  }
+}
+
+Table notifications {
+  id varchar [pk, note: 'UUID']
+  type varchar [not null]
+  notifiable_type varchar [not null, note: 'polymorphic']
+  notifiable_id bigint [not null, note: 'polymorphic — typically users.id']
+  data text [not null]
+  read_at timestamp [null]
+  created_at timestamp
+  updated_at timestamp
+
+  Indexes {
+    (notifiable_type, notifiable_id, read_at)
+    created_at
+  }
+}

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -1,0 +1,346 @@
+# Database Schema — Modelo Entidad-Relación (MER)
+
+This document describes Veltro's domain database schema as an Entity-Relationship Model
+(Modelo Entidad-Relación). It is generated from the migrations in `database/migrations/`
+and the Eloquent models in `app/Models/`.
+
+The diagram below covers the **domain tables only**. Laravel infrastructure tables
+(`cache`, `cache_locks`, `jobs`, `job_batches`, `failed_jobs`, `sessions`,
+`password_reset_tokens`) are intentionally omitted.
+
+> Note: the `matches` table is mapped by the `FootballMatch` model (Eloquent).
+
+## ER Diagram
+
+```mermaid
+erDiagram
+    users {
+        bigint id PK
+        string name
+        string email UK
+        string phone_number "nullable, indexed"
+        timestamp email_verified_at "nullable"
+        string password "nullable (Google OAuth)"
+        string remember_token "nullable"
+        string google_id "nullable, UK"
+        text google_token "nullable"
+        string google_avatar_url "nullable"
+        text two_factor_secret "nullable"
+        text two_factor_recovery_codes "nullable"
+        timestamp two_factor_confirmed_at "nullable"
+        text bio "nullable"
+        string location "nullable"
+        date date_of_birth "nullable"
+        string avatar_path "nullable"
+        boolean onboarding_completed "default false"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    teams {
+        bigint id PK
+        string name
+        enum variant "football_11|football_7|football_5|futsal, indexed"
+        string logo_url "nullable (legacy)"
+        string logo_path "nullable"
+        text description "nullable"
+        int max_members "nullable"
+        bigint created_by FK "nullable, SET NULL"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    team_members {
+        bigint id PK
+        bigint user_id FK "cascade"
+        bigint team_id FK "cascade"
+        enum role "captain|co_captain|player, default player"
+        enum position "goalkeeper|defender|midfielder|forward, nullable"
+        timestamp joined_at
+        enum status "active|inactive, default active"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    join_requests {
+        bigint id PK
+        bigint user_id FK "cascade"
+        bigint team_id FK "cascade"
+        enum status "pending|accepted|rejected, default pending"
+        text message "nullable"
+        timestamp reviewed_at "nullable"
+        bigint reviewed_by FK "nullable, SET NULL"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    team_invitations {
+        bigint id PK
+        bigint team_id FK "cascade"
+        bigint invited_by FK "cascade"
+        string email "nullable"
+        string token UK
+        enum role "player|co_captain, default player"
+        enum status "pending|accepted|expired|revoked, default pending"
+        timestamp expires_at
+        bigint accepted_by FK "nullable, SET NULL"
+        timestamp accepted_at "nullable"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    matches {
+        bigint id PK
+        bigint home_team_id FK "nullable, cascade"
+        bigint away_team_id FK "nullable, cascade"
+        bigint tournament_id FK "nullable, cascade"
+        bigint tournament_round_id FK "nullable, SET NULL"
+        bigint tournament_group_id FK "nullable, SET NULL"
+        int bracket_position "nullable"
+        smallint matchday "nullable"
+        enum variant "football_11|football_7|football_5|futsal"
+        datetime scheduled_at "nullable"
+        string location "nullable"
+        string location_coords "nullable"
+        enum match_type "friendly|competitive, default friendly"
+        enum status "available|pending|confirmed|in_progress|completed|cancelled"
+        int home_score "nullable"
+        int away_score "nullable"
+        text notes "nullable"
+        bigint created_by FK "cascade"
+        timestamp confirmed_at "nullable"
+        timestamp started_at "nullable"
+        timestamp completed_at "nullable"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    match_requests {
+        bigint id PK
+        bigint match_id FK "cascade"
+        bigint requesting_team_id FK "cascade"
+        enum status "pending|accepted|rejected, default pending"
+        text message "nullable"
+        timestamp reviewed_at "nullable"
+        bigint reviewed_by FK "nullable, SET NULL"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    match_lineups {
+        bigint id PK
+        bigint match_id FK "cascade"
+        bigint team_id FK "cascade"
+        bigint user_id FK "cascade"
+        enum position "goalkeeper|defender|midfielder|forward, nullable"
+        boolean is_starter "default true"
+        boolean is_substitute "default false"
+        int minutes_played "default 0"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    match_events {
+        bigint id PK
+        bigint match_id FK "cascade"
+        bigint team_id FK "cascade"
+        bigint user_id FK "nullable, cascade"
+        enum event_type "goal|assist|yellow_card|red_card|substitution_in|substitution_out"
+        int minute "nullable"
+        text description "nullable"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    match_availability {
+        bigint id PK
+        bigint match_id FK "cascade"
+        bigint user_id FK "cascade"
+        bigint team_id FK "cascade"
+        enum status "pending|available|maybe|unavailable, default pending"
+        timestamp confirmed_at "nullable"
+        timestamp reminded_at "nullable"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    tournaments {
+        bigint id PK
+        string name
+        text description "nullable"
+        string logo_url "nullable (legacy)"
+        string logo_path "nullable"
+        bigint organizer_id FK "cascade"
+        enum visibility "public|invite_only, default public"
+        enum status "draft|registration_open|in_progress|completed|cancelled, default draft"
+        enum variant "football_11|football_7|football_5|futsal"
+        enum format "single_elimination|league|group_stage_knockout, default single_elimination"
+        enum phase "not_started|league|group_stage|knockout|completed, default not_started"
+        smallint group_count "nullable"
+        smallint group_size "nullable"
+        int max_teams "default 8"
+        int min_teams "default 4"
+        timestamp registration_deadline "nullable"
+        timestamp starts_at "nullable"
+        timestamp ends_at "nullable"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    tournament_teams {
+        bigint id PK
+        bigint tournament_id FK "cascade"
+        bigint team_id FK "cascade"
+        enum status "pending|approved|rejected|withdrawn, default pending"
+        int seed "nullable"
+        bigint tournament_group_id FK "nullable, SET NULL"
+        bigint registered_by FK "cascade"
+        timestamp registered_at
+        timestamp approved_at "nullable"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    tournament_rounds {
+        bigint id PK
+        bigint tournament_id FK "cascade"
+        int round_number "UK with tournament_id"
+        string name
+        timestamp starts_at "nullable"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    tournament_groups {
+        bigint id PK
+        bigint tournament_id FK "cascade"
+        string name "UK with tournament_id"
+        smallint position "UK with tournament_id"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    profile_comments {
+        bigint id PK
+        bigint user_id FK "author, nullable, SET NULL"
+        bigint profile_user_id FK "profile owner, nullable, SET NULL"
+        text comment
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    user_commendations {
+        bigint id PK
+        bigint from_user_id FK "nullable, SET NULL"
+        bigint to_user_id FK "nullable, SET NULL"
+        enum category "friendly|skilled|teamwork|leadership"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    notifications {
+        uuid id PK
+        string type
+        string notifiable_type "polymorphic"
+        bigint notifiable_id "polymorphic"
+        text data
+        timestamp read_at "nullable"
+        timestamp created_at
+        timestamp updated_at
+    }
+
+    users ||--o{ team_members : "user_id"
+    teams ||--o{ team_members : "team_id"
+
+    users ||--o{ join_requests : "user_id"
+    teams ||--o{ join_requests : "team_id"
+    users ||--o{ join_requests : "reviewed_by"
+
+    teams ||--o{ team_invitations : "team_id"
+    users ||--o{ team_invitations : "invited_by"
+    users ||--o{ team_invitations : "accepted_by"
+
+    teams ||--o{ matches : "home_team_id"
+    teams ||--o{ matches : "away_team_id"
+    users ||--o{ matches : "created_by"
+    tournaments ||--o{ matches : "tournament_id"
+    tournament_rounds ||--o{ matches : "tournament_round_id"
+    tournament_groups ||--o{ matches : "tournament_group_id"
+
+    matches ||--o{ match_requests : "match_id"
+    teams ||--o{ match_requests : "requesting_team_id"
+    users ||--o{ match_requests : "reviewed_by"
+
+    matches ||--o{ match_lineups : "match_id"
+    teams ||--o{ match_lineups : "team_id"
+    users ||--o{ match_lineups : "user_id"
+
+    matches ||--o{ match_events : "match_id"
+    teams ||--o{ match_events : "team_id"
+    users ||--o{ match_events : "user_id"
+
+    matches ||--o{ match_availability : "match_id"
+    users ||--o{ match_availability : "user_id"
+    teams ||--o{ match_availability : "team_id"
+
+    users ||--o{ tournaments : "organizer_id"
+
+    tournaments ||--o{ tournament_teams : "tournament_id"
+    teams ||--o{ tournament_teams : "team_id"
+    users ||--o{ tournament_teams : "registered_by"
+    tournament_groups ||--o{ tournament_teams : "tournament_group_id"
+
+    tournaments ||--o{ tournament_rounds : "tournament_id"
+    tournaments ||--o{ tournament_groups : "tournament_id"
+
+    users ||--o{ profile_comments : "user_id (author)"
+    users ||--o{ profile_comments : "profile_user_id"
+
+    users ||--o{ user_commendations : "from_user_id"
+    users ||--o{ user_commendations : "to_user_id"
+
+    users ||--o{ notifications : "notifiable (polymorphic)"
+```
+
+## Notes
+
+### Pivot / junction tables
+
+- **`team_members`** — resolves the many-to-many between `users` and `teams`, carrying
+  `role`, `position`, `joined_at`, and `status`. Unique constraint on `(user_id, team_id)`.
+- **`match_availability`** — links `users`, `matches`, and `teams` to track per-player
+  availability. Unique constraint on `(match_id, user_id, team_id)`.
+- **`tournament_teams`** — resolves the many-to-many between `tournaments` and `teams`,
+  carrying registration `status`, `seed`, and optional group assignment. Unique constraint
+  on `(tournament_id, team_id)`.
+- **`match_lineups`** — per-match roster rows. Unique constraint on `(match_id, team_id, user_id)`.
+
+### Polymorphic relationship
+
+- **`notifications`** uses Laravel's `morphs('notifiable')` (`notifiable_type` +
+  `notifiable_id`). In practice the notifiable is a `User`, shown here as a
+  `users ||--o{ notifications` edge, but the schema is generic.
+
+### Referential integrity
+
+- Most foreign keys use **`ON DELETE CASCADE`** so dependent rows are removed with their parent.
+- Some keys use **`ON DELETE SET NULL`** to preserve history when the referenced user/round/group
+  is deleted: `teams.created_by`, `*.reviewed_by`, `team_invitations.accepted_by`,
+  `matches.tournament_round_id`, `matches.tournament_group_id`,
+  `tournament_teams.tournament_group_id`, and both FKs on `profile_comments` and
+  `user_commendations`.
+- `matches.away_team_id` and the tournament FKs are **nullable** to support open ("available")
+  friendly matches and non-tournament play.
+
+### Enums
+
+Enum-typed columns (variant, status, role, position, event_type, category, format, phase,
+visibility, match_type) are shown inline in each entity with their allowed values. These are
+enforced at the database level via MySQL `ENUM` columns.
+
+### Source of truth
+
+Regenerate or verify this diagram against `database/migrations/` (table definitions, including
+`add_*` and `fix_*` alter migrations) and `app/Models/` (Eloquent relationship methods).
+GitHub renders the `mermaid` fenced block above natively; it can also be validated at
+<https://mermaid.live>.

--- a/resources/views/vendor/mail/html/header.blade.php
+++ b/resources/views/vendor/mail/html/header.blade.php
@@ -1,0 +1,9 @@
+@props(['url'])
+<tr>
+<td class="header" bgcolor="#101312" style="background-color: #101312;">
+<a href="{{ $url }}" style="display: inline-block; text-decoration: none;">
+<img src="{{ rtrim(config('app.url'), '/') }}/icon-192.png" width="50" height="50" alt="Veltro" style="display: inline-block; vertical-align: middle; height: 50px; width: 50px; border: 0; line-height: 50px;">
+<span style="display: inline-block; vertical-align: middle; margin-left: 12px; color: #f4f7f5; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 26px; font-weight: 800; letter-spacing: 5px; text-transform: uppercase;">Veltro</span>
+</a>
+</td>
+</tr>

--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -1,0 +1,27 @@
+<x-mail::layout>
+{{-- Header --}}
+<x-slot:header>
+<x-mail::header :url="config('app.url')">
+{{ config('app.name') }}
+</x-mail::header>
+</x-slot:header>
+
+{{-- Body --}}
+{!! $slot !!}
+
+{{-- Subcopy --}}
+@isset($subcopy)
+<x-slot:subcopy>
+<x-mail::subcopy>
+{!! $subcopy !!}
+</x-mail::subcopy>
+</x-slot:subcopy>
+@endisset
+
+{{-- Footer --}}
+<x-slot:footer>
+<x-mail::footer>
+© {{ date('Y') }} Veltro · Fútbol amateur en Uruguay
+</x-mail::footer>
+</x-slot:footer>
+</x-mail::layout>

--- a/resources/views/vendor/mail/html/themes/default.css
+++ b/resources/views/vendor/mail/html/themes/default.css
@@ -1,0 +1,300 @@
+/* Base */
+
+body,
+body *:not(html):not(style):not(br):not(tr):not(code) {
+    box-sizing: border-box;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
+        'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    position: relative;
+}
+
+body {
+    -webkit-text-size-adjust: none;
+    background-color: #ffffff;
+    color: #52525b;
+    height: 100%;
+    line-height: 1.4;
+    margin: 0;
+    padding: 0;
+    width: 100% !important;
+}
+
+p,
+ul,
+ol,
+blockquote {
+    line-height: 1.4;
+    text-align: start;
+}
+
+a {
+    color: #15803d;
+}
+
+a img {
+    border: none;
+}
+
+/* Typography */
+
+h1 {
+    color: #101312;
+    font-size: 18px;
+    font-weight: bold;
+    margin-top: 0;
+    text-align: start;
+}
+
+h2 {
+    font-size: 16px;
+    font-weight: bold;
+    margin-top: 0;
+    text-align: start;
+}
+
+h3 {
+    font-size: 14px;
+    font-weight: bold;
+    margin-top: 0;
+    text-align: left;
+}
+
+p {
+    font-size: 16px;
+    line-height: 1.5em;
+    margin-top: 0;
+    text-align: left;
+}
+
+p.sub {
+    font-size: 12px;
+}
+
+img {
+    max-width: 100%;
+}
+
+/* Layout */
+
+.wrapper {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    background-color: #fafafa;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+
+.content {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+
+/* Header */
+
+.header {
+    background-color: #101312;
+    padding: 24px 0;
+    text-align: center;
+}
+
+.header a {
+    color: #f4f7f5;
+    font-size: 19px;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+/* Logo */
+
+.logo {
+    height: 75px;
+    margin-top: 15px;
+    margin-bottom: 10px;
+    max-height: 75px;
+    width: 75px;
+}
+
+/* Body */
+
+.body {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    background-color: #fafafa;
+    border-bottom: 1px solid #fafafa;
+    border-top: 1px solid #fafafa;
+    margin: 0;
+    padding: 0;
+    width: 100%;
+}
+
+.inner-body {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 570px;
+    background-color: #ffffff;
+    border-color: #e4e4e7;
+    border-radius: 8px;
+    border-width: 1px;
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+    margin: 0 auto;
+    padding: 0;
+    width: 570px;
+}
+
+.inner-body a {
+    word-break: break-all;
+}
+
+/* Subcopy */
+
+.subcopy {
+    border-top: 1px solid #e4e4e7;
+    margin-top: 25px;
+    padding-top: 25px;
+}
+
+.subcopy p {
+    font-size: 14px;
+}
+
+/* Footer */
+
+.footer {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 570px;
+    margin: 0 auto;
+    padding: 0;
+    text-align: center;
+    width: 570px;
+}
+
+.footer p {
+    color: #a1a1aa;
+    font-size: 12px;
+    text-align: center;
+}
+
+.footer a {
+    color: #15803d;
+    text-decoration: underline;
+}
+
+/* Tables */
+
+.table table {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    margin: 30px auto;
+    width: 100%;
+}
+
+.table th {
+    border-bottom: 1px solid #e4e4e7;
+    margin: 0;
+    padding-bottom: 8px;
+}
+
+.table td {
+    color: #52525b;
+    font-size: 15px;
+    line-height: 18px;
+    margin: 0;
+    padding: 10px 0;
+}
+
+.content-cell {
+    max-width: 100vw;
+    padding: 32px;
+}
+
+/* Buttons */
+
+.action {
+    -premailer-cellpadding: 0;
+    -premailer-cellspacing: 0;
+    -premailer-width: 100%;
+    margin: 30px auto;
+    padding: 0;
+    text-align: center;
+    width: 100%;
+    float: unset;
+}
+
+.button {
+    -webkit-text-size-adjust: none;
+    border-radius: 8px;
+    color: #fff;
+    display: inline-block;
+    font-weight: bold;
+    overflow: hidden;
+    text-decoration: none;
+}
+
+.button-blue,
+.button-primary {
+    background-color: #48d17a;
+    border-bottom: 8px solid #48d17a;
+    border-left: 18px solid #48d17a;
+    border-right: 18px solid #48d17a;
+    border-top: 8px solid #48d17a;
+    color: #06140c;
+}
+
+.button-green,
+.button-success {
+    background-color: #16a34a;
+    border-bottom: 8px solid #16a34a;
+    border-left: 18px solid #16a34a;
+    border-right: 18px solid #16a34a;
+    border-top: 8px solid #16a34a;
+}
+
+.button-red,
+.button-error {
+    background-color: #dc2626;
+    border-bottom: 8px solid #dc2626;
+    border-left: 18px solid #dc2626;
+    border-right: 18px solid #dc2626;
+    border-top: 8px solid #dc2626;
+}
+
+/* Panels */
+
+.panel {
+    border-left: #48d17a solid 4px;
+    margin: 21px 0;
+}
+
+.panel-content {
+    background-color: #fafafa;
+    color: #52525b;
+    padding: 16px;
+}
+
+.panel-content p {
+    color: #52525b;
+}
+
+.panel-item {
+    padding: 0;
+}
+
+.panel-item p:last-of-type {
+    margin-bottom: 0;
+    padding-bottom: 0;
+}
+
+/* Utilities */
+
+.break-all {
+    word-break: break-all;
+}


### PR DESCRIPTION
## Summary
- Brand Laravel's markdown transactional emails with Veltro identity (dark header band, green hexagon logo + VELTRO wordmark, brand-green CTA buttons, Spanish footer). Branding is global — no per-notification changes needed.
- Add domain database schema documentation: a Mermaid ER diagram (`docs/database-schema.md`) and DBML source for dbdiagram.io (`docs/database-schema.dbml`), generated from migrations and Eloquent models. Laravel infrastructure tables intentionally omitted.

## Notes
- Only the 3 customized mail component files are kept; the rest fall back to framework defaults.
- Logo loads from `config('app.url')/icon-192.png` (absolute URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)