### PR TITLE
ci: make the linter workflow actually enforce quality gates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   quality:
@@ -31,20 +31,27 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+          composer install -q --no-ansi --no-interaction --no-progress --prefer-dist
           bun install --frozen-lockfile
 
       - name: Run Pint
-        run: vendor/bin/pint
+        run: vendor/bin/pint --test
 
-      - name: Format Frontend
-        run: bun run format
+      - name: Check Frontend Formatting
+        run: bun run format:check
 
       - name: Lint Frontend
-        run: bun run lint
+        run: bun run lint:check
 
-      # - name: Commit Changes
-      #   uses: stefanzweifel/git-auto-commit-action@v5
-      #   with:
-      #     commit_message: fix code style
-      #     commit_options: '--no-verify'
+      # Wayfinder route helpers are generated (gitignored), so they must be
+      # produced before type-checking can resolve the @/routes imports.
+      - name: Prepare Environment
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+
+      - name: Generate Wayfinder Routes
+        run: php artisan wayfinder:generate
+
+      - name: Type Check
+        run: bun run types

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,8 +50,10 @@ jobs:
           cp .env.example .env
           php artisan key:generate
 
+      # --with-form matches vite.config.ts (formVariants: true), which the
+      # app relies on for the .form route helpers.
       - name: Generate Wayfinder Routes
-        run: php artisan wayfinder:generate
+        run: php artisan wayfinder:generate --with-form
 
       - name: Type Check
         run: bun run types

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "format": "prettier --write resources/",
         "format:check": "prettier --check resources/",
         "lint": "eslint . --fix",
+        "lint:check": "eslint . --max-warnings=0",
         "types": "tsc --noEmit"
     },
     "devDependencies": {

--- a/resources/views/vendor/mail/html/themes/default.css
+++ b/resources/views/vendor/mail/html/themes/default.css
@@ -3,8 +3,9 @@
 body,
 body *:not(html):not(style):not(br):not(tr):not(code) {
     box-sizing: border-box;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
-        'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+        sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
     position: relative;
 }
 
@@ -142,7 +143,9 @@ img {
     border-color: #e4e4e7;
     border-radius: 8px;
     border-width: 1px;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+    box-shadow:
+        0 1px 3px 0 rgba(0, 0, 0, 0.1),
+        0 1px 2px -1px rgba(0, 0, 0, 0.1);
     margin: 0 auto;
     padding: 0;
     width: 570px;


### PR DESCRIPTION
## Problem
The `linter` workflow ran the **auto-fix** variant of every check, so each one rewrote files in the runner and exited `0` — they never failed the build. Type checking wasn't run at all, and the step that would have committed the auto-fixes was commented out. Net effect: a type error, lint violation, or formatting drift could be merged freely.

## Changes
| Check | Before (no-op) | After (gate) |
|---|---|---|
| Pint | `vendor/bin/pint` | `vendor/bin/pint --test` |
| Prettier | `bun run format` (`--write`) | `bun run format:check` |
| ESLint | `bun run lint` (`--fix`) | `bun run lint:check` *(new: `eslint . --max-warnings=0`)* |
| Types | *(not run)* | `bun run types` (`tsc --noEmit`) |

Supporting changes:
- The Wayfinder route helpers are generated and gitignored, so the workflow now runs `key:generate` + `wayfinder:generate` before the Type Check so `@/routes` imports resolve.
- Dropped `--no-scripts` from `composer install` so package discovery registers the `wayfinder` command (mirrors `tests.yml`).
- Workflow permission downgraded `contents: write` → `read`; removed the dead commented-out auto-commit step.
- Formatted the one file that failed the new format gate (`vendor/mail/html/themes/default.css`).

## Verification
All four gates pass locally on the current tree:
- `vendor/bin/pint --test` ✓ (197 files)
- `bun run format:check` ✓
- `bun run lint:check` ✓
- `bun run types` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)