### PR TITLE
feat: add --force flag to user:purge for non-interactive consoles

### DIFF
--- a/app/Console/Commands/PurgeUser.php
+++ b/app/Console/Commands/PurgeUser.php
@@ -18,7 +18,8 @@ class PurgeUser extends Command
      * @var string
      */
     protected $signature = 'user:purge {id : The ID of the user to permanently delete}
-                            {--dry-run : Show what would be deleted without deleting anything}';
+                            {--dry-run : Show what would be deleted without deleting anything}
+                            {--force : Skip the confirmation prompt (required in non-interactive consoles)}';
 
     /**
      * The console command description.
@@ -69,7 +70,8 @@ class PurgeUser extends Command
             return self::SUCCESS;
         }
 
-        if (! $this->confirm('This is permanent and cannot be undone. Have you taken a DB backup and want to continue?')) {
+        if (! $this->option('force')
+            && ! $this->confirm('This is permanent and cannot be undone. Have you taken a DB backup and want to continue?')) {
             $this->info('Aborted.');
 
             return self::SUCCESS;


### PR DESCRIPTION
## Summary

The `user:purge` confirmation prompt defaults to **no** in a non-interactive console (Laravel Cloud's console has no TTY), so the command always aborts before deleting anything. This adds a `--force` flag to skip the prompt.

## Usage

```bash
php artisan user:purge 5 --dry-run   # preview (unchanged)
php artisan user:purge 5 --force     # execute without the interactive prompt
```

Interactive terminals can still omit `--force` and get the confirmation prompt as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)