### PR TITLE
fix: hide expiry countdown on non-pending team invitations

### DIFF
--- a/resources/js/pages/teams/show.tsx
+++ b/resources/js/pages/teams/show.tsx
@@ -924,12 +924,15 @@ export default function Show({
                                                                     invitation.status,
                                                                 )}
                                                             </Badge>
-                                                            <span className="text-xs text-muted-foreground">
-                                                                {formatRelativeExpiry(
-                                                                    invitation.expires_at,
-                                                                    nowMs,
-                                                                )}
-                                                            </span>
+                                                            {invitation.status ===
+                                                                'pending' && (
+                                                                <span className="text-xs text-muted-foreground">
+                                                                    {formatRelativeExpiry(
+                                                                        invitation.expires_at,
+                                                                        nowMs,
+                                                                    )}
+                                                                </span>
+                                                            )}
                                                         </div>
                                                         {invitation.inviter && (
                                                             <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Problem

When a captain revokes a team invitation, the badge correctly flips to **Cancelada** and the invite link is invalidated server-side — but the row still shows a live **"expira en 7 días"** countdown. A countdown on a dead invitation is misleading and improper. The same applies to expired invitations.

## Fix

Only render the relative-expiry label when `invitation.status === 'pending'`. For revoked/expired invitations the status badge already communicates the state, so the countdown is dropped.

This is a display-only change; revocation behavior and authorization are unchanged.

## Before / After
- **Before:** `Jugador · Cancelada · expira en 7 días`
- **After:** `Jugador · Cancelada`

🤖 Generated with [Claude Code](https://claude.com/claude-code)