### PR TITLE
Release: team logo upload fix

### DIFF
--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -127,9 +127,21 @@ final class TeamController extends Controller
             'name' => ['required', 'string', 'max:255', new CleanText],
             'variant' => ['required', 'in:football_11,football_7,football_5,futsal'],
             'description' => ['nullable', 'string', 'max:1000'],
+            'logo' => ['nullable', 'image', 'mimes:jpg,jpeg,png,webp', 'max:2048'],
+            'remove_logo' => ['nullable', 'boolean'],
         ]);
 
-        $team = $this->teamService->updateTeam($team, $validated);
+        $team = $this->teamService->updateTeam($team, [
+            'name' => $validated['name'],
+            'variant' => $validated['variant'],
+            'description' => $validated['description'] ?? null,
+        ]);
+
+        if ($request->hasFile('logo')) {
+            $this->teamService->updateTeamLogo($team, $request->file('logo'));
+        } elseif ($request->boolean('remove_logo')) {
+            $this->teamService->removeTeamLogo($team);
+        }
 
         return redirect()->route('teams.show', $team->id)
             ->with('success', '¡Equipo actualizado exitosamente!');

--- a/app/Http/Controllers/TeamLogoController.php
+++ b/app/Http/Controllers/TeamLogoController.php
@@ -3,13 +3,16 @@
 namespace App\Http\Controllers;
 
 use App\Models\Team;
+use App\Services\TeamService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\Laravel\Facades\Image;
 
 class TeamLogoController extends Controller
 {
+    public function __construct(
+        private readonly TeamService $teamService
+    ) {}
+
     /**
      * Upload a new logo for the specified team.
      */
@@ -26,34 +29,7 @@ class TeamLogoController extends Controller
             'logo' => ['required', 'image', 'mimes:jpg,jpeg,png,webp', 'max:2048'], // 2MB max
         ]);
 
-        $disk = config('filesystems.default');
-
-        // Delete old logo if exists
-        if ($team->logo_path) {
-            Storage::disk($disk)->delete($team->logo_path);
-        }
-
-        // Get the uploaded file
-        $file = $request->file('logo');
-
-        // Generate unique filename
-        $filename = uniqid().'.'.$file->getClientOriginalExtension();
-        $path = "logos/{$team->id}/{$filename}";
-
-        // Resize and save the image
-        $image = Image::read($file);
-        $image->cover(400, 400); // Resize to 400x400
-
-        // Save to storage
-        Storage::disk($disk)->put(
-            $path,
-            (string) $image->encode()
-        );
-
-        // Update team record
-        $team->update([
-            'logo_path' => $path,
-        ]);
+        $this->teamService->updateTeamLogo($team, $request->file('logo'));
 
         return back()->with('success', 'Logo del equipo actualizado exitosamente.');
     }
@@ -70,17 +46,7 @@ class TeamLogoController extends Controller
             abort(403, 'No tienes permiso para eliminar el logo de este equipo.');
         }
 
-        $disk = config('filesystems.default');
-
-        if ($team->logo_path) {
-            // Delete the file from storage
-            Storage::disk($disk)->delete($team->logo_path);
-
-            // Clear the logo path
-            $team->update([
-                'logo_path' => null,
-            ]);
-        }
+        $this->teamService->removeTeamLogo($team);
 
         return back()->with('success', 'Logo del equipo eliminado exitosamente.');
     }

