### PR TITLE
feat: web push notifications for all notification types

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,13 @@ VITE_REVERB_HOST="${REVERB_HOST}"
 VITE_REVERB_PORT="${REVERB_PORT}"
 VITE_REVERB_SCHEME="${REVERB_SCHEME}"
 
+# Web Push (VAPID). Generate with `php artisan webpush:vapid` (writes the keys
+# to .env). VAPID_SUBJECT must be an https URL or mailto: address identifying
+# the sender. In production set all three on Laravel Cloud.
+VAPID_SUBJECT="${APP_URL}"
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+
 CACHE_STORE=database
 # CACHE_PREFIX=
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install Node Dependencies
         run: bun install --frozen-lockfile

--- a/app/Http/Controllers/PushSubscriptionController.php
+++ b/app/Http/Controllers/PushSubscriptionController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PushSubscriptionController extends Controller
+{
+    /**
+     * Store (or refresh) the authenticated user's browser push subscription.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'endpoint' => ['required', 'string'],
+            'keys.p256dh' => ['required', 'string'],
+            'keys.auth' => ['required', 'string'],
+        ]);
+
+        $request->user()->updatePushSubscription(
+            $data['endpoint'],
+            $data['keys']['p256dh'],
+            $data['keys']['auth'],
+        );
+
+        return response()->json(['success' => true]);
+    }
+
+    /**
+     * Remove a browser push subscription (unsubscribe).
+     */
+    public function destroy(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'endpoint' => ['required', 'string'],
+        ]);
+
+        $request->user()->deletePushSubscription($data['endpoint']);
+
+        return response()->json(['success' => true]);
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -46,6 +46,7 @@ class HandleInertiaRequests extends Middleware
                 'user' => $request->user(),
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
+            'vapidPublicKey' => config('webpush.vapid.public_key'),
             'flash' => [
                 'success' => fn () => $request->session()->get('success'),
                 'error' => fn () => $request->session()->get('error'),

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,11 +8,12 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Facades\DB;
 use Laravel\Fortify\TwoFactorAuthenticatable;
+use NotificationChannels\WebPush\HasPushSubscriptions;
 
 class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable, TwoFactorAuthenticatable;
+    use HasFactory, HasPushSubscriptions, Notifiable, TwoFactorAuthenticatable;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Notifications/AvailabilityReminderNotification.php
+++ b/app/Notifications/AvailabilityReminderNotification.php
@@ -6,14 +6,16 @@ namespace App\Notifications;
 
 use App\Models\FootballMatch;
 use App\Models\Team;
+use App\Notifications\Concerns\BuildsWebPush;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPush\WebPushChannel;
 
 class AvailabilityReminderNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use BuildsWebPush, Queueable;
 
     /**
      * Create a new notification instance.
@@ -30,7 +32,7 @@ class AvailabilityReminderNotification extends Notification implements ShouldQue
      */
     public function via(object $notifiable): array
     {
-        return ['mail', 'database', 'broadcast'];
+        return ['mail', 'database', 'broadcast', WebPushChannel::class];
     }
 
     /**

--- a/app/Notifications/CaptaincyTransferredNotification.php
+++ b/app/Notifications/CaptaincyTransferredNotification.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace App\Notifications;
 
 use App\Models\Team;
+use App\Notifications\Concerns\BuildsWebPush;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPush\WebPushChannel;
 
 class CaptaincyTransferredNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use BuildsWebPush, Queueable;
 
     public function __construct(
         public Team $team
@@ -19,7 +21,7 @@ class CaptaincyTransferredNotification extends Notification implements ShouldQue
 
     public function via(object $notifiable): array
     {
-        return ['database', 'broadcast'];
+        return ['database', 'broadcast', WebPushChannel::class];
     }
 
     public function toDatabase(object $notifiable): array

--- a/app/Notifications/CommendationReceivedNotification.php
+++ b/app/Notifications/CommendationReceivedNotification.php
@@ -5,14 +5,16 @@ declare(strict_types=1);
 namespace App\Notifications;
 
 use App\Models\User;
+use App\Notifications\Concerns\BuildsWebPush;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPush\WebPushChannel;
 
 class CommendationReceivedNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use BuildsWebPush, Queueable;
 
     /**
      * Create a new notification instance.
@@ -29,7 +31,7 @@ class CommendationReceivedNotification extends Notification implements ShouldQue
      */
     public function via(object $notifiable): array
     {
-        return ['mail', 'database', 'broadcast'];
+        return ['mail', 'database', 'broadcast', WebPushChannel::class];
     }
 
     /**

--- a/app/Notifications/Concerns/BuildsWebPush.php
+++ b/app/Notifications/Concerns/BuildsWebPush.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications\Concerns;
+
+use NotificationChannels\WebPush\WebPushMessage;
+
+/**
+ * Builds a Web Push payload from a notification's existing `toDatabase()` array.
+ *
+ * Every notification in this app returns a consistent shape from `toDatabase()`
+ * (`title`, `message`, `action_url`, `icon`, `type`), so the push message can be
+ * derived from it without duplicating copy. Notifications using this trait must
+ * add `WebPushChannel::class` to their `via()` array.
+ */
+trait BuildsWebPush
+{
+    public function toWebPush(object $notifiable, mixed $notification): WebPushMessage
+    {
+        $data = $this->toDatabase($notifiable);
+
+        return (new WebPushMessage)
+            ->title($data['title'])
+            ->body($data['message'])
+            ->icon('/icon-192.png')
+            ->badge('/icon-192.png')
+            ->tag($data['type'])
+            ->data([
+                'url' => $data['action_url'] ?? null,
+                'type' => $data['type'],
+            ])
+            ->options(['TTL' => 3600]);
+    }
+}

--- a/app/Notifications/JoinRequestAcceptedNotification.php
+++ b/app/Notifications/JoinRequestAcceptedNotification.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace App\Notifications;
 
 use App\Models\JoinRequest;
+use App\Notifications\Concerns\BuildsWebPush;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPush\WebPushChannel;
 
 class JoinRequestAcceptedNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use BuildsWebPush, Queueable;
 
     public function __construct(
         public JoinRequest $joinRequest
@@ -19,7 +21,7 @@ class JoinRequestAcceptedNotification extends Notification implements ShouldQueu
 
     public function via(object $notifiable): array
     {
-        return ['database', 'broadcast'];
+        return ['database', 'broadcast', WebPushChannel::class];
     }
 
     public function toDatabase(object $notifiable): array

--- a/app/Notifications/JoinRequestCreatedNotification.php
+++ b/app/Notifications/JoinRequestCreatedNotification.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace App\Notifications;
 
 use App\Models\JoinRequest;
+use App\Notifications\Concerns\BuildsWebPush;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPush\WebPushChannel;
 
 class JoinRequestCreatedNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use BuildsWebPush, Queueable;
 
     public function __construct(
         public JoinRequest $joinRequest
@@ -19,7 +21,7 @@ class JoinRequestCreatedNotification extends Notification implements ShouldQueue
 
     public function via(object $notifiable): array
     {
-        return ['database', 'broadcast'];
+        return ['database', 'broadcast', WebPushChannel::class];
     }
 
     public function toDatabase(object $notifiable): array

--- a/app/Notifications/JoinRequestRejectedNotification.php
+++ b/app/Notifications/JoinRequestRejectedNotification.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace App\Notifications;
 
 use App\Models\JoinRequest;
+use App\Notifications\Concerns\BuildsWebPush;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPush\WebPushChannel;
 
 class JoinRequestRejectedNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use BuildsWebPush, Queueable;
 
     public function __construct(
         public JoinRequest $joinRequest
@@ -19,7 +21,7 @@ class JoinRequestRejectedNotification extends Notification implements ShouldQueu
 
     public function via(object $notifiable): array
     {
-        return ['database', 'broadcast'];
+        return ['database', 'broadcast', WebPushChannel::class];
     }
 
     public function toDatabase(object $notifiable): array

--- a/app/Notifications/MatchCancelledNotification.php
+++ b/app/Notifications/MatchCancelledNotification.php
@@ -6,13 +6,15 @@ namespace App\Notifications;
 
 use App\Models\FootballMatch;
 use App\Models\Team;
+use App\Notifications\Concerns\BuildsWebPush;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPush\WebPushChannel;
 
 class MatchCancelledNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use BuildsWebPush, Queueable;
 
     /**
      * Create a new notification instance.
@@ -29,7 +31,7 @@ class MatchCancelledNotification extends Notification implements ShouldQueue
      */
     public function via(object $notifiable): array
     {
-        return ['database', 'broadcast'];
+        return ['database', 'broadcast', WebPushChannel::class];
     }
 
     /**

--- a/app/Notifications/MatchConfirmedNotification.php
+++ b/app/Notifications/MatchConfirmedNotification.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace App\Notifications;
 
 use App\Models\FootballMatch;
+use App\Notifications\Concerns\BuildsWebPush;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPush\WebPushChannel;
 
 class MatchConfirmedNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use BuildsWebPush, Queueable;
 
     public function __construct(
         public FootballMatch $match
@@ -19,7 +21,7 @@ class MatchConfirmedNotification extends Notification implements ShouldQueue
 
     public function via(object $notifiable): array
     {
-        return ['database', 'broadcast'];
+        return ['database', 'broadcast', WebPushChannel::class];
     }
 
     public function toDatabase(object $notifiable): array

--- a/app/Notifications/MatchRequestAcceptedNotification.php
+++ b/app/Notifications/MatchRequestAcceptedNotification.php
@@ -6,13 +6,15 @@ namespace App\Notifications;
 
 use App\Models\FootballMatch;
 use App\Models\MatchRequest;
+use App\Notifications\Concerns\BuildsWebPush;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPush\WebPushChannel;
 
 class MatchRequestAcceptedNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use BuildsWebPush, Queueable;
 
     /**
      * Create a new notification instance.
@@ -29,7 +31,7 @@ class MatchRequestAcceptedNotification extends Notification implements ShouldQue
      */
     public function via(object $notifiable): array
     {
-        return ['database', 'broadcast'];
+        return ['database', 'broadcast', WebPushChannel::class];
     }
 
     /**

--- a/app/Notifications/MatchRequestReceivedNotification.php
+++ b/app/Notifications/MatchRequestReceivedNotification.php
@@ -7,13 +7,15 @@ namespace App\Notifications;
 use App\Models\FootballMatch;
 use App\Models\MatchRequest;
 use App\Models\Team;
+use App\Notifications\Concerns\BuildsWebPush;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPush\WebPushChannel;
 
 class MatchRequestReceivedNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use BuildsWebPush, Queueable;
 
     /**
      * Create a new notification instance.
@@ -31,7 +33,7 @@ class MatchRequestReceivedNotification extends Notification implements ShouldQue
      */
     public function via(object $notifiable): array
     {
-        return ['database', 'broadcast'];
+        return ['database', 'broadcast', WebPushChannel::class];
     }
 
     /**

--- a/app/Notifications/MatchRequestRejectedNotification.php
+++ b/app/Notifications/MatchRequestRejectedNotification.php
@@ -6,13 +6,15 @@ namespace App\Notifications;
 
 use App\Models\FootballMatch;
 use App\Models\MatchRequest;
+use App\Notifications\Concerns\BuildsWebPush;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPush\WebPushChannel;
 
 class MatchRequestRejectedNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use BuildsWebPush, Queueable;
 
     /**
      * Create a new notification instance.
@@ -29,7 +31,7 @@ class MatchRequestRejectedNotification extends Notification implements ShouldQue
      */
     public function via(object $notifiable): array
     {
-        return ['database', 'broadcast'];
+        return ['database', 'broadcast', WebPushChannel::class];
     }
 
     /**

--- a/app/Notifications/MatchScoreUpdatedNotification.php
+++ b/app/Notifications/MatchScoreUpdatedNotification.php
@@ -6,13 +6,15 @@ namespace App\Notifications;
 
 use App\Models\FootballMatch;
 use App\Models\Team;
+use App\Notifications\Concerns\BuildsWebPush;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPush\WebPushChannel;
 
 class MatchScoreUpdatedNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use BuildsWebPush, Queueable;
 
     /**
      * Create a new notification instance.
@@ -29,7 +31,7 @@ class MatchScoreUpdatedNotification extends Notification implements ShouldQueue
      */
     public function via(object $notifiable): array
     {
-        return ['database', 'broadcast'];
+        return ['database', 'broadcast', WebPushChannel::class];
     }
 
     /**

--- a/app/Notifications/ProfileCommentNotification.php
+++ b/app/Notifications/ProfileCommentNotification.php
@@ -6,15 +6,17 @@ namespace App\Notifications;
 
 use App\Models\ProfileComment;
 use App\Models\User;
+use App\Notifications\Concerns\BuildsWebPush;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Str;
+use NotificationChannels\WebPush\WebPushChannel;
 
 class ProfileCommentNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use BuildsWebPush, Queueable;
 
     /**
      * Create a new notification instance.
@@ -31,7 +33,7 @@ class ProfileCommentNotification extends Notification implements ShouldQueue
      */
     public function via(object $notifiable): array
     {
-        return ['mail', 'database', 'broadcast'];
+        return ['mail', 'database', 'broadcast', WebPushChannel::class];
     }
 
     /**

--- a/app/Notifications/TeamInvitationAcceptedNotification.php
+++ b/app/Notifications/TeamInvitationAcceptedNotification.php
@@ -6,13 +6,15 @@ namespace App\Notifications;
 
 use App\Models\TeamInvitation;
 use App\Models\User;
+use App\Notifications\Concerns\BuildsWebPush;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPush\WebPushChannel;
 
 class TeamInvitationAcceptedNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use BuildsWebPush, Queueable;
 
     public function __construct(
         public TeamInvitation $invitation,
@@ -21,7 +23,7 @@ class TeamInvitationAcceptedNotification extends Notification implements ShouldQ
 
     public function via(object $notifiable): array
     {
-        return ['database', 'broadcast'];
+        return ['database', 'broadcast', WebPushChannel::class];
     }
 
     public function toDatabase(object $notifiable): array

--- a/app/Notifications/TeamInvitationNotification.php
+++ b/app/Notifications/TeamInvitationNotification.php
@@ -6,13 +6,15 @@ namespace App\Notifications;
 
 use App\Models\TeamInvitation;
 use App\Models\User;
+use App\Notifications\Concerns\BuildsWebPush;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPush\WebPushChannel;
 
 class TeamInvitationNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use BuildsWebPush, Queueable;
 
     /**
      * Create a new notification instance.
@@ -29,7 +31,7 @@ class TeamInvitationNotification extends Notification implements ShouldQueue
      */
     public function via(object $notifiable): array
     {
-        return ['database', 'broadcast'];
+        return ['database', 'broadcast', WebPushChannel::class];
     }
 
     /**

--- a/app/Notifications/TournamentRegistrationReviewedNotification.php
+++ b/app/Notifications/TournamentRegistrationReviewedNotification.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace App\Notifications;
 
 use App\Models\TournamentTeam;
+use App\Notifications\Concerns\BuildsWebPush;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\WebPush\WebPushChannel;
 
 class TournamentRegistrationReviewedNotification extends Notification implements ShouldQueue
 {
-    use Queueable;
+    use BuildsWebPush, Queueable;
 
     public function __construct(
         public TournamentTeam $registration,
@@ -20,7 +22,7 @@ class TournamentRegistrationReviewedNotification extends Notification implements
 
     public function via(object $notifiable): array
     {
-        return ['database', 'broadcast'];
+        return ['database', 'broadcast', WebPushChannel::class];
     }
 
     public function toDatabase(object $notifiable): array

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,9 @@ use App\Models\Tournament;
 use App\Policies\TournamentPolicy;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
+use Minishlink\WebPush\WebPush;
+use NotificationChannels\WebPush\WebPushChannel;
+use Psr\Log\LoggerInterface;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -24,5 +27,45 @@ class AppServiceProvider extends ServiceProvider
     {
         // Register policies
         Gate::policy(Tournament::class, TournamentPolicy::class);
+
+        // Give the Web Push channel a WebPush client wired to Laravel's logger.
+        // This overrides the package's default binding so the library's
+        // "GMP/BCMath recommended" advisory is logged instead of raised via
+        // trigger_error() — which Laravel's error handler would otherwise
+        // escalate to a fatal ErrorException on hosts without those extensions.
+        $this->app->when(WebPushChannel::class)
+            ->needs(WebPush::class)
+            ->give(fn ($app): WebPush => (new WebPush(
+                $this->vapidAuth(),
+                [],
+                30,
+                config('webpush.client_options', []),
+                $app->make(LoggerInterface::class),
+            ))
+                ->setReuseVAPIDHeaders(true)
+                ->setAutomaticPadding(config('webpush.automatic_padding')));
+    }
+
+    /**
+     * Build the VAPID auth array for the WebPush client (mirrors the package's
+     * own config resolution).
+     *
+     * @return array<string, mixed>
+     */
+    private function vapidAuth(): array
+    {
+        $vapid = config('webpush.vapid');
+
+        if (empty($vapid['public_key']) || empty($vapid['private_key'])) {
+            return [];
+        }
+
+        return [
+            'VAPID' => [
+                'subject' => $vapid['subject'] ?: url('/'),
+                'publicKey' => $vapid['public_key'],
+                'privateKey' => $vapid['private_key'],
+            ],
+        ];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "php": "^8.2",
         "inertiajs/inertia-laravel": "^2.0",
         "intervention/image-laravel": "^1.5",
+        "laravel-notification-channels/webpush": "^11.0",
         "laravel/fortify": "^1.30",
         "laravel/framework": "^12.0",
         "laravel/reverb": "^1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "45bdb77b1f7c33c8f75b64217327b6ed",
+    "content-hash": "f2fb61971a3a18aa9acc3eb46f594e86",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1852,6 +1852,72 @@
             "time": "2025-04-04T15:09:55+00:00"
         },
         {
+            "name": "laravel-notification-channels/webpush",
+            "version": "11.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel-notification-channels/webpush.git",
+                "reference": "85b577e64459a9df06a24062e2b300abbaa99fa9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel-notification-channels/webpush/zipball/85b577e64459a9df06a24062e2b300abbaa99fa9",
+                "reference": "85b577e64459a9df06a24062e2b300abbaa99fa9",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/notifications": "^12.0|^13.0",
+                "illuminate/support": "^12.0|^13.0",
+                "minishlink/web-push": "^10.0.1",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "larastan/larastan": "^3.1",
+                "laravel/pint": "^1.25",
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^9.2|^10.0|^11.0",
+                "phpunit/phpunit": "^11.5.3|^12.5.12|^13.1.11",
+                "rector/rector": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "NotificationChannels\\WebPush\\WebPushServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "NotificationChannels\\WebPush\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cretu Eusebiu",
+                    "email": "me@cretueusebiu.com",
+                    "homepage": "http://cretueusebiu.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Joost de Bruijn",
+                    "email": "joost@aqualabs.nl",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Web Push Notifications driver for Laravel.",
+            "homepage": "https://github.com/laravel-notification-channels/webpush",
+            "support": {
+                "issues": "https://github.com/laravel-notification-channels/webpush/issues",
+                "source": "https://github.com/laravel-notification-channels/webpush/tree/11.0.0"
+            },
+            "time": "2026-05-24T13:22:27+00:00"
+        },
+        {
             "name": "laravel/fortify",
             "version": "v1.31.3",
             "source": {
@@ -3227,6 +3293,77 @@
                 }
             ],
             "time": "2026-03-08T20:05:35+00:00"
+        },
+        {
+            "name": "minishlink/web-push",
+            "version": "v10.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-push-libs/web-push-php.git",
+                "reference": "c922021b4ed1a61e6604d8dc33a2e0378b4382e3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-push-libs/web-push-php/zipball/c922021b4ed1a61e6604d8dc33a2e0378b4382e3",
+                "reference": "c922021b4ed1a61e6604d8dc33a2e0378b4382e3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-openssl": "*",
+                "guzzlehttp/guzzle": "^7.9.2",
+                "php": ">=8.2",
+                "psr/log": "^2.0|^3.0",
+                "spomky-labs/base64url": "^2.0.4",
+                "symfony/polyfill-php83": "^1.33",
+                "web-token/jwt-library": "^3.4.9|^4.0.6"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^v3.92.2",
+                "phpstan/phpstan": "^2.1.33",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^11.5.46|^12.5.2",
+                "symfony/polyfill-iconv": "^1.33"
+            },
+            "suggest": {
+                "ext-bcmath": "Optional for performance.",
+                "ext-gmp": "Optional for performance."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Minishlink\\WebPush\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Louis Lagrange",
+                    "email": "lagrange.louis@gmail.com",
+                    "homepage": "https://github.com/Minishlink"
+                }
+            ],
+            "description": "Web Push library for PHP",
+            "homepage": "https://github.com/web-push-libs/web-push-php",
+            "keywords": [
+                "Push API",
+                "WebPush",
+                "notifications",
+                "push",
+                "web"
+            ],
+            "support": {
+                "issues": "https://github.com/web-push-libs/web-push-php/issues",
+                "source": "https://github.com/web-push-libs/web-push-php/tree/v10.1.0"
+            },
+            "time": "2026-05-28T09:37:37+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -5671,6 +5808,180 @@
                 "source": "https://github.com/resend/resend-php/tree/v1.3.0"
             },
             "time": "2026-04-11T10:48:32+00:00"
+        },
+        {
+            "name": "spomky-labs/base64url",
+            "version": "v2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/base64url.git",
+                "reference": "7752ce931ec285da4ed1f4c5aa27e45e097be61d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/base64url/zipball/7752ce931ec285da4ed1f4c5aa27e45e097be61d",
+                "reference": "7752ce931ec285da4ed1f4c5aa27e45e097be61d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.11|^0.12",
+                "phpstan/phpstan-beberlei-assert": "^0.11|^0.12",
+                "phpstan/phpstan-deprecation-rules": "^0.11|^0.12",
+                "phpstan/phpstan-phpunit": "^0.11|^0.12",
+                "phpstan/phpstan-strict-rules": "^0.11|^0.12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Base64Url\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky-Labs/base64url/contributors"
+                }
+            ],
+            "description": "Base 64 URL Safe Encoding/Decoding PHP Library",
+            "homepage": "https://github.com/Spomky-Labs/base64url",
+            "keywords": [
+                "base64",
+                "rfc4648",
+                "safe",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/base64url/issues",
+                "source": "https://github.com/Spomky-Labs/base64url/tree/v2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2020-11-03T09:10:25+00:00"
+        },
+        {
+            "name": "spomky-labs/pki-framework",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/pki-framework.git",
+                "reference": "e0d61661962560c1cedfef02b51b431e720aae78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/pki-framework/zipball/e0d61661962560c1cedfef02b51b431e720aae78",
+                "reference": "e0d61661962560c1cedfef02b51b431e720aae78",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17|^0.18",
+                "ext-mbstring": "*",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ekino/phpstan-banned-code": "^1.0|^2.0|^3.0",
+                "ext-gmp": "*",
+                "ext-openssl": "*",
+                "infection/infection": "^0.28|^0.29|^0.31",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpstan/extension-installer": "^1.3|^2.0",
+                "phpstan/phpstan": "^1.8|^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+                "phpstan/phpstan-phpunit": "^1.1|^2.0",
+                "phpstan/phpstan-strict-rules": "^1.3|^2.0",
+                "phpunit/phpunit": "^10.1|^11.0|^12.0",
+                "rector/rector": "^1.0|^2.0",
+                "roave/security-advisories": "dev-latest",
+                "symfony/string": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symplify/easy-coding-standard": "^12.0 || ^13.0"
+            },
+            "suggest": {
+                "ext-bcmath": "For better performance (or GMP)",
+                "ext-gmp": "For better performance (or BCMath)",
+                "ext-openssl": "For OpenSSL based cyphering"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SpomkyLabs\\Pki\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joni Eskelinen",
+                    "email": "jonieske@gmail.com",
+                    "role": "Original developer"
+                },
+                {
+                    "name": "Florent Morselli",
+                    "email": "florent.morselli@spomky-labs.com",
+                    "role": "Spomky-Labs PKI Framework developer"
+                }
+            ],
+            "description": "A PHP framework for managing Public Key Infrastructures. It comprises X.509 public key certificates, attribute certificates, certification requests and certification path validation.",
+            "homepage": "https://github.com/spomky-labs/pki-framework",
+            "keywords": [
+                "DER",
+                "Private Key",
+                "ac",
+                "algorithm identifier",
+                "asn.1",
+                "asn1",
+                "attribute certificate",
+                "certificate",
+                "certification request",
+                "cryptography",
+                "csr",
+                "decrypt",
+                "ec",
+                "encrypt",
+                "pem",
+                "pkcs",
+                "public key",
+                "rsa",
+                "sign",
+                "signature",
+                "verify",
+                "x.509",
+                "x.690",
+                "x509",
+                "x690"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/pki-framework/issues",
+                "source": "https://github.com/Spomky-Labs/pki-framework/tree/1.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-07-16T10:28:45+00:00"
         },
         {
             "name": "symfony/clock",
@@ -8456,6 +8767,95 @@
                 }
             ],
             "time": "2026-04-26T05:33:54+00:00"
