### PR TITLE
refactor: move availability-update logic into MatchService

### DIFF
--- a/app/Http/Controllers/MatchAvailabilityController.php
+++ b/app/Http/Controllers/MatchAvailabilityController.php
@@ -5,66 +5,42 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Models\FootballMatch;
-use App\Models\MatchAvailability;
-use App\Models\Team;
+use App\Services\MatchService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class MatchAvailabilityController extends Controller
 {
+    public function __construct(
+        private readonly MatchService $matchService
+    ) {}
+
     /**
      * Update the availability status for a match.
      */
     public function update(Request $request, int $matchId): RedirectResponse
     {
-        $request->validate([
+        $validated = $request->validate([
             'status' => 'required|in:available,maybe,unavailable',
         ]);
 
         $match = FootballMatch::findOrFail($matchId);
-        $user = Auth::user();
+        $user = $request->user();
 
-        // Determine which team the user belongs to that's playing in this match
-        // This prevents IDOR - users cannot manipulate team_id parameter
-        $teamId = null;
+        // Derive the team from membership (IDOR guard - the client cannot
+        // supply an arbitrary team_id).
+        $team = $this->matchService->resolveUserTeam($match, $user->id);
 
-        if ($match->home_team_id) {
-            $homeTeam = Team::find($match->home_team_id);
-            if ($homeTeam && $homeTeam->hasMember($user->id)) {
-                $teamId = $match->home_team_id;
-            }
-        }
-
-        if (! $teamId && $match->away_team_id) {
-            $awayTeam = Team::find($match->away_team_id);
-            if ($awayTeam && $awayTeam->hasMember($user->id)) {
-                $teamId = $match->away_team_id;
-            }
-        }
-
-        if (! $teamId) {
+        if (! $team) {
             abort(403, 'No sos miembro de ninguno de los equipos que juegan este partido.');
         }
 
-        // Update or create availability
-        $availability = MatchAvailability::updateOrCreate(
-            [
-                'match_id' => $matchId,
-                'user_id' => $user->id,
-                'team_id' => $teamId,
-            ],
-            [
-                'status' => $request->input('status'),
-                'confirmed_at' => now(),
-            ]
-        );
+        $this->matchService->recordPlayerAvailability($match, $user->id, $team->id, $validated['status']);
 
-        // Check if team needs alert for minimum players
-        $team = Team::find($teamId);
-        if ($team && $match->needsPlayerAlert($teamId) && $team->isLeader($user->id)) {
+        // Warn leaders when the team is short of the minimum players.
+        if ($match->needsPlayerAlert($team->id) && $team->isLeader($user->id)) {
             $minimumPlayers = $match->getMinimumPlayers();
-            $availableCount = $match->getAvailablePlayersCount($teamId);
+            $availableCount = $match->getAvailablePlayersCount($team->id);
 
             session()->flash('warning', "Atención: solo {$availableCount}/{$minimumPlayers} jugadores confirmaron disponibilidad.");
         }

--- a/app/Services/MatchService.php
+++ b/app/Services/MatchService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Models\FootballMatch;
+use App\Models\MatchAvailability;
 use App\Models\MatchEvent;
 use App\Models\MatchLineup;
 use App\Models\MatchRequest;
@@ -48,6 +49,48 @@ final class MatchService
                 'created_by' => $user->id,
             ]);
         });
+    }
+
+    /**
+     * Resolve which team in the match the given user belongs to.
+     *
+     * Returns null if the user is not a member of either team. This is the
+     * IDOR guard for availability updates: the team is derived from membership
+     * rather than trusting a client-supplied team_id.
+     */
+    public function resolveUserTeam(FootballMatch $match, int $userId): ?Team
+    {
+        foreach ([$match->home_team_id, $match->away_team_id] as $teamId) {
+            if (! $teamId) {
+                continue;
+            }
+
+            $team = Team::find($teamId);
+
+            if ($team && $team->hasMember($userId)) {
+                return $team;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Create or update a player's availability status for a match.
+     */
+    public function recordPlayerAvailability(FootballMatch $match, int $userId, int $teamId, string $status): MatchAvailability
+    {
+        return MatchAvailability::updateOrCreate(
+            [
+                'match_id' => $match->id,
+                'user_id' => $userId,
+                'team_id' => $teamId,
+            ],
+            [
+                'status' => $status,
+                'confirmed_at' => now(),
+            ],
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
`MatchAvailabilityController` carried its business logic inline, diverging from the project's service-layer convention (thin controllers delegating to a service). This moves that logic into `MatchService` and fixes two defects found along the way.

## Changes
**`MatchService` — new methods:**
- `resolveUserTeam(FootballMatch, int): ?Team` — IDOR-safe team resolution (derived from membership, not a client-supplied `team_id`), returning the `Team` model.
- `recordPlayerAvailability(...)` — the `updateOrCreate` persistence.

**`MatchAvailabilityController` — now thin:**
- Injects `MatchService` via constructor (matching `MatchController` et al.).
- Removes the **dead `$availability` variable** (assigned, never used).
- Removes the **redundant 3rd `Team::find()`** — the team resolved for the IDOR guard is reused for the leader/alert check (one fewer query per request).
- Uses `$request->user()` and the validated array.

## Conventions
Validation stays inline and `abort`/flash stay in the controller — that matches the *actual* local convention (all match controllers use inline `validate()`; services throw/return rather than `abort`).

## Verification
- `./vendor/bin/pint` ✓
- `MatchAvailabilityTest` + `MatchAvailabilityModelTest`: **30 passed (52 assertions)** ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)