### PR TITLE
feat: full-width, broadcast-style match detail layout

### DIFF
--- a/resources/js/components/match/match-hero.tsx
+++ b/resources/js/components/match/match-hero.tsx
@@ -79,10 +79,11 @@ export function MatchHero({
 
     return (
         <>
-            <div className="relative overflow-hidden rounded-xl border bg-gradient-to-br from-background via-background to-muted/20 p-4 md:p-5">
-                <div className="absolute top-0 right-0 -mt-16 -mr-16 h-48 w-48 rounded-full bg-primary/5 blur-3xl" />
+            <div className="relative overflow-hidden rounded-2xl border bg-gradient-to-br from-background via-background to-muted/20 p-5 md:p-8">
+                <div className="absolute top-0 right-0 -mt-16 -mr-16 h-56 w-56 rounded-full bg-primary/5 blur-3xl" />
+                <div className="absolute bottom-0 left-0 -mb-16 -ml-16 h-56 w-56 rounded-full bg-primary/5 blur-3xl" />
 
-                <div className="relative space-y-4">
+                <div className="relative space-y-6">
                     {/* Status badges */}
                     <div className="flex flex-wrap items-center gap-2">
                         <Badge className={getMatchStatusColor(match.status)}>
@@ -91,32 +92,32 @@ export function MatchHero({
                         <VariantBadge variant={match.variant} />
                     </div>
 
-                    {/* Scoreboard — home (local) left, away (visitante) right */}
-                    <div className="mx-auto grid w-full max-w-2xl grid-cols-[1fr_auto_1fr] items-center gap-2 md:gap-4">
-                        {/* Home team */}
+                    {/* Scoreboard — broadcast style: teams flank the score across the full width */}
+                    <div className="mx-auto grid w-full max-w-5xl grid-cols-1 items-center gap-5 md:grid-cols-[1fr_auto_1fr] md:gap-8">
+                        {/* Home team (local) — left edge */}
                         <Link
                             href={`/teams/${match.home_team.id}`}
-                            className="group flex items-center justify-end gap-2.5 rounded-lg p-1.5 transition-colors hover:bg-muted/50 md:gap-3"
+                            className="group flex items-center justify-center gap-3 rounded-xl p-2 transition-colors hover:bg-muted/50 md:justify-start md:gap-4"
                         >
                             <TeamAvatar
                                 name={match.home_team.name}
                                 logoUrl={match.home_team.logo_url}
-                                size="lg"
-                                className="h-12 w-12 shrink-0 md:h-16 md:w-16"
+                                size="xl"
+                                className="h-16 w-16 shrink-0 md:h-20 md:w-20"
                             />
-                            <div className="min-w-0 text-right">
-                                <h2 className="truncate text-base font-bold md:text-xl">
+                            <div className="min-w-0 text-center md:text-left">
+                                <h2 className="truncate text-xl font-bold md:text-2xl">
                                     {match.home_team.name}
                                 </h2>
-                                <div className="flex items-center justify-end gap-1 text-muted-foreground">
+                                <div className="flex items-center justify-center gap-1 text-muted-foreground md:justify-start">
                                     <Shield className="h-3.5 w-3.5" />
                                     <p className="text-xs md:text-sm">Local</p>
                                 </div>
                             </div>
                         </Link>
 
-                        {/* Score / countdown / placeholder */}
-                        <div className="flex flex-col items-center gap-1.5">
+                        {/* Score / countdown / placeholder — center */}
+                        <div className="flex flex-col items-center gap-2">
                             {showScore ? (
                                 <>
                                     {!matchHasStarted &&
@@ -130,7 +131,7 @@ export function MatchHero({
                                             </div>
                                         )}
 
-                                    <div className="flex items-center gap-1.5 rounded-xl border bg-card/80 px-3 py-2 shadow-sm backdrop-blur-sm md:gap-2">
+                                    <div className="flex items-center gap-2 rounded-2xl border bg-card/80 px-4 py-2.5 shadow-sm backdrop-blur-sm md:gap-3 md:px-6">
                                         {canRecord(isHomeLeader) && (
                                             <Button
                                                 variant="ghost"
@@ -149,7 +150,7 @@ export function MatchHero({
                                         )}
                                         <span
                                             className={cn(
-                                                'w-9 text-center text-3xl font-bold tabular-nums md:w-10',
+                                                'w-10 text-center text-4xl font-bold tabular-nums md:w-12 md:text-5xl',
                                                 match.status === 'completed' &&
                                                     homeScore > awayScore &&
                                                     'text-primary',
@@ -157,12 +158,12 @@ export function MatchHero({
                                         >
                                             {homeScore}
                                         </span>
-                                        <span className="text-lg font-bold text-muted-foreground">
+                                        <span className="text-xl font-bold text-muted-foreground md:text-2xl">
                                             -
                                         </span>
                                         <span
                                             className={cn(
-                                                'w-9 text-center text-3xl font-bold tabular-nums md:w-10',
+                                                'w-10 text-center text-4xl font-bold tabular-nums md:w-12 md:text-5xl',
                                                 match.status === 'completed' &&
                                                     awayScore > homeScore &&
                                                     'text-primary',
@@ -189,23 +190,23 @@ export function MatchHero({
                                     </div>
                                 </>
                             ) : (
-                                <div className="rounded-full border bg-card p-3 shadow-sm">
-                                    <Swords className="h-6 w-6 text-muted-foreground" />
+                                <div className="rounded-full border bg-card p-4 shadow-sm">
+                                    <Swords className="h-7 w-7 text-muted-foreground" />
                                 </div>
                             )}
                         </div>
 
-                        {/* Away team */}
+                        {/* Away team (visitante) — right edge */}
                         {match.away_team ? (
                             <Link
                                 href={`/teams/${match.away_team.id}`}
-                                className="group flex items-center justify-start gap-2.5 rounded-lg p-1.5 transition-colors hover:bg-muted/50 md:gap-3"
+                                className="group flex items-center justify-center gap-3 rounded-xl p-2 transition-colors hover:bg-muted/50 md:justify-end md:gap-4"
                             >
-                                <div className="min-w-0 text-left">
-                                    <h2 className="truncate text-base font-bold md:text-xl">
+                                <div className="min-w-0 text-center md:text-right">
+                                    <h2 className="truncate text-xl font-bold md:text-2xl">
                                         {match.away_team.name}
                                     </h2>
-                                    <div className="flex items-center gap-1 text-muted-foreground">
+                                    <div className="flex items-center justify-center gap-1 text-muted-foreground md:justify-end">
                                         <Plane className="h-3.5 w-3.5" />
                                         <p className="text-xs md:text-sm">
                                             Visitante
@@ -215,22 +216,22 @@ export function MatchHero({
                                 <TeamAvatar
                                     name={match.away_team.name}
                                     logoUrl={match.away_team.logo_url}
-                                    size="lg"
-                                    className="h-12 w-12 shrink-0 md:h-16 md:w-16"
+                                    size="xl"
+                                    className="h-16 w-16 shrink-0 md:h-20 md:w-20"
                                 />
                             </Link>
                         ) : (
-                            <div className="flex items-center justify-start gap-2.5 rounded-lg border border-dashed bg-muted/30 p-2 md:gap-3">
-                                <div className="min-w-0">
-                                    <h3 className="truncate text-sm font-semibold">
+                            <div className="flex items-center justify-center gap-3 rounded-xl border border-dashed bg-muted/30 p-3 md:justify-end md:gap-4">
+                                <div className="min-w-0 text-center md:text-right">
+                                    <h3 className="truncate text-base font-semibold">
                                         Buscando rival
                                     </h3>
                                     <p className="truncate text-xs text-muted-foreground">
                                         Esperando solicitudes
                                     </p>
                                 </div>
-                                <div className="rounded-full bg-muted p-2.5">
-                                    <Users className="h-6 w-6 text-muted-foreground" />
+                                <div className="rounded-full bg-muted p-3">
+                                    <Users className="h-7 w-7 text-muted-foreground" />
                                 </div>
                             </div>
                         )}

--- a/resources/js/pages/matches/show.tsx
+++ b/resources/js/pages/matches/show.tsx
@@ -36,7 +36,6 @@ import {
     CardTitle,
 } from '@/components/ui/card';
 import AppLayout from '@/layouts/app-layout';
-import { cn } from '@/lib/utils';
 import matchRequests from '@/routes/match-requests';
 import matches from '@/routes/matches';
 import type {
@@ -183,11 +182,14 @@ export default function Show({
     const takesAvailability =
         match.status === 'available' || match.status === 'confirmed';
 
-    // Whether the sidebar rail will hold anything. When it won't (e.g. a
-    // completed match viewed by a non-leader) we drop the reserved column and
-    // center the narrative instead of leaving a third of the page empty.
+    const lineupsPresent =
+        isConfirmedOrLater && (homeLineup.length > 0 || awayLineup.length > 0);
+
+    // Whether the right column will hold anything. When it won't we let the
+    // narrative span the full width instead of leaving an empty half.
     const hasAside =
         (takesAvailability && userTeamId != null) ||
+        lineupsPresent ||
         (isLeader && isConfirmedOrLater);
 
     const mainContent = (
@@ -248,18 +250,6 @@ export default function Show({
                     ) : null}
                 </Deferred>
             )}
-
-            {isConfirmedOrLater &&
-                (homeLineup.length > 0 || awayLineup.length > 0) && (
-                    <MatchLineups
-                        homeTeamName={match.home_team.name}
-                        awayTeamName={match.away_team?.name}
-                        homeTeamLogoUrl={match.home_team.logo_url}
-                        awayTeamLogoUrl={match.away_team?.logo_url}
-                        homeLineup={homeLineup}
-                        awayLineup={awayLineup}
-                    />
-                )}
         </>
     );
 
@@ -269,6 +259,17 @@ export default function Show({
                 <AvailabilitySelector
                     matchId={match.id}
                     currentStatus={userAvailability ?? undefined}
+                />
+            )}
+
+            {lineupsPresent && (
+                <MatchLineups
+                    homeTeamName={match.home_team.name}
+                    awayTeamName={match.away_team?.name}
+                    homeTeamLogoUrl={match.home_team.logo_url}
+                    awayTeamLogoUrl={match.away_team?.logo_url}
+                    homeLineup={homeLineup}
+                    awayLineup={awayLineup}
                 />
             )}
 
@@ -339,12 +340,7 @@ export default function Show({
                 title={`${match.home_team.name}${match.away_team ? ` vs ${match.away_team.name}` : ''}`}
             />
 
-            <div
-                className={cn(
-                    'mx-auto flex w-full flex-1 flex-col gap-6 p-4 md:p-6',
-                    hasAside ? 'max-w-6xl' : 'max-w-3xl',
-                )}
-            >
+            <div className="mx-auto flex w-full max-w-screen-2xl flex-1 flex-col gap-6 p-4 md:p-6">
                 <MatchHero
                     match={match}
                     isHomeLeader={isHomeLeader}
@@ -358,10 +354,8 @@ export default function Show({
                 />
 
                 {hasAside ? (
-                    <div className="grid gap-6 lg:grid-cols-3">
-                        <div className="space-y-6 lg:col-span-2">
-                            {mainContent}
-                        </div>
+                    <div className="grid items-start gap-6 lg:grid-cols-2">
+                        <div className="space-y-6">{mainContent}</div>
                         <div className="space-y-6">{asideContent}</div>
                     </div>
                 ) : (


### PR DESCRIPTION
Reworks the match detail page (`matches/show.tsx`) to use the full available width with a professional, balanced layout — reversing the narrow `max-w-3xl` cap from #153 that left large empty margins on wide screens.

## What

- **`show.tsx` — full-width, two-column layout.** Container widened to `max-w-screen-2xl`; content laid out in two balanced columns (`lg:grid-cols-2`) that fill the width. Lineups moved into the right column so a completed match shows **timeline and lineups side by side** instead of a single lone card. Falls back to a single full-width column when the right column has nothing to show.
- **`match-hero.tsx` — broadcast-style scoreboard.** Teams pushed to the edges flanking a larger centered score (bigger crests, `text-2xl` names, `text-5xl` score, roomier padding, `rounded-2xl`). The scoreboard content spreads to `max-w-5xl` while the hero band itself spans the full width, so it reads as a premium match header without a sparse center on ultrawide.

No backend, route, or Wayfinder changes.

## Verification

- ✅ `bun run types` (touched files clean; pre-existing Wayfinder `.form()` errors unrelated), `bun run lint`, `bun run format:check`, `bun run build` (no errors)
- ⚠️ No live browser walkthrough (no browser tool in the authoring env; dev DB empty). Reviewer should eyeball at a wide viewport: the completed match (hero broadcast header + timeline/lineups side by side filling width), a leader on confirmed/in_progress (availability + right-column tools), and mobile (columns stack, hero centers, no horizontal scroll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)