+        },
+        {
+            "name": "web-token/jwt-library",
+            "version": "4.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-token/jwt-library.git",
+                "reference": "fbcbf2c276d04d8b056f5c2957815abd5dfb704d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-token/jwt-library/zipball/fbcbf2c276d04d8b056f5c2957815abd5dfb704d",
+                "reference": "fbcbf2c276d04d8b056f5c2957815abd5dfb704d",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "php": ">=8.2",
+                "psr/clock": "^1.0",
+                "spomky-labs/pki-framework": "^1.2.1"
+            },
+            "conflict": {
+                "spomky-labs/jose": "*"
+            },
+            "suggest": {
+                "ext-bcmath": "GMP or BCMath is highly recommended to improve the library performance",
+                "ext-gmp": "GMP or BCMath is highly recommended to improve the library performance",
+                "ext-openssl": "For key management (creation, optimization, etc.) and some algorithms (AES, RSA, ECDSA, etc.)",
+                "ext-sodium": "Sodium is required for OKP key creation, EdDSA signature algorithm and ECDH-ES key encryption with OKP keys",
+                "paragonie/sodium_compat": "Sodium is required for OKP key creation, EdDSA signature algorithm and ECDH-ES key encryption with OKP keys",
+                "spomky-labs/aes-key-wrap": "For all Key Wrapping algorithms (AxxxKW, AxxxGCMKW, PBES2-HSxxx+AyyyKW...)",
+                "symfony/console": "Needed to use console commands",
+                "symfony/http-client": "To enable JKU/X5U support."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jose\\Component\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/web-token/jwt-framework/contributors"
+                }
+            ],
+            "description": "JWT library",
+            "homepage": "https://github.com/web-token",
+            "keywords": [
+                "JOSE",
+                "JWE",
+                "JWK",
+                "JWKSet",
+                "JWS",
+                "Jot",
+                "RFC7515",
+                "RFC7516",
+                "RFC7517",
+                "RFC7518",
+                "RFC7519",
+                "RFC7520",
+                "bundle",
+                "jwa",
+                "jwt",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/web-token/jwt-library/issues",
+                "source": "https://github.com/web-token/jwt-library/tree/4.1.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-06-06T18:12:39+00:00"
         }
     ],
     "packages-dev": [

--- a/config/webpush.php
+++ b/config/webpush.php
@@ -1,0 +1,46 @@
+<?php
+
+use NotificationChannels\WebPush\PushSubscription;
+
+return [
+
+    /**
+     * These are the keys for authentication (VAPID).
+     * These keys must be safely stored and should not change.
+     */
+    'vapid' => [
+        'subject' => env('VAPID_SUBJECT'),
+        'public_key' => env('VAPID_PUBLIC_KEY'),
+        'private_key' => env('VAPID_PRIVATE_KEY'),
+        'pem_file' => env('VAPID_PEM_FILE'),
+    ],
+
+    /**
+     * This is model that will be used to for push subscriptions.
+     */
+    'model' => PushSubscription::class,
+
+    /**
+     * This is the name of the table that will be created by the migration and
+     * used by the PushSubscription model shipped with this package.
+     */
+    'table_name' => env('WEBPUSH_DB_TABLE', 'push_subscriptions'),
+
+    /**
+     * This is the database connection that will be used by the migration and
+     * the PushSubscription model shipped with this package.
+     */
+    'database_connection' => env('WEBPUSH_DB_CONNECTION', env('DB_CONNECTION', 'mysql')),
+
+    /**
+     * The Guzzle client options used by Minishlink\WebPush.
+     */
+    'client_options' => [],
+
+    /**
+     * The automatic padding in bytes used by Minishlink\WebPush.
+     * Set to false to support Firefox Android with v1 endpoint.
+     */
+    'automatic_padding' => env('WEBPUSH_AUTOMATIC_PADDING', true),
+
+];

--- a/database/migrations/2026_07_16_185145_create_push_subscriptions_table.php
+++ b/database/migrations/2026_07_16_185145_create_push_subscriptions_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {

--- a/database/migrations/2026_07_16_185145_create_push_subscriptions_table.php
+++ b/database/migrations/2026_07_16_185145_create_push_subscriptions_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection(config('webpush.database_connection'))->create(config('webpush.table_name'), function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->morphs('subscribable', 'push_subscriptions_subscribable_morph_idx');
+            $table->string('endpoint', 500)->unique();
+            $table->string('public_key')->nullable();
+            $table->string('auth_token')->nullable();
+            $table->string('content_encoding')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection(config('webpush.database_connection'))->dropIfExists(config('webpush.table_name'));
+    }
+};

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,64 @@
+/* Veltro service worker — Web Push delivery.
+ *
+ * Kept intentionally minimal: it only handles push display and click routing.
+ * It is served from the web root (/sw.js) so its scope covers the whole app.
+ */
+
+self.addEventListener('install', () => {
+    // Activate immediately so pushes work on first subscribe without a reload.
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+    event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('push', (event) => {
+    if (!event.data) return;
+
+    let payload = {};
+    try {
+        payload = event.data.json();
+    } catch {
+        payload = { title: 'Veltro', body: event.data.text() };
+    }
+
+    const title = payload.title || 'Veltro';
+    const options = {
+        body: payload.body || '',
+        icon: payload.icon || '/icon-192.png',
+        badge: payload.badge || '/icon-192.png',
+        tag: payload.tag,
+        data: payload.data || {},
+    };
+
+    event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+    event.notification.close();
+
+    const url = event.notification.data && event.notification.data.url;
+    const target = url || '/';
+
+    event.waitUntil(
+        self.clients
+            .matchAll({ type: 'window', includeUncontrolled: true })
+            .then((clientList) => {
+                // Focus an existing tab on the same origin if we can.
+                for (const client of clientList) {
+                    if ('focus' in client) {
+                        client.focus();
+                        if ('navigate' in client && url) {
+                            return client.navigate(target);
+                        }
+                        return undefined;
+                    }
+                }
+                if (self.clients.openWindow) {
+                    return self.clients.openWindow(target);
+                }
+                return undefined;
+            }),
+    );
+});

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -49,3 +49,14 @@ createInertiaApp({
 
 // This will set light / dark mode on load...
 initializeTheme();
+
+// Register the service worker that powers Web Push (and future offline work).
+// Guarded by feature detection so it silently no-ops in unsupported browsers.
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/sw.js').catch(() => {
+            // Registration failures (e.g. insecure context) are non-fatal; the
+            // app still works, just without push.
+        });
+    });
+}

