### PR TITLE
feat: compact, symmetric match hero scoreboard

### DIFF
--- a/resources/js/components/match/match-hero.tsx
+++ b/resources/js/components/match/match-hero.tsx
@@ -19,6 +19,7 @@ import {
     getMatchStatusColor,
     getMatchStatusText,
 } from '@/lib/match-format';
+import { cn } from '@/lib/utils';
 import matches from '@/routes/matches';
 import { Link } from '@inertiajs/react';
 import {
@@ -26,6 +27,7 @@ import {
     Clock,
     Edit,
     MapPin,
+    Plane,
     Plus,
     Shield,
     Swords,
@@ -76,73 +78,58 @@ export function MatchHero({
         match.status === 'in_progress' ||
         match.status === 'completed';
 
+    const showScorers =
+        match.status === 'in_progress' || match.status === 'completed';
+
+    const canRecord = (leader: boolean) =>
+        leader && match.status !== 'completed' && matchHasStarted;
+
     return (
         <>
-            <div className="relative overflow-hidden rounded-xl border bg-gradient-to-br from-background via-background to-muted/20 p-6 md:p-8">
-                <div className="absolute top-0 right-0 -mt-16 -mr-16 h-64 w-64 rounded-full bg-primary/5 blur-3xl" />
-                <div className="absolute bottom-0 left-0 -mb-16 -ml-16 h-64 w-64 rounded-full bg-primary/5 blur-3xl" />
+            <div className="relative overflow-hidden rounded-xl border bg-gradient-to-br from-background via-background to-muted/20 p-4 md:p-5">
+                <div className="absolute top-0 right-0 -mt-16 -mr-16 h-48 w-48 rounded-full bg-primary/5 blur-3xl" />
 
-                <div className="relative">
+                <div className="relative space-y-4">
                     {/* Status badges */}
-                    <div className="mb-4 flex flex-wrap items-center gap-2">
+                    <div className="flex flex-wrap items-center gap-2">
                         <Badge className={getMatchStatusColor(match.status)}>
                             {getMatchStatusText(match.status)}
                         </Badge>
                         <VariantBadge variant={match.variant} />
                     </div>
 
-                    {/* Matchup */}
-                    <div className="grid grid-cols-1 items-center gap-6 md:grid-cols-[1fr,auto,1fr]">
+                    {/* Scoreboard — home (local) left, away (visitante) right */}
+                    <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2 md:gap-4">
                         {/* Home team */}
-                        <div className="flex flex-col items-center md:items-end">
-                            <Link
-                                href={`/teams/${match.home_team.id}`}
-                                className="group flex flex-col items-center gap-3 rounded-lg p-4 transition-colors hover:bg-muted/50 md:flex-row md:justify-end"
-                            >
-                                <TeamAvatar
-                                    name={match.home_team.name}
-                                    logoUrl={match.home_team.logo_url}
-                                    size="lg"
-                                    className="h-20 w-20"
-                                />
-                                <div className="text-center md:text-right">
-                                    <h2 className="text-2xl font-bold">
-                                        {match.home_team.name}
-                                    </h2>
-                                    <div className="mt-1 flex items-center justify-center gap-1 md:justify-end">
-                                        <Shield className="h-4 w-4 text-muted-foreground" />
-                                        <p className="text-sm text-muted-foreground">
-                                            Local
-                                        </p>
-                                    </div>
+                        <Link
+                            href={`/teams/${match.home_team.id}`}
+                            className="group flex items-center justify-end gap-2.5 rounded-lg p-1.5 transition-colors hover:bg-muted/50 md:gap-3"
+                        >
+                            <TeamAvatar
+                                name={match.home_team.name}
+                                logoUrl={match.home_team.logo_url}
+                                size="lg"
+                                className="h-12 w-12 shrink-0 md:h-16 md:w-16"
+                            />
+                            <div className="min-w-0 text-right">
+                                <h2 className="truncate text-base font-bold md:text-xl">
+                                    {match.home_team.name}
+                                </h2>
+                                <div className="flex items-center justify-end gap-1 text-muted-foreground">
+                                    <Shield className="h-3.5 w-3.5" />
+                                    <p className="text-xs md:text-sm">Local</p>
                                 </div>
-                            </Link>
-                            {(match.status === 'in_progress' ||
-                                match.status === 'completed') && (
-                                <GoalScorersList
-                                    events={events}
-                                    teamId={match.home_team.id}
-                                    isLeader={isHomeLeader}
-                                    alignment="right"
-                                    matchStatus={match.status}
-                                    onRecordGoal={() =>
-                                        setRecordGoalDialog({
-                                            open: true,
-                                            team: 'home',
-                                        })
-                                    }
-                                />
-                            )}
-                        </div>
+                            </div>
+                        </Link>
 
                         {/* Score / countdown / placeholder */}
-                        <div className="flex flex-col items-center justify-center gap-3">
+                        <div className="flex flex-col items-center gap-1.5">
                             {showScore ? (
                                 <>
                                     {!matchHasStarted &&
                                         countdown &&
                                         match.status !== 'completed' && (
-                                            <div className="flex items-center gap-1.5 rounded-full border bg-card/80 px-3 py-1 text-xs backdrop-blur-sm">
+                                            <div className="flex items-center gap-1.5 rounded-full border bg-card/80 px-2.5 py-0.5 text-xs backdrop-blur-sm">
                                                 <Clock className="h-3 w-3 text-muted-foreground" />
                                                 <span className="font-medium">
                                                     {countdown}
@@ -150,150 +137,149 @@ export function MatchHero({
                                             </div>
                                         )}
 
-                                    <div className="rounded-xl border bg-card/80 px-4 py-3 shadow-lg backdrop-blur-sm md:px-6">
-                                        <div className="flex items-center gap-3 md:gap-4">
-                                            <div className="flex items-center gap-2">
-                                                {isHomeLeader &&
-                                                    match.status !==
-                                                        'completed' &&
-                                                    matchHasStarted && (
-                                                        <Button
-                                                            variant="ghost"
-                                                            size="icon"
-                                                            className="h-7 w-7 rounded-full"
-                                                            aria-label="Registrar gol local"
-                                                            onClick={() =>
-                                                                setRecordGoalDialog(
-                                                                    {
-                                                                        open: true,
-                                                                        team: 'home',
-                                                                    },
-                                                                )
-                                                            }
-                                                        >
-                                                            <Plus className="h-3.5 w-3.5" />
-                                                        </Button>
-                                                    )}
-                                                <div
-                                                    className={`flex h-12 w-12 items-center justify-center rounded-lg text-3xl font-bold md:h-14 md:w-14 ${
-                                                        match.status ===
-                                                            'completed' &&
-                                                        homeScore > awayScore
-                                                            ? 'text-primary'
-                                                            : ''
-                                                    }`}
-                                                >
-                                                    {homeScore}
-                                                </div>
-                                            </div>
-
-                                            <span className="text-xl font-bold text-muted-foreground md:text-2xl">
-                                                -
-                                            </span>
-
-                                            <div className="flex items-center gap-2">
-                                                <div
-                                                    className={`flex h-12 w-12 items-center justify-center rounded-lg text-3xl font-bold md:h-14 md:w-14 ${
-                                                        match.status ===
-                                                            'completed' &&
-                                                        awayScore > homeScore
-                                                            ? 'text-primary'
-                                                            : ''
-                                                    }`}
-                                                >
-                                                    {awayScore}
-                                                </div>
-                                                {isAwayLeader &&
-                                                    match.status !==
-                                                        'completed' &&
-                                                    matchHasStarted && (
-                                                        <Button
-                                                            variant="ghost"
-                                                            size="icon"
-                                                            className="h-7 w-7 rounded-full"
-                                                            aria-label="Registrar gol visitante"
-                                                            onClick={() =>
-                                                                setRecordGoalDialog(
-                                                                    {
-                                                                        open: true,
-                                                                        team: 'away',
-                                                                    },
-                                                                )
-                                                            }
-                                                        >
-                                                            <Plus className="h-3.5 w-3.5" />
-                                                        </Button>
-                                                    )}
-                                            </div>
-                                        </div>
+                                    <div className="flex items-center gap-1.5 rounded-xl border bg-card/80 px-3 py-2 shadow-sm backdrop-blur-sm md:gap-2">
+                                        {canRecord(isHomeLeader) && (
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                className="h-6 w-6 rounded-full"
+                                                aria-label="Registrar gol local"
+                                                onClick={() =>
+                                                    setRecordGoalDialog({
+                                                        open: true,
+                                                        team: 'home',
+                                                    })
+                                                }
+                                            >
+                                                <Plus className="h-3.5 w-3.5" />
+                                            </Button>
+                                        )}
+                                        <span
+                                            className={cn(
+                                                'w-9 text-center text-3xl font-bold tabular-nums md:w-10',
+                                                match.status === 'completed' &&
+                                                    homeScore > awayScore &&
+                                                    'text-primary',
+                                            )}
+                                        >
+                                            {homeScore}
+                                        </span>
+                                        <span className="text-lg font-bold text-muted-foreground">
+                                            -
+                                        </span>
+                                        <span
+                                            className={cn(
+                                                'w-9 text-center text-3xl font-bold tabular-nums md:w-10',
+                                                match.status === 'completed' &&
+                                                    awayScore > homeScore &&
+                                                    'text-primary',
+                                            )}
+                                        >
+                                            {awayScore}
+                                        </span>
+                                        {canRecord(isAwayLeader) && (
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                className="h-6 w-6 rounded-full"
+                                                aria-label="Registrar gol visitante"
+                                                onClick={() =>
+                                                    setRecordGoalDialog({
+                                                        open: true,
+                                                        team: 'away',
+                                                    })
+                                                }
+                                            >
+                                                <Plus className="h-3.5 w-3.5" />
+                                            </Button>
+                                        )}
                                     </div>
                                 </>
                             ) : (
-                                <div className="rounded-full border bg-card p-4 shadow-sm">
-                                    <Swords className="h-8 w-8 text-muted-foreground" />
+                                <div className="rounded-full border bg-card p-3 shadow-sm">
+                                    <Swords className="h-6 w-6 text-muted-foreground" />
                                 </div>
                             )}
                         </div>
 
                         {/* Away team */}
-                        <div className="flex flex-col items-center md:items-start">
-                            {match.away_team ? (
-                                <Link
-                                    href={`/teams/${match.away_team.id}`}
-                                    className="group flex flex-col items-center gap-3 rounded-lg p-4 transition-colors hover:bg-muted/50 md:flex-row"
-                                >
-                                    <TeamAvatar
-                                        name={match.away_team.name}
-                                        logoUrl={match.away_team.logo_url}
-                                        size="lg"
-                                        className="h-20 w-20"
-                                    />
-                                    <div className="text-center md:text-left">
-                                        <h2 className="text-2xl font-bold">
-                                            {match.away_team.name}
-                                        </h2>
-                                        <p className="mt-1 text-sm text-muted-foreground">
+                        {match.away_team ? (
+                            <Link
+                                href={`/teams/${match.away_team.id}`}
+                                className="group flex items-center justify-start gap-2.5 rounded-lg p-1.5 transition-colors hover:bg-muted/50 md:gap-3"
+                            >
+                                <div className="min-w-0 text-left">
+                                    <h2 className="truncate text-base font-bold md:text-xl">
+                                        {match.away_team.name}
+                                    </h2>
+                                    <div className="flex items-center gap-1 text-muted-foreground">
+                                        <Plane className="h-3.5 w-3.5" />
+                                        <p className="text-xs md:text-sm">
                                             Visitante
                                         </p>
                                     </div>
-                                </Link>
-                            ) : (
-                                <div className="flex flex-col items-center gap-3 rounded-lg border-2 border-dashed bg-muted/30 p-6 md:flex-row">
-                                    <div className="rounded-full bg-muted p-4">
-                                        <Users className="h-8 w-8 text-muted-foreground" />
-                                    </div>
-                                    <div className="text-center md:text-left">
-                                        <h3 className="text-lg font-semibold">
-                                            Buscando Rival
-                                        </h3>
-                                        <p className="text-sm text-muted-foreground">
-                                            Esperando solicitudes de equipos
-                                        </p>
-                                    </div>
                                 </div>
-                            )}
-                            {(match.status === 'in_progress' ||
-                                match.status === 'completed') &&
-                                match.away_team && (
-                                    <GoalScorersList
-                                        events={events}
-                                        teamId={match.away_team.id}
-                                        isLeader={isAwayLeader}
-                                        alignment="left"
-                                        matchStatus={match.status}
-                                        onRecordGoal={() =>
-                                            setRecordGoalDialog({
-                                                open: true,
-                                                team: 'away',
-                                            })
-                                        }
-                                    />
-                                )}
-                        </div>
+                                <TeamAvatar
+                                    name={match.away_team.name}
+                                    logoUrl={match.away_team.logo_url}
+                                    size="lg"
+                                    className="h-12 w-12 shrink-0 md:h-16 md:w-16"
+                                />
+                            </Link>
+                        ) : (
+                            <div className="flex items-center justify-start gap-2.5 rounded-lg border border-dashed bg-muted/30 p-2 md:gap-3">
+                                <div className="min-w-0">
+                                    <h3 className="truncate text-sm font-semibold">
+                                        Buscando rival
+                                    </h3>
+                                    <p className="truncate text-xs text-muted-foreground">
+                                        Esperando solicitudes
+                                    </p>
+                                </div>
+                                <div className="rounded-full bg-muted p-2.5">
+                                    <Users className="h-6 w-6 text-muted-foreground" />
+                                </div>
+                            </div>
+                        )}
                     </div>
 
+                    {/* Scorers — symmetric row under each team */}
+                    {showScorers && (
+                        <div className="grid grid-cols-[1fr_auto_1fr] items-start gap-2 md:gap-4">
+                            <GoalScorersList
+                                events={events}
+                                teamId={match.home_team.id}
+                                isLeader={isHomeLeader}
+                                alignment="right"
+                                matchStatus={match.status}
+                                onRecordGoal={() =>
+                                    setRecordGoalDialog({
+                                        open: true,
+                                        team: 'home',
+                                    })
+                                }
+                            />
+                            <span />
+                            {match.away_team && (
+                                <GoalScorersList
+                                    events={events}
+                                    teamId={match.away_team.id}
+                                    isLeader={isAwayLeader}
+                                    alignment="left"
+                                    matchStatus={match.status}
+                                    onRecordGoal={() =>
+                                        setRecordGoalDialog({
+                                            open: true,
+                                            team: 'away',
+                                        })
+                                    }
+                                />
+                            )}
+                        </div>
+                    )}
+
                     {/* Match info row */}
-                    <div className="mt-6 flex flex-wrap items-center justify-center gap-6 text-sm">
+                    <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 border-t pt-4 text-sm">
                         <div className="flex items-center gap-2">
                             <Calendar className="h-4 w-4 text-muted-foreground" />
                             <span className="font-medium">
@@ -317,56 +303,62 @@ export function MatchHero({
                     </div>
 
                     {/* Action buttons */}
-                    <div className="mt-6 flex flex-wrap justify-center gap-3">
-                        {isHomeLeader && match.status === 'available' && (
-                            <>
-                                <Button asChild variant="outline">
-                                    <Link href={matches.edit(match.id).url}>
-                                        <Edit className="mr-2 h-4 w-4" />
-                                        Editar
-                                    </Link>
-                                </Button>
-                                <Button
-                                    variant="destructive"
-                                    onClick={onCancelClick}
-                                >
-                                    <X className="mr-2 h-4 w-4" />
-                                    Cancelar Partido
-                                </Button>
-                            </>
-                        )}
-                        {isLeader && match.status === 'in_progress' && (
-                            <Button
-                                onClick={onCompleteClick}
-                                disabled={!matchHasStarted}
-                                title={
-                                    !matchHasStarted
-                                        ? 'No se puede completar el partido antes de que comience'
-                                        : ''
-                                }
-                            >
-                                <Trophy className="mr-2 h-4 w-4" />
-                                Completar Partido
-                            </Button>
-                        )}
-                        {!isLeader &&
-                            match.status === 'available' &&
-                            eligibleTeams.length > 0 && (
-                                <CreateMatchRequestDialog
-                                    matchId={match.id}
-                                    eligibleTeams={eligibleTeams}
-                                />
+                    {(isHomeLeader && match.status === 'available') ||
+                    (isLeader && match.status === 'in_progress') ||
+                    (!isLeader &&
+                        match.status === 'available' &&
+                        eligibleTeams.length > 0) ? (
+                        <div className="flex flex-wrap justify-center gap-3">
+                            {isHomeLeader && match.status === 'available' && (
+                                <>
+                                    <Button asChild variant="outline">
+                                        <Link href={matches.edit(match.id).url}>
+                                            <Edit className="mr-2 h-4 w-4" />
+                                            Editar
+                                        </Link>
+                                    </Button>
+                                    <Button
+                                        variant="destructive"
+                                        onClick={onCancelClick}
+                                    >
+                                        <X className="mr-2 h-4 w-4" />
+                                        Cancelar Partido
+                                    </Button>
+                                </>
                             )}
-                    </div>
+                            {isLeader && match.status === 'in_progress' && (
+                                <Button
+                                    onClick={onCompleteClick}
+                                    disabled={!matchHasStarted}
+                                    title={
+                                        !matchHasStarted
+                                            ? 'No se puede completar el partido antes de que comience'
+                                            : ''
+                                    }
+                                >
+                                    <Trophy className="mr-2 h-4 w-4" />
+                                    Completar Partido
+                                </Button>
+                            )}
+                            {!isLeader &&
+                                match.status === 'available' &&
+                                eligibleTeams.length > 0 && (
+                                    <CreateMatchRequestDialog
+                                        matchId={match.id}
+                                        eligibleTeams={eligibleTeams}
+                                    />
+                                )}
+                        </div>
+                    ) : null}
 
                     {!isLeader &&
                         match.tournament_id != null &&
                         (match.status === 'confirmed' ||
                             match.status === 'in_progress' ||
                             match.status === 'completed') && (
-                            <p className="mt-4 text-center text-sm text-muted-foreground">
-                                Solo el organizador del torneo puede gestionar
-                                el resultado de este partido.
+                            <p className="text-center text-sm text-muted-foreground">
+                                Solo el organizador del torneo puede gestionar el
+                                resultado de este partido.
                             </p>
                         )}
                 </div>

--- a/resources/js/components/match/match-hero.tsx
+++ b/resources/js/components/match/match-hero.tsx
@@ -357,8 +357,8 @@ export function MatchHero({
                             match.status === 'in_progress' ||
                             match.status === 'completed') && (
                             <p className="text-center text-sm text-muted-foreground">
-                                Solo el organizador del torneo puede gestionar el
-                                resultado de este partido.
+                                Solo el organizador del torneo puede gestionar
+                                el resultado de este partido.
                             </p>
                         )}
                 </div>


### PR DESCRIPTION
Follow-up to #151 (which is already merged). That PR rebalanced the match page and added the timeline; this one fixes the hero itself.

## Why

The hero used `grid-cols-[1fr,auto,1fr]` — **commas make it invalid CSS**, so Tailwind dropped the class and the 3-column grid never applied. The teams collapsed into a stacked layout rendered *diagonally* (home aligned right/top, away left/bottom), the home team ended up on the right, and the banner consumed most of the viewport.

<img width="600" alt="before" src="https://github.com/user-attachments/assets/placeholder" />

## What

Rebuild the hero as a compact horizontal scoreboard:

- **Local team on the left, Visitante on the right**, crests flanking the score on a single `items-center` line — valid `grid-cols-[1fr_auto_1fr]`, so both teams sit on the same horizontal baseline (no more diagonal).
- Symmetric composition: home is `justify-end` (crest → name), away `justify-start` (name → crest); crests anchor the outer edges, names hug the score.
- **Compacted** ~in half: padding `p-6/p-8 → p-4/p-5`, crests `h-20 → h-12/h-16`, slimmer inline score block, one decorative blob instead of two, and the date/time/location row now sits on a top divider.
- Goal scorers move to a symmetric row beneath the scoreboard, preserving the leader record/delete affordances and the pre-kickoff countdown pill.

No backend or route changes.

## Verification

- ✅ `bun run types` (hero file clean; remaining errors are pre-existing Wayfinder `.form()` issues), `bun run lint`, `bun run build` (4110 modules, no errors)
- ⚠️ No live browser walkthrough (no browser tool in the authoring env; dev DB empty). Reviewer should eyeball desktop + mobile — the 3-column scoreboard on narrow widths is the main thing to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)