### PR TITLE
feat: rebalance match detail page and add event timeline

### DIFF
--- a/resources/js/components/match/match-lineups.tsx
+++ b/resources/js/components/match/match-lineups.tsx
@@ -1,0 +1,86 @@
+import type { LineupPlayer } from '@/components/match/types';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { UserAvatar } from '@/components/user-avatar';
+import { UserNameLink } from '@/components/user-name-link';
+
+interface MatchLineupsProps {
+    homeTeamName: string;
+    awayTeamName?: string;
+    homeLineup: LineupPlayer[];
+    awayLineup: LineupPlayer[];
+}
+
+/**
+ * Read-only view of the confirmed rosters for both teams. Leaders edit the
+ * lineup on the dedicated `/lineup` page; this only displays who's selected.
+ */
+export function MatchLineups({
+    homeTeamName,
+    awayTeamName,
+    homeLineup,
+    awayLineup,
+}: MatchLineupsProps) {
+    const showAway = Boolean(awayTeamName) && awayLineup.length > 0;
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Alineaciones</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <div className="grid gap-6 sm:grid-cols-2">
+                    <LineupColumn
+                        teamName={homeTeamName}
+                        players={homeLineup}
+                    />
+                    {showAway && (
+                        <LineupColumn
+                            teamName={awayTeamName as string}
+                            players={awayLineup}
+                        />
+                    )}
+                </div>
+            </CardContent>
+        </Card>
+    );
+}
+
+function LineupColumn({
+    teamName,
+    players,
+}: {
+    teamName: string;
+    players: LineupPlayer[];
+}) {
+    return (
+        <div className="space-y-3">
+            <div className="flex items-center justify-between gap-2">
+                <p className="truncate text-sm font-semibold">{teamName}</p>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                    {players.length}{' '}
+                    {players.length === 1 ? 'jugador' : 'jugadores'}
+                </span>
+            </div>
+            {players.length > 0 ? (
+                <ul className="space-y-2">
+                    {players.map((player) => (
+                        <li
+                            key={player.id}
+                            className="flex items-center gap-2.5"
+                        >
+                            <UserAvatar name={player.user.name} size="sm" />
+                            <UserNameLink
+                                user={player.user}
+                                className="truncate text-sm"
+                            />
+                        </li>
+                    ))}
+                </ul>
+            ) : (
+                <p className="text-sm text-muted-foreground">
+                    Sin jugadores seleccionados.
+                </p>
+            )}
+        </div>
+    );
+}