--- a/resources/js/layouts/settings/layout.tsx
+++ b/resources/js/layouts/settings/layout.tsx
@@ -2,6 +2,7 @@ import Heading from '@/components/heading';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { cn, isSameUrl, resolveUrl } from '@/lib/utils';
+import { edit as editNotifications } from '@/routes/notifications';
 import { edit } from '@/routes/profile';
 import { show } from '@/routes/two-factor';
 import { edit as editPassword } from '@/routes/user-password';
@@ -23,6 +24,11 @@ const sidebarNavItems: NavItem[] = [
     {
         title: 'Autenticación 2FA',
         href: show(),
+        icon: null,
+    },
+    {
+        title: 'Notificaciones',
+        href: editNotifications(),
         icon: null,
     },
 ];

--- a/resources/js/lib/push.ts
+++ b/resources/js/lib/push.ts
@@ -1,0 +1,144 @@
+/* Browser Web Push helpers.
+ *
+ * Wraps service-worker registration, PushManager subscribe/unsubscribe, and the
+ * server sync calls. All functions are safe to call in unsupported browsers —
+ * they return a state indicating push is unavailable rather than throwing.
+ */
+
+import { store, destroy } from '@/routes/push/subscriptions';
+
+export type PushState = {
+    supported: boolean;
+    permission: NotificationPermission;
+    subscribed: boolean;
+};
+
+// Mirrors the CSRF header approach used by use-notifications.ts: read the live
+// XSRF-TOKEN cookie (Laravel rotates it) rather than a stale meta tag.
+function mutationHeaders(): HeadersInit {
+    const xsrfToken = document.cookie
+        .split('; ')
+        .find((row) => row.startsWith('XSRF-TOKEN='))
+        ?.split('=')[1];
+
+    return {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-XSRF-TOKEN': xsrfToken ? decodeURIComponent(xsrfToken) : '',
+    };
+}
+
+export function isPushSupported(): boolean {
+    return (
+        typeof window !== 'undefined' &&
+        'serviceWorker' in navigator &&
+        'PushManager' in window &&
+        'Notification' in window
+    );
+}
+
+// VAPID public keys are base64url; PushManager needs a Uint8Array.
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+    const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+    const base64 = (base64String + padding)
+        .replace(/-/g, '+')
+        .replace(/_/g, '/');
+    const raw = window.atob(base64);
+    const output = new Uint8Array(raw.length);
+    for (let i = 0; i < raw.length; i++) {
+        output[i] = raw.charCodeAt(i);
+    }
+    return output;
+}
+
+async function getRegistration(): Promise<ServiceWorkerRegistration | null> {
+    if (!isPushSupported()) return null;
+    // app.tsx registers /sw.js on load; `ready` resolves once it's active.
+    return navigator.serviceWorker.ready;
+}
+
+export async function getPushState(): Promise<PushState> {
+    if (!isPushSupported()) {
+        return { supported: false, permission: 'denied', subscribed: false };
+    }
+
+    const registration = await getRegistration();
+    const subscription = await registration?.pushManager.getSubscription();
+
+    return {
+        supported: true,
+        permission: Notification.permission,
+        subscribed: !!subscription,
+    };
+}
+
+export async function subscribeToPush(
+    vapidPublicKey: string,
+): Promise<PushState> {
+    if (!isPushSupported()) {
+        return { supported: false, permission: 'denied', subscribed: false };
+    }
+
+    const permission = await Notification.requestPermission();
+    if (permission !== 'granted') {
+        return { supported: true, permission, subscribed: false };
+    }
+
+    const registration = await getRegistration();
+    if (!registration) {
+        return { supported: false, permission, subscribed: false };
+    }
+
+    const subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(
+            vapidPublicKey,
+        ) as BufferSource,
+    });
+
+    const json = subscription.toJSON();
+    const response = await fetch(store().url, {
+        method: 'POST',
+        headers: mutationHeaders(),
+        credentials: 'same-origin',
+        body: JSON.stringify({
+            endpoint: json.endpoint,
+            keys: json.keys,
+        }),
+    });
+
+    if (!response.ok) {
+        // Roll back the local subscription so state stays consistent.
+        await subscription.unsubscribe();
+        throw new Error('Failed to save push subscription');
+    }
+
+    return { supported: true, permission, subscribed: true };
+}
+
+export async function unsubscribeFromPush(): Promise<PushState> {
+    if (!isPushSupported()) {
+        return { supported: false, permission: 'denied', subscribed: false };
+    }
+
+    const registration = await getRegistration();
+    const subscription = await registration?.pushManager.getSubscription();
+
+    if (subscription) {
+        const endpoint = subscription.endpoint;
+        await subscription.unsubscribe();
+        await fetch(destroy().url, {
+            method: 'DELETE',
+            headers: mutationHeaders(),
+            credentials: 'same-origin',
+            body: JSON.stringify({ endpoint }),
+        });
+    }
+
+    return {
+        supported: true,
+        permission: Notification.permission,
+        subscribed: false,
+    };
+}

