### PR TITLE
feat: polish tournament detail layout and UX

### DIFF
--- a/resources/js/components/tournament/standings-table.tsx
+++ b/resources/js/components/tournament/standings-table.tsx
@@ -1,6 +1,7 @@
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { cn } from '@/lib/utils';
 import type { StandingRow } from '@/types';
+import { Crown } from 'lucide-react';
 
 interface Props {
     rows: StandingRow[];
@@ -15,8 +16,11 @@ export function StandingsTable({
     title,
     className,
 }: Props) {
+    const showQualification =
+        highlightTopN !== undefined && highlightTopN > 0 && rows.length > 0;
+
     return (
-        <div className={cn('overflow-hidden rounded-md border', className)}>
+        <div className={cn('overflow-hidden rounded-xl border', className)}>
             {title && (
                 <div className="border-b bg-muted/40 px-4 py-2 text-sm font-semibold">
                     {title}
@@ -25,27 +29,35 @@ export function StandingsTable({
             <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                     <thead>
-                        <tr className="bg-muted/40 text-xs text-muted-foreground uppercase">
-                            <th className="px-3 py-2 text-left">#</th>
-                            <th className="px-3 py-2 text-left">Equipo</th>
-                            <th className="px-2 py-2 text-center">PJ</th>
-                            <th className="hidden px-2 py-2 text-center sm:table-cell">
+                        <tr className="text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
+                            <th className="py-2.5 pr-2 pl-4 text-center font-medium">
+                                #
+                            </th>
+                            <th className="px-2 py-2.5 text-left font-medium">
+                                Equipo
+                            </th>
+                            <th className="w-9 px-1 py-2.5 text-center font-medium">
+                                PJ
+                            </th>
+                            <th className="hidden w-9 px-1 py-2.5 text-center font-medium sm:table-cell">
                                 G
                             </th>
-                            <th className="hidden px-2 py-2 text-center sm:table-cell">
+                            <th className="hidden w-9 px-1 py-2.5 text-center font-medium sm:table-cell">
                                 E
                             </th>
-                            <th className="hidden px-2 py-2 text-center sm:table-cell">
+                            <th className="hidden w-9 px-1 py-2.5 text-center font-medium sm:table-cell">
                                 P
                             </th>
-                            <th className="hidden px-2 py-2 text-center md:table-cell">
+                            <th className="hidden w-9 px-1 py-2.5 text-center font-medium md:table-cell">
                                 GF
                             </th>
-                            <th className="hidden px-2 py-2 text-center md:table-cell">
+                            <th className="hidden w-9 px-1 py-2.5 text-center font-medium md:table-cell">
                                 GC
                             </th>
-                            <th className="px-2 py-2 text-center">DG</th>
-                            <th className="px-3 py-2 text-center font-semibold">
+                            <th className="w-11 px-1 py-2.5 text-center font-medium">
+                                DG
+                            </th>
+                            <th className="w-12 py-2.5 pr-4 pl-1 text-center font-semibold text-foreground">
                                 Pts
                             </th>
                         </tr>
@@ -65,71 +77,100 @@ export function StandingsTable({
                             const highlighted =
                                 highlightTopN !== undefined &&
                                 row.position <= highlightTopN;
+                            const isLeader = row.position === 1;
                             return (
                                 <tr
                                     key={row.team_id}
                                     className={cn(
-                                        'border-t',
-                                        highlighted && 'bg-emerald-500/5',
-                                        row.tied_with_above && 'border-dashed',
+                                        'group border-t border-border/60 transition-colors hover:bg-muted/40',
+                                        highlighted && 'bg-primary/[0.04]',
+                                        row.tied_with_above &&
+                                            'border-t-dashed border-t-border',
                                     )}
                                 >
-                                    <td className="px-3 py-2 text-left font-medium tabular-nums">
-                                        {row.position}
+                                    <td className="relative py-2.5 pr-2 pl-4 text-center">
+                                        {highlighted && (
+                                            <span
+                                                aria-hidden
+                                                className="absolute inset-y-0 left-0 w-[3px] rounded-r bg-primary"
+                                            />
+                                        )}
+                                        <span
+                                            className={cn(
+                                                'inline-flex size-6 items-center justify-center rounded-md text-xs font-semibold tabular-nums',
+                                                isLeader
+                                                    ? 'bg-primary/15 text-primary'
+                                                    : 'text-muted-foreground',
+                                            )}
+                                        >
+                                            {row.position}
+                                        </span>
                                     </td>
-                                    <td className="px-3 py-2 text-left">
-                                        <div className="flex items-center gap-2">
-                                            <Avatar className="size-6">
+                                    <td className="px-2 py-2.5 text-left">
+                                        <div className="flex items-center gap-2.5">
+                                            <Avatar className="size-7 shrink-0">
                                                 {row.team?.logo_url && (
                                                     <AvatarImage
                                                         src={row.team.logo_url}
                                                         alt={row.team?.name}
                                                     />
                                                 )}
-                                                <AvatarFallback className="text-[10px]">
+                                                <AvatarFallback className="bg-primary/10 text-[10px] font-semibold text-primary">
                                                     {row.team?.name
                                                         ?.slice(0, 2)
                                                         .toUpperCase() ?? '?'}
                                                 </AvatarFallback>
                                             </Avatar>
-                                            <span className="truncate">
+                                            <span
+                                                className={cn(
+                                                    'truncate',
+                                                    isLeader
+                                                        ? 'font-semibold'
+                                                        : 'font-medium',
+                                                )}
+                                            >
                                                 {row.team?.name ??
                                                     `Team ${row.team_id}`}
                                             </span>
+                                            {isLeader && (
+                                                <Crown className="size-3.5 shrink-0 text-amber-400" />
+                                            )}
                                         </div>
                                     </td>
-                                    <td className="px-2 py-2 text-center tabular-nums">
+                                    <td className="px-1 py-2.5 text-center tabular-nums">
                                         {row.played}
                                     </td>
-                                    <td className="hidden px-2 py-2 text-center tabular-nums sm:table-cell">
+                                    <td className="hidden px-1 py-2.5 text-center tabular-nums sm:table-cell">
                                         {row.wins}
                                     </td>
-                                    <td className="hidden px-2 py-2 text-center tabular-nums sm:table-cell">
+                                    <td className="hidden px-1 py-2.5 text-center tabular-nums sm:table-cell">
                                         {row.draws}
                                     </td>
-                                    <td className="hidden px-2 py-2 text-center tabular-nums sm:table-cell">
+                                    <td className="hidden px-1 py-2.5 text-center tabular-nums sm:table-cell">
                                         {row.losses}
                                     </td>
-                                    <td className="hidden px-2 py-2 text-center tabular-nums md:table-cell">
+                                    <td className="hidden px-1 py-2.5 text-center tabular-nums md:table-cell">
                                         {row.goals_for}
                                     </td>
-                                    <td className="hidden px-2 py-2 text-center tabular-nums md:table-cell">
+                                    <td className="hidden px-1 py-2.5 text-center tabular-nums md:table-cell">
                                         {row.goals_against}
                                     </td>
                                     <td
                                         className={cn(
-                                            'px-2 py-2 text-center tabular-nums',
+                                            'px-1 py-2.5 text-center font-medium tabular-nums',
                                             row.goal_difference > 0 &&
-                                                'text-emerald-600',
+                                                'text-emerald-500',
                                             row.goal_difference < 0 &&
-                                                'text-rose-600',
+                                                'text-rose-500',
+                                            row.goal_difference === 0 &&
+                                                'text-muted-foreground',
                                         )}
                                     >
                                         {row.goal_difference > 0
                                             ? `+${row.goal_difference}`
                                             : row.goal_difference}
                                     </td>
-                                    <td className="px-3 py-2 text-center font-semibold tabular-nums">
+                                    <td className="py-2.5 pr-4 pl-1 text-center text-[15px] font-bold tabular-nums">
                                         {row.points}
                                     </td>
                                 </tr>
@@ -138,6 +179,14 @@ export function StandingsTable({
                     </tbody>
                 </table>
             </div>
+            {showQualification && (
+                <div className="flex items-center gap-2 border-t bg-muted/20 px-4 py-2 text-[11px] text-muted-foreground">
+                    <span className="inline-block h-2.5 w-[3px] rounded-full bg-primary" />
+                    {highlightTopN === 1
+                        ? 'Puesto de campeón'
+                        : `Zona de clasificación (top ${highlightTopN})`}
+                </div>
+            )}
         </div>
     );
 }

--- a/resources/js/pages/tournaments/show.tsx
+++ b/resources/js/pages/tournaments/show.tsx
@@ -108,6 +108,128 @@ const teamStatusConfig: Record<
     withdrawn: { label: 'Retirado', variant: 'outline' },
 };
 
+function StatTile({
+    icon: Icon,
+    label,
+    children,
+}: {
+    icon: React.ComponentType<{ className?: string }>;
+    label: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <div className="rounded-xl border border-border bg-card p-4 transition-colors hover:border-border/80">
+            <div className="mb-2.5 flex items-center gap-2">
+                <span className="flex size-6 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                    <Icon className="size-3.5" />
+                </span>
+                <span className="text-[11px] font-medium tracking-wide text-muted-foreground uppercase">
+                    {label}
+                </span>
+            </div>
+            {children}
+        </div>
+    );
+}
+
+function MatchSide({
+    team,
+    align,
+}: {
+    team?: Team | null;
+    align: 'start' | 'end';
+}) {
+    const name = team?.name ?? 'Por definir';
+    return (
+        <div
+            className={cn(
+                'flex min-w-0 flex-1 items-center gap-2.5',
+                align === 'end' && 'flex-row-reverse text-right',
+            )}
+        >
+            {team ? (
+                <TeamAvatar
+                    name={name}
+                    logoUrl={team.logo_url}
+                    size="sm"
+                    className="size-8 shrink-0"
+                />
+            ) : (
+                <span className="flex size-8 shrink-0 items-center justify-center rounded-full border border-dashed text-muted-foreground">
+                    <Users className="size-3.5" />
+                </span>
+            )}
+            <span
+                className={cn(
+                    'truncate text-sm font-medium',
+                    !team && 'text-muted-foreground',
+                )}
+            >
+                {name}
+            </span>
+        </div>
+    );
+}
+
+function ScheduleMatchRow({
+    match,
+    canEdit,
+    onSchedule,
+}: {
+    match: FootballMatch;
+    canEdit: boolean;
+    onSchedule: () => void;
+}) {
+    const scheduled = Boolean(match.scheduled_at);
+    return (
+        <div
+            className={cn(
+                'rounded-xl border bg-card/40 p-3.5 transition-colors',
+                canEdit && 'hover:border-primary/30 hover:bg-muted/20',
+            )}
+        >
+            <div className="flex items-center gap-3">
+                <MatchSide team={match.home_team} align="start" />
+                <span className="shrink-0 rounded-md bg-muted px-2 py-0.5 text-[11px] font-semibold tracking-wide text-muted-foreground uppercase">
+                    vs
+                </span>
+                <MatchSide team={match.away_team} align="end" />
+            </div>
+
+            <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-border/50 pt-3">
+                <span
+                    className={cn(
+                        'inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs',
+                        scheduled
+                            ? 'bg-muted/60 text-foreground'
+                            : 'bg-amber-500/10 text-amber-500',
+                    )}
+                >
+                    <CalendarClock className="size-3.5" />
+                    {scheduled
+                        ? formatScheduledAt(match.scheduled_at)
+                        : 'Sin programar'}
+                </span>
+                <span className="inline-flex items-center gap-1.5 rounded-md bg-muted/60 px-2 py-1 text-xs text-muted-foreground">
+                    <MapPin className="size-3.5" />
+                    {match.location ?? 'Por definir'}
+                </span>
+                {canEdit && (
+                    <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={onSchedule}
+                        className="ml-auto h-7 gap-1.5 px-2.5 text-xs"
+                    >
+                        <Pencil className="size-3.5" />
+                        {scheduled ? 'Editar' : 'Programar'}
+                    </Button>
+                )}
+            </div>
+        </div>
+    );
+}
+
 function SidebarLabel({
     label,
     children,
@@ -338,21 +460,19 @@ export default function TournamentShow({
 
                 {/* Stat strip */}
                 <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-                    <div className="rounded-xl border border-border bg-card p-4">
-                        <div className="flex items-center justify-between text-xs text-muted-foreground">
-                            <span className="flex items-center gap-1.5">
-                                <Users className="size-3.5" />
-                                Equipos
+                    <StatTile icon={Users} label="Equipos">
+                        <div className="flex items-baseline gap-1">
+                            <span className="text-2xl leading-none font-bold tracking-tight tabular-nums">
+                                {approvedTeams.length}
                             </span>
-                            <span>mín. {tournament.min_teams}</span>
+                            <span className="text-sm font-medium text-muted-foreground">
+                                / {tournament.max_teams}
+                            </span>
+                            <span className="ml-auto text-[11px] text-muted-foreground">
+                                mín. {tournament.min_teams}
+                            </span>
                         </div>
-                        <p className="mt-1 text-2xl font-bold tracking-tight tabular-nums">
-                            {approvedTeams.length}
-                            <span className="text-base font-medium text-muted-foreground">
-                                /{tournament.max_teams}
-                            </span>
-                        </p>
-                        <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                        <div className="mt-2.5 h-1.5 w-full overflow-hidden rounded-full bg-muted">
                             <div
                                 className={cn(
                                     'h-full rounded-full transition-all duration-500',
@@ -376,34 +496,28 @@ export default function TournamentShow({
                                 }}
                             />
                         </div>
-                    </div>
+                    </StatTile>
 
-                    <div className="rounded-xl border border-border bg-card p-4">
-                        <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                            <Trophy className="size-3.5" />
-                            Formato
-                        </p>
-                        <p className="mt-1 text-lg font-semibold tracking-tight">
+                    <StatTile icon={Trophy} label="Formato">
+                        <p className="truncate text-lg leading-tight font-semibold tracking-tight">
                             {tournamentFormatLabel(tournament.format)}
                         </p>
-                    </div>
+                    </StatTile>
 
-                    <div className="rounded-xl border border-border bg-card p-4">
-                        <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                            <Info className="size-3.5" />
-                            Estado
-                        </p>
-                        <p className="mt-1 text-lg font-semibold tracking-tight">
+                    <StatTile icon={Info} label="Estado">
+                        <p className="flex items-center gap-2 text-lg leading-tight font-semibold tracking-tight">
+                            {tournament.status === 'in_progress' && (
+                                <span className="relative flex size-2">
+                                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary/70" />
+                                    <span className="relative inline-flex size-2 rounded-full bg-primary" />
+                                </span>
+                            )}
                             {tournamentStatusMeta(tournament).label}
                         </p>
-                    </div>
+                    </StatTile>
 
-                    <div className="rounded-xl border border-border bg-card p-4">
-                        <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                            <CalendarClock className="size-3.5" />
-                            Inicio
-                        </p>
-                        <p className="mt-1 text-lg font-semibold tracking-tight">
+                    <StatTile icon={CalendarClock} label="Inicio">
+                        <p className="text-lg leading-tight font-semibold tracking-tight">
                             {tournament.starts_at
                                 ? formatDate(tournament.starts_at, {
                                       day: 'numeric',
@@ -412,7 +526,7 @@ export default function TournamentShow({
                                   })
                                 : 'Por definir'}
                         </p>
-                    </div>
+                    </StatTile>
                 </div>
 
                 <div className="grid items-start gap-6 xl:grid-cols-[minmax(0,1fr)_22rem] 2xl:grid-cols-[minmax(0,1fr)_24rem]">
@@ -550,15 +664,26 @@ export default function TournamentShow({
                                                 : 'Fechas y canchas confirmadas por el organizador.'}
                                         </CardDescription>
                                     </CardHeader>
-                                    <CardContent className="space-y-5">
+                                    <CardContent className="space-y-6">
                                         {tournament.rounds.map((round) => (
                                             <div
                                                 key={round.id}
-                                                className="space-y-2.5"
+                                                className="space-y-3"
                                             >
-                                                <h3 className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
-                                                    {round.name}
-                                                </h3>
+                                                <div className="flex items-center gap-3">
+                                                    <h3 className="text-xs font-semibold tracking-[0.12em] text-muted-foreground uppercase">
+                                                        {round.name}
+                                                    </h3>
+                                                    <span className="h-px flex-1 bg-border/60" />
+                                                    <span className="text-[11px] text-muted-foreground tabular-nums">
+                                                        {round.matches
+                                                            ?.length ?? 0}{' '}
+                                                        {(round.matches
+                                                            ?.length ?? 0) === 1
+                                                            ? 'partido'
+                                                            : 'partidos'}
+                                                    </span>
+                                                </div>
                                                 <div className="space-y-2">
                                                     {(round.matches?.length ??
                                                         0) === 0 ? (
@@ -568,16 +693,6 @@ export default function TournamentShow({
                                                     ) : (
                                                         round.matches!.map(
                                                             (match) => {
-                                                                const home =
-                                                                    match
-                                                                        .home_team
-                                                                        ?.name ??
-                                                                    'Por definir';
-                                                                const away =
-                                                                    match
-                                                                        .away_team
-                                                                        ?.name ??
-                                                                    'Por definir';
                                                                 const isLocked =
                                                                     match.status ===
                                                                         'in_progress' ||
@@ -587,70 +702,22 @@ export default function TournamentShow({
                                                                     permissions.canScheduleMatches &&
                                                                     !isLocked;
                                                                 return (
-                                                                    <div
+                                                                    <ScheduleMatchRow
                                                                         key={
                                                                             match.id
                                                                         }
-                                                                        className={cn(
-                                                                            'flex flex-col gap-3 rounded-lg border bg-card/40 p-3 transition-colors sm:flex-row sm:items-center sm:justify-between',
-                                                                            canEditMatch &&
-                                                                                'hover:border-primary/30 hover:bg-muted/20',
-                                                                        )}
-                                                                    >
-                                                                        <div className="min-w-0 flex-1">
-                                                                            <p className="truncate text-sm font-medium">
-                                                                                {
-                                                                                    home
-                                                                                }{' '}
-                                                                                <span className="text-muted-foreground">
-                                                                                    vs
-                                                                                </span>{' '}
-                                                                                {
-                                                                                    away
-                                                                                }
-                                                                            </p>
-                                                                            <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-                                                                                <span className="flex items-center gap-1">
-                                                                                    <CalendarClock className="size-3.5" />
-                                                                                    {match.scheduled_at ? (
-                                                                                        formatScheduledAt(
-                                                                                            match.scheduled_at,
-                                                                                        )
-                                                                                    ) : (
-                                                                                        <Badge
-                                                                                            variant="outline"
-                                                                                            className="font-normal"
-                                                                                        >
-                                                                                            Sin
-                                                                                            programar
-                                                                                        </Badge>
-                                                                                    )}
-                                                                                </span>
-                                                                                <span className="flex items-center gap-1">
-                                                                                    <MapPin className="size-3.5" />
-                                                                                    {match.location ??
-                                                                                        'Por definir'}
-                                                                                </span>
-                                                                            </div>
-                                                                        </div>
-                                                                        {canEditMatch && (
-                                                                            <Button
-                                                                                size="sm"
-                                                                                variant="outline"
-                                                                                onClick={() =>
-                                                                                    setScheduleMatch(
-                                                                                        match,
-                                                                                    )
-                                                                                }
-                                                                                className="w-full gap-1.5 sm:w-auto"
-                                                                            >
-                                                                                <Pencil className="size-3.5" />
-                                                                                {match.scheduled_at
-                                                                                    ? 'Editar'
-                                                                                    : 'Programar'}
-                                                                            </Button>
-                                                                        )}
-                                                                    </div>
+                                                                        match={
+                                                                            match
+                                                                        }
+                                                                        canEdit={
+                                                                            canEditMatch
+                                                                        }
+                                                                        onSchedule={() =>
+                                                                            setScheduleMatch(
+                                                                                match,
+                                                                            )
+                                                                        }
+                                                                    />
                                                                 );
                                                             },
                                                         )
@@ -804,7 +871,7 @@ export default function TournamentShow({
                                             return (
                                                 <div
                                                     key={tt.id}
-                                                    className="flex items-center gap-3 rounded-lg border p-3"
+                                                    className="flex items-center gap-3 rounded-xl border bg-card/40 p-3 transition-colors hover:border-primary/30 hover:bg-muted/20"
                                                 >
                                                     <TeamAvatar
                                                         name={team.name}


### PR DESCRIPTION
## Summary

Refines the **tournament detail page** so its main surfaces read as one cohesive, professional system — agency-grade polish within the existing design language (emerald brand, dark theme, `font-display`, rounded cards). No behavioral changes; presentation only.

### Stat strip
- Unified all four tiles into a single `StatTile` structure (tinted icon chip + uppercase label + value) so they carry equal visual weight, instead of the previous mix where only "Equipos" stood out.
- **Estado** tile shows a live pinging dot when the tournament is `in_progress`.

### Standings table
- Qualification / champion zone now marked with a clean **left accent bar** + subtle row tint and a **legend footer**, replacing the flat full-row wash.
- Ranks sit in badges; the leader gets a tinted rank chip and an amber **crown**.
- Hover rows, larger crests, bolder leader name, stronger **Pts** column, refined GD colors.

### Match schedule
- Rows rebuilt with **team crests** and a symmetric `home — vs — away` layout (proper "vs" pill).
- Date/location become chips; **"Sin programar"** reads as a soft amber chip.
- Round headers gain a divider rule + per-round match count.

### Confirmed teams
- Matched the new `rounded-xl` + hover treatment for consistency.

## Testing
- `bun run types` — clean
- `bun run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)