--- a/app/Services/TeamService.php
+++ b/app/Services/TeamService.php
@@ -16,8 +16,11 @@ use App\Notifications\JoinRequestCreatedNotification;
 use App\Notifications\JoinRequestRejectedNotification;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Laravel\Facades\Image;
 
 final class TeamService
 {
@@ -63,6 +66,52 @@ final class TeamService
         $team->update($data);
 
         return $team->load(['teamMembers.user', 'creator']);
+    }
+
+    /**
+     * Store (or replace) a team's logo: resize to 400x400 and persist.
+     */
+    public function updateTeamLogo(Team $team, UploadedFile $file): Team
+    {
+        $disk = config('filesystems.default');
+
+        // Delete old logo if exists
+        if ($team->logo_path) {
+            Storage::disk($disk)->delete($team->logo_path);
+        }
+
+        // Generate unique filename
+        $filename = uniqid().'.'.$file->getClientOriginalExtension();
+        $path = "logos/{$team->id}/{$filename}";
+
+        // Resize and save the image
+        $image = Image::read($file);
+        $image->cover(400, 400);
+
+        Storage::disk($disk)->put(
+            $path,
+            (string) $image->encode()
+        );
+
+        $team->update(['logo_path' => $path]);
+
+        return $team;
+    }
+
+    /**
+     * Remove a team's custom logo and delete the stored file.
+     */
+    public function removeTeamLogo(Team $team): Team
+    {
+        $disk = config('filesystems.default');
+
+        if ($team->logo_path) {
+            Storage::disk($disk)->delete($team->logo_path);
+
+            $team->update(['logo_path' => null]);
+        }
+
+        return $team;
     }
 
     /**

--- a/tests/Feature/TeamTest.php
+++ b/tests/Feature/TeamTest.php
@@ -6,6 +6,8 @@ use App\Models\Team;
 use App\Models\TeamMember;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 
 uses(RefreshDatabase::class);
 
@@ -186,6 +188,56 @@ test('non-member cannot update team', function () {
             'variant' => 'football_11',
         ])
         ->assertForbidden();
+});
+
+test('captain can update team with a logo', function () {
+    $disk = config('filesystems.default');
+    Storage::fake($disk);
+
+    $this->actingAs($this->captain)
+        ->put(route('teams.update', $this->team->id), [
+            'name' => 'Logo FC',
+            'variant' => 'football_11',
+            'logo' => UploadedFile::fake()->image('logo.png', 600, 600),
+        ])
+        ->assertRedirect(route('teams.show', $this->team->id));
+
+    $this->team->refresh();
+    expect($this->team->logo_path)->not->toBeNull();
+    Storage::disk($disk)->assertExists($this->team->logo_path);
+});
+
+test('captain can remove team logo via update', function () {
+    $disk = config('filesystems.default');
+    Storage::fake($disk);
+
+    // Seed an existing logo
+    Storage::disk($disk)->put("logos/{$this->team->id}/old.png", 'fake');
+    $this->team->update(['logo_path' => "logos/{$this->team->id}/old.png"]);
+
+    $this->actingAs($this->captain)
+        ->put(route('teams.update', $this->team->id), [
+            'name' => 'No Logo FC',
+            'variant' => 'football_11',
+            'remove_logo' => '1',
+        ])
+        ->assertRedirect();
+
+    $this->team->refresh();
+    expect($this->team->logo_path)->toBeNull();
+    Storage::disk($disk)->assertMissing("logos/{$this->team->id}/old.png");
+});
+
+test('team update rejects a non-image logo', function () {
+    Storage::fake(config('filesystems.default'));
+
+    $this->actingAs($this->captain)
+        ->put(route('teams.update', $this->team->id), [
+            'name' => 'Bad Logo FC',
+            'variant' => 'football_11',
+            'logo' => UploadedFile::fake()->create('document.pdf', 100, 'application/pdf'),
+        ])
+        ->assertSessionHasErrors('logo');
 });
 
 test('captain can delete team', function () {


### PR DESCRIPTION
Promotes `dev` to `main`.

## Included changes

- **fix: team logo upload does nothing** (#137)
  The edit-team modal posted the logo file to `teams.update`, which ignored it, so uploads silently did nothing. Logo handling (`logo`/`remove_logo` validation + store/resize/delete) is now wired into the update flow, with the file logic extracted into reusable `TeamService` methods shared with `TeamLogoController`. Feature tests added; full `TeamTest.php` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)