--- a/resources/js/lib/push.ts
+++ b/resources/js/lib/push.ts
@@ -5,7 +5,7 @@
  * they return a state indicating push is unavailable rather than throwing.
  */
 
-import { store, destroy } from '@/routes/push/subscriptions';
+import { destroy, store } from '@/routes/push/subscriptions';
 
 export type PushState = {
     supported: boolean;

--- a/resources/js/pages/settings/notifications.tsx
+++ b/resources/js/pages/settings/notifications.tsx
@@ -61,7 +61,9 @@ export default function Notifications() {
                 }
             }
         } catch {
-            toast.error('No se pudo actualizar la suscripción. Intentá de nuevo.');
+            toast.error(
+                'No se pudo actualizar la suscripción. Intentá de nuevo.',
+            );
         } finally {
             setLoading(false);
         }
@@ -129,8 +131,9 @@ export default function Notifications() {
                                     <AlertTitle>Permiso bloqueado</AlertTitle>
                                     <AlertDescription>
                                         Bloqueaste las notificaciones para este
-                                        sitio. Habilitalas desde la configuración
-                                        de tu navegador para poder activarlas.
+                                        sitio. Habilitalas desde la
+                                        configuración de tu navegador para poder
+                                        activarlas.
                                     </AlertDescription>
                                 </Alert>
                             )}