--- a/resources/js/components/match/match-timeline.tsx
+++ b/resources/js/components/match/match-timeline.tsx
@@ -1,0 +1,149 @@
+import type { MatchEvent } from '@/components/match/types';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getEventVisual } from '@/lib/match-format';
+import { cn } from '@/lib/utils';
+
+interface MatchTimelineProps {
+    events: MatchEvent[];
+    homeTeamId: number;
+    emptyMessage?: string;
+}
+
+/**
+ * Read-only, merged, minute-ordered feed of every match event. Home-team events
+ * sit on the left of a central spine, away-team events on the right — mirroring
+ * the hero's home-left/away-right convention. Goal recording and deletion live
+ * in the hero's per-crest `GoalScorersList`; this component never mutates.
+ */
+export function MatchTimeline({
+    events,
+    homeTeamId,
+    emptyMessage = 'El partido aún no comenzó. Los eventos aparecerán acá.',
+}: MatchTimelineProps) {
+    const ordered = [...events].sort(
+        (a, b) => (a.minute ?? 0) - (b.minute ?? 0),
+    );
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Cronología</CardTitle>
+            </CardHeader>
+            <CardContent>
+                {ordered.length === 0 ? (
+                    <p className="py-6 text-center text-sm text-muted-foreground">
+                        {emptyMessage}
+                    </p>
+                ) : (
+                    <div className="relative">
+                        {/* Central spine */}
+                        <span
+                            aria-hidden
+                            className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border"
+                        />
+                        <ol className="relative space-y-3">
+                            {ordered.map((event) => {
+                                const isHome =
+                                    Number(event.team_id) ===
+                                    Number(homeTeamId);
+                                const {
+                                    icon: Icon,
+                                    label,
+                                    colorClass,
+                                } = getEventVisual(event.event_type);
+
+                                return (
+                                    <li
+                                        key={event.id}
+                                        className="grid grid-cols-[1fr_auto_1fr] items-center gap-2"
+                                    >
+                                        {/* Home side */}
+                                        <div className="flex justify-end">
+                                            {isHome && (
+                                                <EventChip
+                                                    icon={Icon}
+                                                    colorClass={colorClass}
+                                                    label={label}
+                                                    name={event.user?.name}
+                                                    description={
+                                                        event.description
+                                                    }
+                                                    align="right"
+                                                />
+                                            )}
+                                        </div>
+
+                                        {/* Minute marker on the spine */}
+                                        <span className="z-10 rounded-full border bg-background px-2 py-0.5 text-xs font-semibold tabular-nums">
+                                            {event.minute != null
+                                                ? `${event.minute}'`
+                                                : '·'}
+                                        </span>
+
+                                        {/* Away side */}
+                                        <div className="flex justify-start">
+                                            {!isHome && (
+                                                <EventChip
+                                                    icon={Icon}
+                                                    colorClass={colorClass}
+                                                    label={label}
+                                                    name={event.user?.name}
+                                                    description={
+                                                        event.description
+                                                    }
+                                                    align="left"
+                                                />
+                                            )}
+                                        </div>
+                                    </li>
+                                );
+                            })}
+                        </ol>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+interface EventChipProps {
+    icon: React.ComponentType<{ className?: string }>;
+    colorClass: string;
+    label: string;
+    name?: string;
+    description?: string;
+    align: 'left' | 'right';
+}
+
+function EventChip({
+    icon: Icon,
+    colorClass,
+    label,
+    name,
+    description,
+    align,
+}: EventChipProps) {
+    return (
+        <div
+            className={cn(
+                'inline-flex max-w-full items-center gap-2 rounded-lg border bg-card px-3 py-1.5',
+                align === 'right' && 'flex-row-reverse text-right',
+            )}
+        >
+            <Icon className={cn('h-4 w-4 shrink-0', colorClass)} />
+            <div className="min-w-0">
+                <p
+                    className={cn(
+                        'truncate text-sm font-medium',
+                        !name && 'text-muted-foreground italic',
+                    )}
+                >
+                    {name ?? 'Sin asignar'}
+                </p>
+                <p className="truncate text-xs text-muted-foreground">
+                    {description ? `${label} · ${description}` : label}
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/lib/match-format.ts
+++ b/resources/js/lib/match-format.ts
@@ -1,4 +1,12 @@
 import { formatDate, formatTime } from '@/lib/datetime';
+import {
+    ArrowRightLeft,
+    Circle,
+    Footprints,
+    type LucideIcon,
+    RectangleVertical,
+    Target,
+} from 'lucide-react';
 
 export const getMatchStatusColor = (status: string): string => {
     switch (status) {
@@ -50,4 +58,59 @@ export const formatMatchTime = (dateString: string | null): string => {
         hour: 'numeric',
         minute: '2-digit',
     });
+};
+
+export interface EventVisual {
+    icon: LucideIcon;
+    label: string;
+    colorClass: string;
+}
+
+/**
+ * Maps a match `event_type` to the icon, Spanish label, and colour used to
+ * render it in the timeline. Covers every value of the `match_events`
+ * `event_type` enum; unknown types fall back to a neutral dot so the timeline
+ * never renders blank as new event types are added.
+ */
+export const getEventVisual = (eventType: string): EventVisual => {
+    switch (eventType) {
+        case 'goal':
+            return { icon: Target, label: 'Gol', colorClass: 'text-green-600' };
+        case 'assist':
+            return {
+                icon: Footprints,
+                label: 'Asistencia',
+                colorClass: 'text-blue-500',
+            };
+        case 'yellow_card':
+            return {
+                icon: RectangleVertical,
+                label: 'Tarjeta amarilla',
+                colorClass: 'text-yellow-500',
+            };
+        case 'red_card':
+            return {
+                icon: RectangleVertical,
+                label: 'Tarjeta roja',
+                colorClass: 'text-red-600',
+            };
+        case 'substitution_in':
+            return {
+                icon: ArrowRightLeft,
+                label: 'Entra',
+                colorClass: 'text-green-600',
+            };
+        case 'substitution_out':
+            return {
+                icon: ArrowRightLeft,
+                label: 'Sale',
+                colorClass: 'text-orange-500',
+            };
+        default:
+            return {
+                icon: Circle,
+                label: 'Evento',
+                colorClass: 'text-muted-foreground',
+            };
+    }
 };

--- a/resources/js/pages/matches/show.tsx
+++ b/resources/js/pages/matches/show.tsx
@@ -6,7 +6,9 @@ import {
 } from '@/components/loading-skeletons';
 import { CompleteMatchDialog } from '@/components/match/complete-match-dialog';
 import { MatchHero } from '@/components/match/match-hero';
+import { MatchLineups } from '@/components/match/match-lineups';
 import { MatchRequestsCard } from '@/components/match/match-requests-card';
+import { MatchTimeline } from '@/components/match/match-timeline';
 import { OpposingLeadersCard } from '@/components/match/opposing-leaders-card';
 import type {
     LineupPlayer,
@@ -194,7 +196,7 @@ export default function Show({
                 />
 
                 <div className="grid gap-6 lg:grid-cols-3">
-                    {/* Main column */}
+                    {/* Main column — the match narrative */}
                     <div className="space-y-6 lg:col-span-2">
                         {isHomeLeader &&
                             match.status === 'available' &&
@@ -207,36 +209,14 @@ export default function Show({
                                 />
                             )}
 
-                        {isLeader &&
-                            (match.status === 'confirmed' ||
-                                match.status === 'in_progress' ||
-                                match.status === 'completed') && (
-                                <Deferred
-                                    data="opposingTeamLeaders"
-                                    fallback={<CardSkeleton />}
-                                >
-                                    {opposingTeamLeaders &&
-                                    opposingTeamLeaders.length > 0 ? (
-                                        <OpposingLeadersCard
-                                            leaders={opposingTeamLeaders}
-                                        />
-                                    ) : null}
-                                </Deferred>
-                            )}
-                    </div>
-
-                    {/* Sidebar */}
-                    <div className="space-y-6">
                         {(match.status === 'confirmed' ||
-                            match.status === 'available') &&
-                            userTeamId && (
-                                <AvailabilitySelector
-                                    matchId={match.id}
-                                    currentStatus={
-                                        userAvailability ?? undefined
-                                    }
-                                />
-                            )}
+                            match.status === 'in_progress' ||
+                            match.status === 'completed') && (
+                            <MatchTimeline
+                                events={events}
+                                homeTeamId={match.home_team.id}
+                            />
+                        )}
 
                         {(match.status === 'confirmed' ||
                             match.status === 'available') && (
@@ -274,6 +254,50 @@ export default function Show({
                                 ) : null}
                             </Deferred>
                         )}
+
+                        {(match.status === 'confirmed' ||
+                            match.status === 'in_progress' ||
+                            match.status === 'completed') &&
+                            (homeLineup.length > 0 ||
+                                awayLineup.length > 0) && (
+                                <MatchLineups
+                                    homeTeamName={match.home_team.name}
+                                    awayTeamName={match.away_team?.name}
+                                    homeLineup={homeLineup}
+                                    awayLineup={awayLineup}
+                                />
+                            )}
+                    </div>
+
+                    {/* Sidebar — personal tools & contact */}
+                    <div className="space-y-6">
+                        {(match.status === 'confirmed' ||
+                            match.status === 'available') &&
+                            userTeamId && (
+                                <AvailabilitySelector
+                                    matchId={match.id}
+                                    currentStatus={
+                                        userAvailability ?? undefined
+                                    }
+                                />
+                            )}
+
+                        {isLeader &&
+                            (match.status === 'confirmed' ||
+                                match.status === 'in_progress' ||
+                                match.status === 'completed') && (
+                                <Deferred
+                                    data="opposingTeamLeaders"
+                                    fallback={<CardSkeleton />}
+                                >
+                                    {opposingTeamLeaders &&
+                                    opposingTeamLeaders.length > 0 ? (
+                                        <OpposingLeadersCard
+                                            leaders={opposingTeamLeaders}
+                                        />
+                                    ) : null}
+                                </Deferred>
+                            )}
 
                         {isLeader &&
                             (match.status === 'confirmed' ||


### PR DESCRIPTION
## Why

The match detail page (`matches/show.tsx`) is the app's centerpiece — the game itself — yet it was the emptiest screen. The `lg:grid-cols-3` layout kept almost all content in the narrow sidebar (availability selector, availability panel, lineup management), while the wide 2-column main area only rendered for two narrow leader cases. A regular player viewing a confirmed match saw a large empty left column. There was also **no chronological event view** anywhere — goals only appeared as two separate per-crest columns in the hero, and card/sub event types were never surfaced.

## What

Reallocate the existing 3-column grid so the main column carries the match narrative:

- **Main column:** match requests → **timeline** → availability panel (moved up from the sidebar) → **inline lineups**
- **Sidebar:** personal availability selector → opposing-leaders contact (moved down here) → lineup management

Result: the wide column is filled at every status — `available` → requests + availability; `confirmed` → availability + lineups + timeline placeholder; `in_progress`/`completed` → timeline + lineups.

### New components

- **`MatchTimeline`** — read-only, merged, minute-ordered feed of all event types on a central spine (home events left, away right, mirroring the hero). Additive: the hero's per-crest `GoalScorersList` and its goal record/delete affordances are untouched.
- **`MatchLineups`** — read-only two-column rosters reusing `UserAvatar`/`UserNameLink`; the leader edit flow stays on the separate `/lineup` page.
- **`getEventVisual()`** helper added to the existing `lib/match-format.ts` — maps each `event_type` to icon/label/colour, with a neutral fallback so the timeline never renders blank as event recording expands beyond goals.

**No backend, route, or Wayfinder changes** — all data (`events`, `homeLineup`, `awayLineup`) already flowed to the page.

## Verification

- ✅ `bun run types` — new files clean (remaining errors are pre-existing Wayfinder `.form()` issues on `main`, unrelated)
- ✅ `bun run lint` / `bun run format` clean
- ✅ `bun run build` — full production bundle, 4110 modules, no errors
- ⚠️ Not run: a live browser click-through per match status (no browser tool available in the authoring environment). Reviewer should eyeball, especially recording a goal on an `in_progress` match — it should appear both under the crest and as a new timeline row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)