--- a/resources/js/pages/settings/notifications.tsx
+++ b/resources/js/pages/settings/notifications.tsx
@@ -1,0 +1,143 @@
+import { Head, usePage } from '@inertiajs/react';
+import { Bell, BellOff } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+import HeadingSmall from '@/components/heading-small';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import AppLayout from '@/layouts/app-layout';
+import SettingsLayout from '@/layouts/settings/layout';
+import {
+    getPushState,
+    isPushSupported,
+    subscribeToPush,
+    unsubscribeFromPush,
+    type PushState,
+} from '@/lib/push';
+import { edit as editNotifications } from '@/routes/notifications';
+import type { BreadcrumbItem, SharedData } from '@/types';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Notificaciones push',
+        href: editNotifications().url,
+    },
+];
+
+export default function Notifications() {
+    const { vapidPublicKey } = usePage<SharedData>().props;
+
+    const [state, setState] = useState<PushState | null>(null);
+    const [loading, setLoading] = useState(false);
+
+    useEffect(() => {
+        getPushState().then(setState);
+    }, []);
+
+    const handleToggle = async () => {
+        if (!state) return;
+        setLoading(true);
+        try {
+            if (state.subscribed) {
+                const next = await unsubscribeFromPush();
+                setState(next);
+                toast.success('Notificaciones push desactivadas');
+            } else {
+                if (!vapidPublicKey) {
+                    toast.error(
+                        'Las notificaciones push no están configuradas en el servidor.',
+                    );
+                    return;
+                }
+                const next = await subscribeToPush(vapidPublicKey);
+                setState(next);
+                if (next.subscribed) {
+                    toast.success('Notificaciones push activadas');
+                } else if (next.permission === 'denied') {
+                    toast.error(
+                        'Permiso denegado. Habilitá las notificaciones en tu navegador.',
+                    );
+                }
+            }
+        } catch {
+            toast.error('No se pudo actualizar la suscripción. Intentá de nuevo.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const unsupported = state ? !state.supported : !isPushSupported();
+    const denied = state?.permission === 'denied' && !state.subscribed;
+    const subscribed = !!state?.subscribed;
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Notificaciones push" />
+
+            <SettingsLayout>
+                <div className="space-y-6">
+                    <HeadingSmall
+                        title="Notificaciones push"
+                        description="Recibí avisos de partidos, invitaciones y actividad de tu equipo aunque no tengas la app abierta."
+                    />
+
+                    {unsupported ? (
+                        <Alert>
+                            <BellOff className="h-4 w-4" />
+                            <AlertTitle>No disponible</AlertTitle>
+                            <AlertDescription>
+                                Tu navegador no admite notificaciones push. En
+                                iPhone/iPad, instalá Veltro en la pantalla de
+                                inicio (iOS 16.4 o superior) para habilitarlas.
+                            </AlertDescription>
+                        </Alert>
+                    ) : (
+                        <div className="space-y-4">
+                            <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
+                                <div className="flex items-start gap-3">
+                                    {subscribed ? (
+                                        <Bell className="mt-0.5 h-5 w-5 text-primary" />
+                                    ) : (
+                                        <BellOff className="mt-0.5 h-5 w-5 text-muted-foreground" />
+                                    )}
+                                    <div>
+                                        <p className="text-sm font-medium">
+                                            {subscribed
+                                                ? 'Activadas en este dispositivo'
+                                                : 'Desactivadas en este dispositivo'}
+                                        </p>
+                                        <p className="text-sm text-muted-foreground">
+                                            {subscribed
+                                                ? 'Vas a recibir notificaciones push en este navegador.'
+                                                : 'Activá las notificaciones para no perderte novedades.'}
+                                        </p>
+                                    </div>
+                                </div>
+                                <Button
+                                    onClick={handleToggle}
+                                    disabled={loading || !state || denied}
+                                    variant={subscribed ? 'outline' : 'default'}
+                                >
+                                    {subscribed ? 'Desactivar' : 'Activar'}
+                                </Button>
+                            </div>
+
+                            {denied && (
+                                <Alert>
+                                    <BellOff className="h-4 w-4" />
+                                    <AlertTitle>Permiso bloqueado</AlertTitle>
+                                    <AlertDescription>
+                                        Bloqueaste las notificaciones para este
+                                        sitio. Habilitalas desde la configuración
+                                        de tu navegador para poder activarlas.
+                                    </AlertDescription>
+                                </Alert>
+                            )}
+                        </div>
+                    )}
+                </div>
+            </SettingsLayout>
+        </AppLayout>
+    );
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -27,6 +27,7 @@ export interface SharedData {
     quote: { message: string; author: string };
     auth: Auth;
     sidebarOpen: boolean;
+    vapidPublicKey: string | null;
     [key: string]: unknown;
 }
 

--- a/routes/notifications.php
+++ b/routes/notifications.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\NotificationController;
+use App\Http\Controllers\PushSubscriptionController;
 use App\Http\Middleware\HandleInertiaRequests;
 use Illuminate\Support\Facades\Route;
 
@@ -16,4 +17,8 @@ Route::middleware(['auth', 'verified', 'throttle:dashboard'])
         Route::post('/notifications/mark-all-read', [NotificationController::class, 'markAllAsRead'])->name('notifications.mark-all-read');
         Route::delete('/notifications/{id}', [NotificationController::class, 'destroy'])->name('notifications.destroy');
         Route::post('/notifications/clear-read', [NotificationController::class, 'clearRead'])->name('notifications.clear-read');
+
+        // Web Push subscription management (called from the browser push helper)
+        Route::post('/push/subscriptions', [PushSubscriptionController::class, 'store'])->name('push.subscriptions.store');
+        Route::delete('/push/subscriptions', [PushSubscriptionController::class, 'destroy'])->name('push.subscriptions.destroy');
     });

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -39,6 +39,10 @@ Route::middleware(['auth', 'onboarding'])->group(function () {
         return Inertia::render('settings/appearance');
     })->middleware('throttle:settings-read')->name('appearance.edit');
 
+    Route::get('settings/notifications', function () {
+        return Inertia::render('settings/notifications');
+    })->middleware('throttle:settings-read')->name('notifications.edit');
+
     Route::get('settings/two-factor', [TwoFactorAuthenticationController::class, 'show'])
         ->middleware('throttle:settings-read')
         ->name('two-factor.show');


### PR DESCRIPTION
## Context

Veltro already has a complete in-app notification system — 16 `Notification` classes with a consistent payload, a `notifications` table, the bell UI, and real-time delivery over Reverb/Echo. What was missing is delivery **when the app/tab is closed**. This adds **Web Push** (VAPID) so notifications reach the device even when Veltro isn't open.

Per product decisions: **all 16 notifications** fire a push, opt-in is a **settings toggle**, and scope is **web push / PWA only** (no native FCM/APNs).

## What's included

**Backend**
- `laravel-notification-channels/webpush` + `push_subscriptions` table; `User` uses `HasPushSubscriptions`.
- `BuildsWebPush` trait derives the push payload from each notification's existing `toDatabase()` array — every notification appends `WebPushChannel::class` to `via()`.
- `PushSubscriptionController` (`store`/`destroy`) as JSON routes `POST|DELETE /push/subscriptions`.
- VAPID public key shared to the frontend via Inertia.
- `AppServiceProvider` overrides the package's `WebPush` binding to inject Laravel's PSR logger — see note below.

**Frontend**
- `public/sw.js` service worker (push display + click routing), registered in `app.tsx`.
- `resources/js/lib/push.ts` subscribe/unsubscribe/state helpers.
- `settings/notifications.tsx` opt-in toggle with permission-denied and unsupported-browser guidance (incl. the iOS "install to home screen" note), linked in settings nav.

## Notable implementation detail

`minishlink/web-push` calls `trigger_error(E_USER_NOTICE)` when BCMath/GMP are absent, which Laravel escalates to a **fatal `ErrorException`** — this broke 4 tests that dispatch notifications synchronously and would have broken the queued job in production. Injecting a PSR logger routes that advisory to the log instead. Installing `ext-bcmath`/`ext-gmp` in production is a good complementary step (faster VAPID crypto) but is no longer required for correctness.

## Deploy notes

- Set `VAPID_SUBJECT`, `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY` on Laravel Cloud (generate with `php artisan webpush:vapid`).
- Run the new migration.

## Testing

- Full suite green: **391 passed** (1758 assertions).
- Not verifiable headlessly: the real browser subscribe → push-to-closed-tab → click round trip. Recommend a manual pass over a secure context with the queue worker running before shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)