### PR TITLE
feat: use opaque public IDs in address-bar URLs

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -84,7 +84,7 @@ final class DashboardController extends Controller
             ->withCount('teamMembers')
             ->latest()
             ->limit(3)
-            ->get(['id', 'name', 'variant', 'logo_url', 'max_members']);
+            ->get(['id', 'public_id', 'name', 'variant', 'logo_url', 'max_members']);
 
         // Has the user's team ever published a match? (drives the "next steps" checklist)
         $hasPublishedMatch = $hasTeams

--- a/app/Http/Controllers/MatchController.php
+++ b/app/Http/Controllers/MatchController.php
@@ -100,7 +100,7 @@ final class MatchController extends Controller
                 $validated
             );
 
-            return redirect()->route('matches.show', $match->id)
+            return redirect()->route('matches.show', $match)
                 ->with('success', '¡Disponibilidad de partido creada exitosamente!');
         } catch (\Exception $e) {
             return back()->with('error', $e->getMessage());
@@ -110,9 +110,9 @@ final class MatchController extends Controller
     /**
      * Display the specified match.
      */
-    public function show(int $id): Response
+    public function show(FootballMatch $match): Response
     {
-        $match = $this->matchService->getMatchDetails($id);
+        $match = $this->matchService->getMatchDetails($match->id);
 
         if (! $match) {
             abort(404);
@@ -338,9 +338,9 @@ final class MatchController extends Controller
     /**
      * Show the form for editing the match.
      */
-    public function edit(int $id): Response|RedirectResponse
+    public function edit(FootballMatch $match): Response|RedirectResponse
     {
-        $match = FootballMatch::with(['homeTeam'])->findOrFail($id);
+        $match->load(['homeTeam']);
         $user = Auth::user();
 
         if (! $this->canSchedule($match, $user->id)) {
@@ -348,7 +348,7 @@ final class MatchController extends Controller
         }
 
         if ($match->hasStarted()) {
-            return redirect()->route('matches.show', $match->id)
+            return redirect()->route('matches.show', $match)
                 ->with('error', 'No se puede editar un partido que ya ha comenzado');
         }
 
@@ -379,7 +379,7 @@ final class MatchController extends Controller
         try {
             $match = $this->matchService->updateMatch($match, $validated);
 
-            return redirect()->route('matches.show', $match->id)
+            return redirect()->route('matches.show', $match)
                 ->with('success', '¡Partido actualizado exitosamente!');
         } catch (\Exception $e) {
             return back()->with('error', $e->getMessage());
@@ -521,7 +521,7 @@ final class MatchController extends Controller
         try {
             $this->matchService->completeMatch($match);
 
-            return redirect()->route('matches.show', $match->id)
+            return redirect()->route('matches.show', $match)
                 ->with('success', '¡Partido completado exitosamente!');
         } catch (\Exception $e) {
             return back()->with('error', $e->getMessage());

--- a/app/Http/Controllers/MatchLineupController.php
+++ b/app/Http/Controllers/MatchLineupController.php
@@ -20,14 +20,14 @@ final class MatchLineupController extends Controller
     /**
      * Show the lineup form for a team in a match.
      */
-    public function edit(Request $request, int $matchId): Response
+    public function edit(Request $request, FootballMatch $match): Response
     {
-        $match = FootballMatch::with([
+        $match->load([
             'homeTeam.teamMembers.user',
             'awayTeam.teamMembers.user',
             'tournament',
             'lineups',
-        ])->findOrFail($matchId);
+        ]);
 
         $user = Auth::user();
 

--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -78,16 +78,16 @@ final class TeamController extends Controller
             $this->teamService->updateTeamLogo($team, $request->file('logo'));
         }
 
-        return redirect()->route('teams.show', $team->id)
+        return redirect()->route('teams.show', $team)
             ->with('success', '¡Equipo creado exitosamente!');
     }
 
     /**
      * Display the specified team.
      */
-    public function show(int $id): Response
+    public function show(Team $team): Response
     {
-        $team = $this->teamService->getTeamWithDetails($id);
+        $team = $this->teamService->getTeamWithDetails($team->id);
 
         if (! $team) {
             abort(404);
@@ -153,7 +153,7 @@ final class TeamController extends Controller
             $this->teamService->removeTeamLogo($team);
         }
 
-        return redirect()->route('teams.show', $team->id)
+        return redirect()->route('teams.show', $team)
             ->with('success', '¡Equipo actualizado exitosamente!');
     }
 

--- a/app/Http/Controllers/TeamInvitationController.php
+++ b/app/Http/Controllers/TeamInvitationController.php
@@ -92,7 +92,7 @@ final class TeamInvitationController extends Controller
 
         // If already accepted
         if ($invitation->status === 'accepted') {
-            return redirect()->route('teams.show', $invitation->team_id)
+            return redirect()->route('teams.show', $invitation->team)
                 ->with('info', 'Esta invitación ya fue aceptada');
         }
 
@@ -120,7 +120,7 @@ final class TeamInvitationController extends Controller
                 ->exists();
 
             if ($isMember) {
-                return redirect()->route('teams.show', $invitation->team_id)
+                return redirect()->route('teams.show', $invitation->team)
                     ->with('info', 'Ya eres miembro de este equipo');
             }
 
@@ -176,7 +176,7 @@ final class TeamInvitationController extends Controller
             ->exists();
 
         if ($isMember) {
-            return redirect()->route('teams.show', $invitation->team_id)
+            return redirect()->route('teams.show', $invitation->team)
                 ->with('info', 'Ya eres miembro de este equipo');
         }
 
@@ -184,7 +184,7 @@ final class TeamInvitationController extends Controller
             return back()->with('error', 'El equipo ha alcanzado su capacidad máxima y no puede aceptar más miembros');
         }
 
-        return redirect()->route('teams.show', $invitation->team_id)
+        return redirect()->route('teams.show', $invitation->team)
             ->with('success', '¡Te has unido al equipo exitosamente!');
     }
 

--- a/app/Http/Controllers/TournamentController.php
+++ b/app/Http/Controllers/TournamentController.php
@@ -138,7 +138,7 @@ final class TournamentController extends Controller
                 $this->uploadLogo($tournament, $request->file('logo'));
             }
 
-            return redirect()->route('tournaments.show', $tournament->id)
+            return redirect()->route('tournaments.show', $tournament)
                 ->with('success', 'Torneo creado exitosamente');
         } catch (\Throwable $e) {
             return back()->with('error', $e->getMessage())->withInput();
@@ -148,7 +148,7 @@ final class TournamentController extends Controller
     /**
      * Display the specified tournament.
      */
-    public function show(int $id): Response
+    public function show(Tournament $tournament): Response
     {
         $tournament = Tournament::with([
             'organizer:id,name,avatar_path,google_avatar_url',
@@ -162,7 +162,7 @@ final class TournamentController extends Controller
             ->withCount(['tournamentTeams as registered_teams_count' => function ($query) {
                 $query->whereIn('status', ['pending', 'approved']);
             }])
-            ->findOrFail($id);
+            ->findOrFail($tournament->id);
 
         $this->authorize('view', $tournament);
 
@@ -320,15 +320,13 @@ final class TournamentController extends Controller
     /**
      * Show the form for editing the specified tournament.
      */
-    public function edit(int $id): Response|\Illuminate\Http\RedirectResponse
+    public function edit(Tournament $tournament): Response|\Illuminate\Http\RedirectResponse
     {
-        $tournament = Tournament::findOrFail($id);
-
         $this->authorize('update', $tournament);
 
         if (! $tournament->canBeEdited()) {
             return redirect()
-                ->route('tournaments.show', $tournament->id)
+                ->route('tournaments.show', $tournament)
                 ->with('error', 'Este torneo ya no se puede editar.');
         }
 
@@ -359,7 +357,7 @@ final class TournamentController extends Controller
                 $this->deleteLogo($tournament);
             }
 
-            return redirect()->route('tournaments.show', $tournament->id)
+            return redirect()->route('tournaments.show', $tournament)
                 ->with('success', 'Torneo actualizado exitosamente');
         } catch (\RuntimeException|\InvalidArgumentException $e) {
             throw ValidationException::withMessages([
@@ -406,7 +404,7 @@ final class TournamentController extends Controller
 
         $tournament->update(['status' => 'registration_open']);
 
-        return redirect()->route('tournaments.show', $tournament->id)
+        return redirect()->route('tournaments.show', $tournament)
             ->with('success', 'Inscripción abierta. Los equipos ahora pueden registrarse.');
     }
 
@@ -422,7 +420,7 @@ final class TournamentController extends Controller
         try {
             $this->tournamentService->startTournament($tournament);
 
-            return redirect()->route('tournaments.show', $tournament->id)
+            return redirect()->route('tournaments.show', $tournament)
                 ->with('success', 'Torneo iniciado exitosamente. Se ha generado el bracket.');
         } catch (\RuntimeException|\InvalidArgumentException $e) {
             throw ValidationException::withMessages([
@@ -443,7 +441,7 @@ final class TournamentController extends Controller
         try {
             $this->tournamentService->cancelTournament($tournament);
 
-            return redirect()->route('tournaments.show', $tournament->id)
+            return redirect()->route('tournaments.show', $tournament)
                 ->with('success', 'Torneo cancelado');
         } catch (\Exception $e) {
             return back()->with('error', $e->getMessage());

--- a/app/Http/Controllers/TournamentGroupController.php
+++ b/app/Http/Controllers/TournamentGroupController.php
@@ -72,7 +72,7 @@ final class TournamentGroupController extends Controller
             }
         });
 
-        return redirect()->route('tournaments.show', $tournament->id)
+        return redirect()->route('tournaments.show', $tournament)
             ->with('success', 'Sorteo guardado.');
     }
 
@@ -87,7 +87,7 @@ final class TournamentGroupController extends Controller
         TournamentTeam::where('tournament_id', $tournament->id)
             ->update(['tournament_group_id' => null]);
 
-        return redirect()->route('tournaments.show', $tournament->id)
+        return redirect()->route('tournaments.show', $tournament)
             ->with('success', 'Sorteo reiniciado.');
     }
 }

--- a/app/Http/Controllers/TournamentRegistrationController.php
+++ b/app/Http/Controllers/TournamentRegistrationController.php
@@ -41,7 +41,7 @@ final class TournamentRegistrationController extends Controller
                 ? 'Equipo registrado exitosamente'
                 : 'Solicitud de registro enviada. Esperando aprobación del organizador.';
 
-            return redirect()->route('tournaments.show', $tournament->id)
+            return redirect()->route('tournaments.show', $tournament)
                 ->with('success', $message);
         } catch (\RuntimeException|\InvalidArgumentException $e) {
             \Log::error('Tournament registration failed', [

--- a/app/Models/Concerns/HasPublicId.php
+++ b/app/Models/Concerns/HasPublicId.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Concerns;
+
+/**
+ * Gives a model a short, opaque, non-sequential public identifier used in URLs
+ * instead of the auto-increment primary key. This removes ID enumeration as an
+ * attack/scraping surface and keeps internal foreign keys unchanged.
+ *
+ * The token is a 12-character base62 string (~71 bits of entropy). A unique
+ * index on `public_id` plus regeneration-on-conflict guarantees uniqueness.
+ */
+trait HasPublicId
+{
+    /**
+     * Characters used to build the public id. Base62 is URL-safe and has no
+     * ambiguous separators, so the whole token is a single path segment.
+     */
+    private const PUBLIC_ID_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+    private const PUBLIC_ID_LENGTH = 12;
+
+    protected static function bootHasPublicId(): void
+    {
+        static::creating(function ($model): void {
+            if (empty($model->public_id)) {
+                $model->public_id = $model->generateUniquePublicId();
+            }
+        });
+    }
+
+    /**
+     * Resolve route-model binding by the public id instead of the primary key.
+     */
+    public function getRouteKeyName(): string
+    {
+        return 'public_id';
+    }
+
+    /**
+     * Generate a public id that is not already used by another row.
+     */
+    public function generateUniquePublicId(): string
+    {
+        do {
+            $candidate = static::makePublicId();
+        } while (static::query()->where('public_id', $candidate)->exists());
+
+        return $candidate;
+    }
+
+    /**
+     * Build a random base62 token of the configured length.
+     */
+    public static function makePublicId(): string
+    {
+        $alphabet = self::PUBLIC_ID_ALPHABET;
+        $max = strlen($alphabet) - 1;
+
+        $token = '';
+        for ($i = 0; $i < self::PUBLIC_ID_LENGTH; $i++) {
+            $token .= $alphabet[random_int(0, $max)];
+        }
+
+        return $token;
+    }
+}

--- a/app/Models/FootballMatch.php
+++ b/app/Models/FootballMatch.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -12,6 +13,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 final class FootballMatch extends Model
 {
     use HasFactory;
+    use HasPublicId;
 
     /**
      * The table associated with the model.

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -13,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 final class Team extends Model
 {
     use HasFactory;
+    use HasPublicId;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Models/Tournament.php
+++ b/app/Models/Tournament.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -13,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 final class Tournament extends Model
 {
     use HasFactory;
+    use HasPublicId;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasPublicId;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -13,7 +14,7 @@ use NotificationChannels\WebPush\HasPushSubscriptions;
 class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, HasPushSubscriptions, Notifiable, TwoFactorAuthenticatable;
+    use HasFactory, HasPublicId, HasPushSubscriptions, Notifiable, TwoFactorAuthenticatable;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Notifications/AvailabilityReminderNotification.php
+++ b/app/Notifications/AvailabilityReminderNotification.php
@@ -40,7 +40,7 @@ class AvailabilityReminderNotification extends Notification implements ShouldQue
      */
     public function toMail(object $notifiable): MailMessage
     {
-        $matchUrl = route('matches.show', $this->match->id);
+        $matchUrl = route('matches.show', $this->match);
         $opponent = $this->match->home_team_id === $this->team->id
             ? ($this->match->awayTeam ? $this->match->awayTeam->name : 'A definir')
             : $this->match->homeTeam->name;
@@ -76,7 +76,7 @@ class AvailabilityReminderNotification extends Notification implements ShouldQue
             'type' => 'availability_reminder',
             'title' => 'Confirmá tu disponibilidad',
             'message' => "El partido contra {$opponent} es en 48 horas",
-            'action_url' => route('matches.show', $this->match->id),
+            'action_url' => route('matches.show', $this->match),
             'icon' => 'Clock',
             'related_model' => [
                 'match_id' => $this->match->id,

--- a/app/Notifications/CaptaincyTransferredNotification.php
+++ b/app/Notifications/CaptaincyTransferredNotification.php
@@ -32,7 +32,7 @@ class CaptaincyTransferredNotification extends Notification implements ShouldQue
             'type' => 'captaincy_transferred',
             'title' => "Ahora sos capitán de {$teamName}",
             'message' => "Te transfirieron la capitanía de {$teamName}",
-            'action_url' => route('teams.show', $this->team->id),
+            'action_url' => route('teams.show', $this->team),
             'icon' => 'Crown',
             'related_model' => [
                 'team_id' => $this->team->id,

--- a/app/Notifications/CommendationReceivedNotification.php
+++ b/app/Notifications/CommendationReceivedNotification.php
@@ -53,7 +53,7 @@ class CommendationReceivedNotification extends Notification implements ShouldQue
             ->greeting("¡Hola {$notifiable->name}!")
             ->line("{$this->fromUser->name} te ha reconocido por tu {$categoryName}.")
             ->line('Este reconocimiento se agregó a tu perfil para que otros jugadores puedan verlo.')
-            ->action('Ver Mi Perfil', route('users.show', $notifiable->id))
+            ->action('Ver Mi Perfil', route('users.show', $notifiable))
             ->line('¡Gracias por ser un gran jugador!');
     }
 
@@ -77,7 +77,7 @@ class CommendationReceivedNotification extends Notification implements ShouldQue
             'type' => 'commendation_received',
             'title' => "{$this->fromUser->name} te ha reconocido",
             'message' => "Has recibido un reconocimiento por {$categoryName}",
-            'action_url' => route('users.show', $notifiable->id),
+            'action_url' => route('users.show', $notifiable),
             'icon' => 'Award',
             'related_model' => [
                 'from_user_id' => $this->fromUser->id,

--- a/app/Notifications/JoinRequestAcceptedNotification.php
+++ b/app/Notifications/JoinRequestAcceptedNotification.php
@@ -32,7 +32,7 @@ class JoinRequestAcceptedNotification extends Notification implements ShouldQueu
             'type' => 'join_request_accepted',
             'title' => "¡Te aceptaron en {$teamName}!",
             'message' => "Tu solicitud para unirte a {$teamName} fue aceptada",
-            'action_url' => route('teams.show', $this->joinRequest->team_id),
+            'action_url' => route('teams.show', $this->joinRequest->team),
             'icon' => 'CheckCircle',
             'related_model' => [
                 'team_id' => $this->joinRequest->team_id,

--- a/app/Notifications/JoinRequestCreatedNotification.php
+++ b/app/Notifications/JoinRequestCreatedNotification.php
@@ -33,7 +33,7 @@ class JoinRequestCreatedNotification extends Notification implements ShouldQueue
             'type' => 'join_request_created',
             'title' => "Nueva solicitud para unirse a {$teamName}",
             'message' => "{$userName} quiere unirse a tu equipo",
-            'action_url' => route('teams.show', $this->joinRequest->team_id),
+            'action_url' => route('teams.show', $this->joinRequest->team),
             'icon' => 'UserPlus',
             'related_model' => [
                 'team_id' => $this->joinRequest->team_id,

--- a/app/Notifications/MatchCancelledNotification.php
+++ b/app/Notifications/MatchCancelledNotification.php
@@ -45,7 +45,7 @@ class MatchCancelledNotification extends Notification implements ShouldQueue
             'type' => 'match_cancelled',
             'title' => 'Partido cancelado',
             'message' => "{$this->cancellingTeam->name} canceló el partido",
-            'action_url' => route('matches.show', $this->match->id),
+            'action_url' => route('matches.show', $this->match),
             'icon' => 'X',
             'related_model' => [
                 'match_id' => $this->match->id,

--- a/app/Notifications/MatchConfirmedNotification.php
+++ b/app/Notifications/MatchConfirmedNotification.php
@@ -32,7 +32,7 @@ class MatchConfirmedNotification extends Notification implements ShouldQueue
             'type' => 'match_confirmed',
             'title' => '¡Partido confirmado!',
             'message' => "Tu partido contra {$opponentName} quedó confirmado",
-            'action_url' => route('matches.show', $this->match->id),
+            'action_url' => route('matches.show', $this->match),
             'icon' => 'CalendarCheck',
             'related_model' => [
                 'match_id' => $this->match->id,

--- a/app/Notifications/MatchRequestAcceptedNotification.php
+++ b/app/Notifications/MatchRequestAcceptedNotification.php
@@ -47,7 +47,7 @@ class MatchRequestAcceptedNotification extends Notification implements ShouldQue
             'type' => 'match_request_accepted',
             'title' => 'Solicitud de partido aceptada',
             'message' => "{$homeTeamName} aceptó tu solicitud de partido",
-            'action_url' => route('matches.show', $this->match->id),
+            'action_url' => route('matches.show', $this->match),
             'icon' => 'CheckCircle',
             'related_model' => [
                 'match_id' => $this->match->id,

--- a/app/Notifications/MatchRequestReceivedNotification.php
+++ b/app/Notifications/MatchRequestReceivedNotification.php
@@ -47,7 +47,7 @@ class MatchRequestReceivedNotification extends Notification implements ShouldQue
             'type' => 'match_request_received',
             'title' => 'Nueva solicitud de partido',
             'message' => "{$this->requestingTeam->name} quiere jugar tu partido",
-            'action_url' => route('matches.show', $this->match->id),
+            'action_url' => route('matches.show', $this->match),
             'icon' => 'Trophy',
             'related_model' => [
                 'match_id' => $this->match->id,

--- a/app/Notifications/MatchRequestRejectedNotification.php
+++ b/app/Notifications/MatchRequestRejectedNotification.php
@@ -47,7 +47,7 @@ class MatchRequestRejectedNotification extends Notification implements ShouldQue
             'type' => 'match_request_rejected',
             'title' => 'Solicitud de partido rechazada',
             'message' => "{$homeTeamName} rechazó tu solicitud de partido",
-            'action_url' => route('matches.show', $this->match->id),
+            'action_url' => route('matches.show', $this->match),
             'icon' => 'XCircle',
             'related_model' => [
                 'match_id' => $this->match->id,

--- a/app/Notifications/MatchScoreUpdatedNotification.php
+++ b/app/Notifications/MatchScoreUpdatedNotification.php
@@ -47,7 +47,7 @@ class MatchScoreUpdatedNotification extends Notification implements ShouldQueue
             'type' => 'match_score_updated',
             'title' => 'Resultado actualizado',
             'message' => "{$this->updatingTeam->name} actualizó el resultado a {$score}",
-            'action_url' => route('matches.show', $this->match->id),
+            'action_url' => route('matches.show', $this->match),
             'icon' => 'Target',
             'related_model' => [
                 'match_id' => $this->match->id,

--- a/app/Notifications/ProfileCommentNotification.php
+++ b/app/Notifications/ProfileCommentNotification.php
@@ -48,7 +48,7 @@ class ProfileCommentNotification extends Notification implements ShouldQueue
             ->greeting("¡Hola {$notifiable->name}!")
             ->line("{$this->commenter->name} ha comentado en tu perfil:")
             ->line("\"{$preview}\"")
-            ->action('Ver Comentario', route('users.show', $notifiable->id))
+            ->action('Ver Comentario', route('users.show', $notifiable))
             ->line('Gracias por ser parte de la comunidad Veltro.');
     }
 
@@ -65,7 +65,7 @@ class ProfileCommentNotification extends Notification implements ShouldQueue
             'type' => 'profile_comment',
             'title' => "{$this->commenter->name} comentó en tu perfil",
             'message' => $preview,
-            'action_url' => route('users.show', $notifiable->id),
+            'action_url' => route('users.show', $notifiable),
             'icon' => 'MessageCircle',
             'related_model' => [
                 'comment_id' => $this->comment->id,

--- a/app/Notifications/TeamInvitationAcceptedNotification.php
+++ b/app/Notifications/TeamInvitationAcceptedNotification.php
@@ -34,7 +34,7 @@ class TeamInvitationAcceptedNotification extends Notification implements ShouldQ
             'type' => 'team_invitation_accepted',
             'title' => "{$this->acceptedBy->name} aceptó tu invitación",
             'message' => "{$this->acceptedBy->name} se unió a {$teamName}",
-            'action_url' => route('teams.show', $this->invitation->team_id),
+            'action_url' => route('teams.show', $this->invitation->team),
             'icon' => 'UserCheck',
             'related_model' => [
                 'team_id' => $this->invitation->team_id,

--- a/database/migrations/2026_07_19_114834_add_public_id_to_teams_tournaments_matches_users.php
+++ b/database/migrations/2026_07_19_114834_add_public_id_to_teams_tournaments_matches_users.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adds an opaque, non-sequential `public_id` to the resources that appear in
+ * address-bar URLs (teams, tournaments, matches, users) so those URLs no longer
+ * expose enumerable auto-increment primary keys.
+ *
+ * Three steps per table: add the column nullable, backfill existing rows with
+ * unique tokens, then enforce NOT NULL + a unique index.
+ */
+return new class extends Migration
+{
+    /**
+     * Tables that receive a public id.
+     *
+     * @var array<int, string>
+     */
+    private array $tables = ['teams', 'tournaments', 'matches', 'users'];
+
+    private const ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+    private const LENGTH = 12;
+
+    public function up(): void
+    {
+        foreach ($this->tables as $table) {
+            Schema::table($table, function (Blueprint $blueprint): void {
+                $blueprint->string('public_id', 12)->nullable()->after('id');
+            });
+
+            $this->backfill($table);
+
+            Schema::table($table, function (Blueprint $blueprint) use ($table): void {
+                $blueprint->string('public_id', 12)->nullable(false)->change();
+                $blueprint->unique('public_id', "{$table}_public_id_unique");
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $table) {
+            Schema::table($table, function (Blueprint $blueprint) use ($table): void {
+                $blueprint->dropUnique("{$table}_public_id_unique");
+                $blueprint->dropColumn('public_id');
+            });
+        }
+    }
+
+    /**
+     * Assign a unique token to every existing row.
+     */
+    private function backfill(string $table): void
+    {
+        $used = [];
+
+        DB::table($table)->orderBy('id')->select('id')->chunkById(500, function ($rows) use ($table, &$used): void {
+            foreach ($rows as $row) {
+                do {
+                    $token = $this->makeToken();
+                } while (isset($used[$token]));
+
+                $used[$token] = true;
+
+                DB::table($table)->where('id', $row->id)->update(['public_id' => $token]);
+            }
+        });
+    }
+
+    private function makeToken(): string
+    {
+        $max = strlen(self::ALPHABET) - 1;
+        $token = '';
+
+        for ($i = 0; $i < self::LENGTH; $i++) {
+            $token .= self::ALPHABET[random_int(0, $max)];
+        }
+
+        return $token;
+    }
+};

--- a/resources/js/components/dashboard/next-match-spotlight.tsx
+++ b/resources/js/components/dashboard/next-match-spotlight.tsx
@@ -194,7 +194,7 @@ export function NextMatchSpotlight({
 
             <div className="mt-6 flex justify-center">
                 <Button asChild>
-                    <Link href={matches.show(match.id).url}>
+                    <Link href={matches.show(match.public_id).url}>
                         Ver partido y confirmar disponibilidad
                     </Link>
                 </Button>

--- a/resources/js/components/match-card.tsx
+++ b/resources/js/components/match-card.tsx
@@ -20,6 +20,7 @@ interface Team {
 
 interface Match {
     id: number;
+    public_id: string;
     home_team_id: number;
     away_team_id?: number;
     variant: string;
@@ -189,7 +190,9 @@ export function MatchCard({ match }: MatchCardProps) {
                 </div>
 
                 <Button asChild variant="outline" className="mt-3 w-full">
-                    <Link href={matches.show(match.id).url}>Ver Detalles</Link>
+                    <Link href={matches.show(match.public_id).url}>
+                        Ver Detalles
+                    </Link>
                 </Button>
             </CardContent>
         </Card>

--- a/resources/js/components/match/match-hero.tsx
+++ b/resources/js/components/match/match-hero.tsx
@@ -364,7 +364,12 @@ export function MatchHero({
                             {isHomeLeader && match.status === 'available' && (
                                 <>
                                     <Button asChild variant="outline">
-                                        <Link href={matches.edit(match.id).url}>
+                                        <Link
+                                            href={
+                                                matches.edit(match.public_id)
+                                                    .url
+                                            }
+                                        >
                                             <Edit className="mr-2 h-4 w-4" />
                                             Editar
                                         </Link>

--- a/resources/js/components/match/types.ts
+++ b/resources/js/components/match/types.ts
@@ -56,6 +56,7 @@ export interface OpposingTeamLeader {
 
 export interface MatchPageMatch {
     id: number;
+    public_id: string;
     home_team_id: number;
     away_team_id?: number;
     tournament_id?: number;

--- a/resources/js/components/team-card.tsx
+++ b/resources/js/components/team-card.tsx
@@ -196,7 +196,7 @@ export function TeamCard({ team, mode, currentUserId }: TeamCardProps) {
                 <div className="flex gap-2 pt-1">
                     {mode === 'mine' ? (
                         <Button asChild variant="outline" className="w-full">
-                            <Link href={teams.show(team.id).url}>
+                            <Link href={teams.show(team.public_id).url}>
                                 Ver equipo
                                 <ArrowRight className="ml-2 h-4 w-4" />
                             </Link>
@@ -211,7 +211,9 @@ export function TeamCard({ team, mode, currentUserId }: TeamCardProps) {
                                 Completo
                             </Button>
                             <Button asChild variant="outline">
-                                <Link href={teams.show(team.id).url}>Ver</Link>
+                                <Link href={teams.show(team.public_id).url}>
+                                    Ver
+                                </Link>
                             </Button>
                         </>
                     ) : (
@@ -227,7 +229,9 @@ export function TeamCard({ team, mode, currentUserId }: TeamCardProps) {
                                 }
                             />
                             <Button asChild variant="outline">
-                                <Link href={teams.show(team.id).url}>Ver</Link>
+                                <Link href={teams.show(team.public_id).url}>
+                                    Ver
+                                </Link>
                             </Button>
                         </>
                     )}

--- a/resources/js/components/tournament/tournament-card.tsx
+++ b/resources/js/components/tournament/tournament-card.tsx
@@ -128,7 +128,7 @@ export const TournamentCard = ({
                 </div>
 
                 <Button asChild variant="outline" className="mt-auto w-full">
-                    <Link href={tournaments.show(tournament.id).url}>
+                    <Link href={tournaments.show(tournament.public_id).url}>
                         Ver torneo
                         <ArrowRight className="ml-2 h-4 w-4" />
                     </Link>

--- a/resources/js/components/tournament/tournament-header.tsx
+++ b/resources/js/components/tournament/tournament-header.tsx
@@ -117,7 +117,11 @@ export function TournamentHeader({
                             size="sm"
                             className="gap-2"
                         >
-                            <Link href={tournaments.edit(tournament.id).url}>
+                            <Link
+                                href={
+                                    tournaments.edit(tournament.public_id).url
+                                }
+                            >
                                 <Edit className="size-4" />
                                 Editar
                             </Link>

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -124,7 +124,7 @@ function QuickAction({
 
 function TeamRow({ team }: { team: MyTeam }) {
     return (
-        <Link href={teams.show(team.id).url} className="group block">
+        <Link href={teams.show(team.public_id).url} className="group block">
             <Card className="transition-all hover:border-primary/20 hover:shadow-md">
                 <CardContent className="flex items-center gap-3 py-3">
                     <TeamAvatar

--- a/resources/js/pages/matches/edit.tsx
+++ b/resources/js/pages/matches/edit.tsx
@@ -22,6 +22,7 @@ interface Team {
 }
 
 interface Match {
+    public_id: string;
     id: number;
     scheduled_at: string | null;
     location: string | null;
@@ -42,11 +43,11 @@ export default function Edit({ match }: Props) {
         },
         {
             title: match.home_team.name,
-            href: matches.show(match.id).url,
+            href: matches.show(match.public_id).url,
         },
         {
             title: 'Editar',
-            href: matches.edit(match.id).url,
+            href: matches.edit(match.public_id).url,
         },
     ];
 
@@ -160,7 +161,9 @@ export default function Edit({ match }: Props) {
                                     type="button"
                                     variant="outline"
                                     onClick={() =>
-                                        router.visit(matches.show(match.id).url)
+                                        router.visit(
+                                            matches.show(match.public_id).url,
+                                        )
                                     }
                                 >
                                     Cancelar

--- a/resources/js/pages/matches/index.tsx
+++ b/resources/js/pages/matches/index.tsx
@@ -57,6 +57,7 @@ function PublishMatchButton({ teams }: { teams: Team[] }) {
 }
 
 interface Match {
+    public_id: string;
     id: number;
     home_team_id: number;
     away_team_id?: number;

--- a/resources/js/pages/matches/lineup.tsx
+++ b/resources/js/pages/matches/lineup.tsx
@@ -45,6 +45,7 @@ interface Team {
 }
 
 interface Match {
+    public_id: string;
     id: number;
     home_team_id: number;
     away_team_id?: number;
@@ -82,7 +83,7 @@ export default function Lineup({
         },
         {
             title: 'Alineación',
-            href: matches.lineup.edit(match.id).url,
+            href: matches.lineup.edit(match.public_id).url,
         },
     ];
 
@@ -134,7 +135,7 @@ export default function Lineup({
             {
                 onSuccess: () => {
                     toast.success('¡Alineación actualizada exitosamente!');
-                    router.visit(matches.show(match.id).url);
+                    router.visit(matches.show(match.public_id).url);
                 },
                 onError: (errors) => {
                     const firstError = Object.values(errors)[0];
@@ -181,7 +182,7 @@ export default function Lineup({
                                 }
                                 onClick={() =>
                                     router.visit(
-                                        matches.lineup.edit(match.id, {
+                                        matches.lineup.edit(match.public_id, {
                                             query: { team: t.id },
                                         }).url,
                                     )
@@ -282,7 +283,9 @@ export default function Lineup({
                                 type="button"
                                 variant="outline"
                                 onClick={() =>
-                                    router.visit(matches.show(match.id).url)
+                                    router.visit(
+                                        matches.show(match.public_id).url,
+                                    )
                                 }
                             >
                                 Cancelar

--- a/resources/js/pages/matches/show.tsx
+++ b/resources/js/pages/matches/show.tsx
@@ -96,7 +96,7 @@ export default function Show({
         },
         {
             title: `${match.home_team.name}${match.away_team ? ` vs ${match.away_team.name}` : ''}`,
-            href: matches.show(match.id).url,
+            href: matches.show(match.public_id).url,
         },
     ];
 
@@ -296,7 +296,11 @@ export default function Show({
                         </CardHeader>
                         <CardContent className="space-y-3">
                             <Button asChild className="w-full">
-                                <Link href={matches.lineup.edit(match.id).url}>
+                                <Link
+                                    href={
+                                        matches.lineup.edit(match.public_id).url
+                                    }
+                                >
                                     <Users className="mr-2 h-4 w-4" />
                                     Gestionar Alineación
                                 </Link>

--- a/resources/js/pages/teams/invitation-expired.tsx
+++ b/resources/js/pages/teams/invitation-expired.tsx
@@ -12,6 +12,7 @@ import { Head, Link } from '@inertiajs/react';
 import { Clock } from 'lucide-react';
 
 interface Team {
+    public_id: string;
     id: number;
     name: string;
     logo_url?: string;
@@ -53,7 +54,7 @@ export default function InvitationExpired({ team }: Props) {
 
                     <div className="flex flex-col gap-3">
                         <Button asChild>
-                            <Link href={teams.show(team.id).url}>
+                            <Link href={teams.show(team.public_id).url}>
                                 Ver Equipo
                             </Link>
                         </Button>

--- a/resources/js/pages/teams/invitation-revoked.tsx
+++ b/resources/js/pages/teams/invitation-revoked.tsx
@@ -12,6 +12,7 @@ import { Head, Link } from '@inertiajs/react';
 import { XCircle } from 'lucide-react';
 
 interface Team {
+    public_id: string;
     id: number;
     name: string;
     logo_url?: string;
@@ -55,7 +56,7 @@ export default function InvitationRevoked({ team }: Props) {
 
                     <div className="flex flex-col gap-3">
                         <Button asChild>
-                            <Link href={teams.show(team.id).url}>
+                            <Link href={teams.show(team.public_id).url}>
                                 Ver Equipo
                             </Link>
                         </Button>

--- a/resources/js/pages/teams/search.tsx
+++ b/resources/js/pages/teams/search.tsx
@@ -53,6 +53,7 @@ interface TeamMember {
 }
 
 interface Team {
+    public_id: string;
     id: number;
     name: string;
     variant: string;
@@ -273,7 +274,10 @@ export default function SearchTeams({ teams: searchResults, filters }: Props) {
                                             className="w-full group-hover:bg-primary group-hover:text-primary-foreground"
                                         >
                                             <Link
-                                                href={teams.show(team.id).url}
+                                                href={
+                                                    teams.show(team.public_id)
+                                                        .url
+                                                }
                                             >
                                                 Ver equipo
                                                 <ArrowRight className="ml-2 h-4 w-4" />

--- a/resources/js/pages/teams/show.tsx
+++ b/resources/js/pages/teams/show.tsx
@@ -76,6 +76,7 @@ interface TeamInvitation {
 }
 
 interface Team {
+    public_id: string;
     id: number;
     name: string;
     variant: string;
@@ -237,7 +238,7 @@ export default function Show({
         },
         {
             title: team.name,
-            href: teams.show(team.id).url,
+            href: teams.show(team.public_id).url,
         },
     ];
 

--- a/resources/js/pages/tournaments/edit.tsx
+++ b/resources/js/pages/tournaments/edit.tsx
@@ -10,8 +10,11 @@ interface PageProps {
 
 const breadcrumbs = (tournament: Tournament): BreadcrumbItem[] => [
     { title: 'Torneos', href: tournaments.index().url },
-    { title: tournament.name, href: tournaments.show(tournament.id).url },
-    { title: 'Editar', href: tournaments.edit(tournament.id).url },
+    {
+        title: tournament.name,
+        href: tournaments.show(tournament.public_id).url,
+    },
+    { title: 'Editar', href: tournaments.edit(tournament.public_id).url },
 ];
 
 export default function TournamentEdit({ tournament }: PageProps) {

--- a/resources/js/pages/tournaments/show.tsx
+++ b/resources/js/pages/tournaments/show.tsx
@@ -254,7 +254,10 @@ function formatCountdown(prefix: string, days: number): string {
 
 const breadcrumbs = (tournament: Tournament): BreadcrumbItem[] => [
     { title: 'Torneos', href: tournaments.index().url },
-    { title: tournament.name, href: tournaments.show(tournament.id).url },
+    {
+        title: tournament.name,
+        href: tournaments.show(tournament.public_id).url,
+    },
 ];
 
 export default function TournamentShow({

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -33,6 +33,7 @@ export interface SharedData {
 
 export interface User {
     id: number;
+    public_id: string;
     name: string;
     email: string;
     avatar_url?: string;
@@ -146,6 +147,7 @@ export interface ProfileComment {
 
 export interface Team {
     id: number;
+    public_id: string;
     name: string;
     variant: string;
     logo_url?: string;
@@ -303,6 +305,7 @@ export interface TournamentGroup {
 
 export interface Tournament {
     id: number;
+    public_id: string;
     name: string;
     description?: string;
     logo_url?: string;
@@ -360,6 +363,7 @@ export interface TournamentRound {
 
 export interface FootballMatch {
     id: number;
+    public_id: string;
     home_team_id: number;
     away_team_id?: number;
     tournament_id?: number;

--- a/routes/matches.php
+++ b/routes/matches.php
@@ -13,8 +13,8 @@ Route::middleware(['auth', 'verified', 'throttle:matches', 'onboarding'])->group
     Route::get('/matches', [MatchController::class, 'index'])->name('matches.index');
     Route::get('/matches/create', [MatchController::class, 'create'])->name('matches.create');
     Route::post('/matches', [MatchController::class, 'store'])->name('matches.store');
-    Route::get('/matches/{id}', [MatchController::class, 'show'])->name('matches.show');
-    Route::get('/matches/{id}/edit', [MatchController::class, 'edit'])->name('matches.edit');
+    Route::get('/matches/{match}', [MatchController::class, 'show'])->name('matches.show');
+    Route::get('/matches/{match}/edit', [MatchController::class, 'edit'])->name('matches.edit');
     Route::put('/matches/{id}', [MatchController::class, 'update'])->name('matches.update');
     Route::post('/matches/{id}/cancel', [MatchController::class, 'cancel'])->name('matches.cancel');
     Route::post('/matches/{id}/complete', [MatchController::class, 'complete'])->name('matches.complete');
@@ -25,7 +25,7 @@ Route::middleware(['auth', 'verified', 'throttle:matches', 'onboarding'])->group
     Route::post('/match-requests/{id}/reject', [MatchController::class, 'rejectRequest'])->name('match-requests.reject');
 
     // Match Lineups
-    Route::get('/matches/{matchId}/lineup', [MatchLineupController::class, 'edit'])->name('matches.lineup.edit');
+    Route::get('/matches/{match}/lineup', [MatchLineupController::class, 'edit'])->name('matches.lineup.edit');
     Route::post('/matches/{matchId}/lineup', [MatchLineupController::class, 'update'])->name('matches.lineup.update');
 
     // Match Events

--- a/routes/teams.php
+++ b/routes/teams.php
@@ -32,7 +32,7 @@ Route::middleware(['auth', 'verified', 'throttle:teams', 'onboarding'])->group(f
         ->name('teams.invitation.accept');
 
     // Team CRUD - {id} routes must come after specific routes
-    Route::get('/teams/{id}', [TeamController::class, 'show'])->name('teams.show');
+    Route::get('/teams/{team}', [TeamController::class, 'show'])->name('teams.show');
     Route::put('/teams/{id}', [TeamController::class, 'update'])->name('teams.update');
     Route::delete('/teams/{id}', [TeamController::class, 'destroy'])->name('teams.destroy');
 

--- a/routes/tournaments.php
+++ b/routes/tournaments.php
@@ -14,8 +14,8 @@ Route::middleware(['auth', 'verified', 'throttle:tournaments', 'onboarding'])->g
     Route::get('/tournaments', [TournamentController::class, 'index'])->name('tournaments.index');
     Route::get('/tournaments/create', [TournamentController::class, 'create'])->name('tournaments.create');
     Route::post('/tournaments', [TournamentController::class, 'store'])->name('tournaments.store');
-    Route::get('/tournaments/{id}', [TournamentController::class, 'show'])->name('tournaments.show');
-    Route::get('/tournaments/{id}/edit', [TournamentController::class, 'edit'])->name('tournaments.edit');
+    Route::get('/tournaments/{tournament}', [TournamentController::class, 'show'])->name('tournaments.show');
+    Route::get('/tournaments/{tournament}/edit', [TournamentController::class, 'edit'])->name('tournaments.edit');
     Route::put('/tournaments/{id}', [TournamentController::class, 'update'])->name('tournaments.update');
     Route::delete('/tournaments/{id}', [TournamentController::class, 'destroy'])->name('tournaments.destroy');
     Route::post('/tournaments/{id}/open-registration', [TournamentController::class, 'openRegistration'])->name('tournaments.open-registration');
@@ -23,7 +23,7 @@ Route::middleware(['auth', 'verified', 'throttle:tournaments', 'onboarding'])->g
     Route::post('/tournaments/{id}/cancel', [TournamentController::class, 'cancel'])->name('tournaments.cancel');
 
     // Tournament Match Scheduling
-    Route::patch('/tournaments/{tournament}/matches/{match}', [TournamentMatchController::class, 'update'])->name('tournaments.matches.update');
+    Route::patch('/tournaments/{tournament:id}/matches/{match:id}', [TournamentMatchController::class, 'update'])->name('tournaments.matches.update');
 
     // Tournament Groups (group_stage_knockout draw)
     Route::post('/tournaments/{id}/groups/draw', [TournamentGroupController::class, 'assign'])->name('tournaments.groups.assign');

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,7 +41,7 @@ Route::get('/jugadores/{user}', [UserController::class, 'show'])
     ->name('users.show');
 
 // API endpoint for modal/AJAX requests (kept for backward compatibility)
-Route::get('/api/users/{user}', [UserController::class, 'showApi'])
+Route::get('/api/users/{user:id}', [UserController::class, 'showApi'])
     ->middleware('throttle:profile-view')
     ->name('users.show.api');
 
@@ -53,24 +53,24 @@ Route::middleware(['auth', 'verified', 'throttle:settings-write'])->group(functi
 });
 
 // Commendations (public read, auth required for write)
-Route::get('/api/users/{user}/commendations', [UserCommendationController::class, 'index'])
+Route::get('/api/users/{user:id}/commendations', [UserCommendationController::class, 'index'])
     ->middleware('throttle:profile-view')
     ->name('users.commendations.index');
 
 Route::middleware(['auth', 'verified', 'throttle:settings-write'])->group(function () {
-    Route::post('/api/users/{user}/commendations', [UserCommendationController::class, 'store'])
+    Route::post('/api/users/{user:id}/commendations', [UserCommendationController::class, 'store'])
         ->name('users.commendations.store');
-    Route::delete('/api/users/{user}/commendations/{category}', [UserCommendationController::class, 'destroy'])
+    Route::delete('/api/users/{user:id}/commendations/{category}', [UserCommendationController::class, 'destroy'])
         ->name('users.commendations.destroy');
 });
 
 // Profile comments (public read, auth required for write)
-Route::get('/api/users/{user}/comments', [ProfileCommentController::class, 'index'])
+Route::get('/api/users/{user:id}/comments', [ProfileCommentController::class, 'index'])
     ->middleware('throttle:profile-view')
     ->name('users.comments.index');
 
 Route::middleware(['auth', 'verified', 'throttle:settings-write'])->group(function () {
-    Route::post('/api/users/{user}/comments', [ProfileCommentController::class, 'store'])
+    Route::post('/api/users/{user:id}/comments', [ProfileCommentController::class, 'store'])
         ->name('users.comments.store');
     Route::delete('/api/comments/{comment}', [ProfileCommentController::class, 'destroy'])
         ->name('comments.destroy');

--- a/tests/Feature/MatchTest.php
+++ b/tests/Feature/MatchTest.php
@@ -128,7 +128,7 @@ test('authenticated user can view a match', function () {
     $match = createMatch();
 
     $this->actingAs($this->homeCaptain)
-        ->get(route('matches.show', $match->id))
+        ->get(route('matches.show', $match))
         ->assertSuccessful();
 });
 
@@ -141,7 +141,7 @@ test('match availability and opposing leaders are deferred', function () {
     $this->actingAs($this->homeCaptain);
 
     // The below-the-fold blocks are deferred → absent on the initial page load.
-    $this->get(route('matches.show', $match->id))
+    $this->get(route('matches.show', $match))
         ->assertOk()
         ->assertInertia(fn ($page) => $page
             ->component('matches/show')
@@ -154,7 +154,7 @@ test('match availability and opposing leaders are deferred', function () {
 
     // ...and delivered by the follow-up deferred (partial) request.
     $version = app(\App\Http\Middleware\HandleInertiaRequests::class)->version(request());
-    $this->get(route('matches.show', $match->id), [
+    $this->get(route('matches.show', $match), [
         'X-Inertia' => 'true',
         'X-Inertia-Version' => $version,
         'X-Inertia-Partial-Component' => 'matches/show',
@@ -226,8 +226,8 @@ test('cannot edit a match that has started', function () {
     ]);
 
     $this->actingAs($this->homeCaptain)
-        ->get(route('matches.edit', $match->id))
-        ->assertRedirect(route('matches.show', $match->id));
+        ->get(route('matches.edit', $match))
+        ->assertRedirect(route('matches.show', $match));
 });
 
 // ============================================================

--- a/tests/Feature/TeamInvitationTest.php
+++ b/tests/Feature/TeamInvitationTest.php
@@ -60,7 +60,7 @@ test('captain sees pending invitations on team show page', function () {
     $invitation = makeInvitation();
 
     $this->actingAs($this->captain)
-        ->get(route('teams.show', $this->team->id))
+        ->get(route('teams.show', $this->team))
         ->assertSuccessful()
         ->assertInertia(fn ($page) => $page
             ->component('teams/show')
@@ -78,7 +78,7 @@ test('co-captain sees pending invitations on team show page', function () {
     makeInvitation();
 
     $this->actingAs($this->player)
-        ->get(route('teams.show', $this->team->id))
+        ->get(route('teams.show', $this->team))
         ->assertInertia(fn ($page) => $page
             ->where('canManage', true)
             ->has('pendingInvitations', 1)
@@ -89,7 +89,7 @@ test('regular player does not see pending invitations', function () {
     makeInvitation();
 
     $this->actingAs($this->player)
-        ->get(route('teams.show', $this->team->id))
+        ->get(route('teams.show', $this->team))
         ->assertInertia(fn ($page) => $page
             ->where('canManage', false)
             ->has('pendingInvitations', 0)
@@ -100,7 +100,7 @@ test('non-member does not see pending invitations', function () {
     makeInvitation();
 
     $this->actingAs($this->outsider)
-        ->get(route('teams.show', $this->team->id))
+        ->get(route('teams.show', $this->team))
         ->assertInertia(fn ($page) => $page
             ->where('canManage', false)
             ->has('pendingInvitations', 0)
@@ -114,7 +114,7 @@ test('show page surfaces pending, expired, and revoked invitations to leaders', 
     makeInvitation(['status' => 'accepted', 'accepted_at' => now()]);
 
     $this->actingAs($this->captain)
-        ->get(route('teams.show', $this->team->id))
+        ->get(route('teams.show', $this->team))
         ->assertInertia(fn ($page) => $page
             ->has('pendingInvitations', 3)
         );
@@ -126,7 +126,7 @@ test('expired pending invitations are auto-marked when leader views the page', f
     expect($invitation->status)->toBe('pending');
 
     $this->actingAs($this->captain)
-        ->get(route('teams.show', $this->team->id));
+        ->get(route('teams.show', $this->team));
 
     expect($invitation->fresh()->status)->toBe('expired');
 });
@@ -299,7 +299,7 @@ test('an authenticated member visiting the invite link is redirected to the team
 
     $this->actingAs($this->player)
         ->get(route('teams.invitation.show', $invitation->token))
-        ->assertRedirect(route('teams.show', $this->team->id));
+        ->assertRedirect(route('teams.show', $this->team));
 });
 
 test('invitation is not accepted when the team is full', function () {

--- a/tests/Feature/TeamTest.php
+++ b/tests/Feature/TeamTest.php
@@ -147,7 +147,7 @@ test('team description cannot exceed 1000 characters', function () {
 
 test('authenticated user can view a team', function () {
     $this->actingAs($this->captain)
-        ->get(route('teams.show', $this->team->id))
+        ->get(route('teams.show', $this->team))
         ->assertSuccessful();
 });
 
@@ -164,7 +164,7 @@ test('captain can update team', function () {
             'variant' => 'football_11',
             'description' => 'Updated description',
         ])
-        ->assertRedirect(route('teams.show', $this->team->id));
+        ->assertRedirect(route('teams.show', $this->team));
 
     $this->assertDatabaseHas('teams', [
         'id' => $this->team->id,
@@ -218,7 +218,7 @@ test('captain can update team with a logo', function () {
             'variant' => 'football_11',
             'logo' => UploadedFile::fake()->image('logo.png', 600, 600),
         ])
-        ->assertRedirect(route('teams.show', $this->team->id));
+        ->assertRedirect(route('teams.show', $this->team));
 
     $this->team->refresh();
     expect($this->team->logo_path)->not->toBeNull();

--- a/tests/Feature/Tournament/GroupStageKnockoutTest.php
+++ b/tests/Feature/Tournament/GroupStageKnockoutTest.php
@@ -243,7 +243,7 @@ test('group standings appear in show endpoint props', function () {
     $this->actingAs($organizer);
 
     // groupStandings is a deferred prop, absent on the initial page load...
-    $response = $this->get("/tournaments/{$tournament->id}");
+    $response = $this->get("/tournaments/{$tournament->public_id}");
     $response->assertOk();
     $response->assertInertia(fn ($page) => $page
         ->component('tournaments/show')
@@ -252,7 +252,7 @@ test('group standings appear in show endpoint props', function () {
 
     // ...and delivered by the follow-up deferred (partial) request.
     $version = app(\App\Http\Middleware\HandleInertiaRequests::class)->version(request());
-    $deferred = $this->get("/tournaments/{$tournament->id}", [
+    $deferred = $this->get("/tournaments/{$tournament->public_id}", [
         'X-Inertia' => 'true',
         'X-Inertia-Version' => $version,
         'X-Inertia-Partial-Component' => 'tournaments/show',

--- a/tests/Feature/Tournament/LeagueFormatTest.php
+++ b/tests/Feature/Tournament/LeagueFormatTest.php
@@ -213,7 +213,7 @@ test('tournament show endpoint includes standings for league format', function (
     $this->actingAs($organizer);
 
     // standings is a deferred prop, so it is absent on the initial page load...
-    $response = $this->get("/tournaments/{$tournament->id}");
+    $response = $this->get("/tournaments/{$tournament->public_id}");
     $response->assertOk();
     $response->assertInertia(fn ($page) => $page
         ->component('tournaments/show')
@@ -222,7 +222,7 @@ test('tournament show endpoint includes standings for league format', function (
 
     // ...and is delivered by the follow-up deferred (partial) request.
     $version = app(\App\Http\Middleware\HandleInertiaRequests::class)->version(request());
-    $deferred = $this->get("/tournaments/{$tournament->id}", [
+    $deferred = $this->get("/tournaments/{$tournament->public_id}", [
         'X-Inertia' => 'true',
         'X-Inertia-Version' => $version,
         'X-Inertia-Partial-Component' => 'tournaments/show',

--- a/tests/Feature/TournamentMatchManagementTest.php
+++ b/tests/Feature/TournamentMatchManagementTest.php
@@ -120,7 +120,7 @@ test('organizer can complete a tournament match', function () {
 test('organizer can set the lineup for both teams', function () {
     // GET the lineup page and confirm both teams are offered.
     $this->actingAs($this->organizer)
-        ->get(route('matches.lineup.edit', $this->match->id))
+        ->get(route('matches.lineup.edit', $this->match))
         ->assertOk()
         ->assertInertia(fn ($page) => $page->has('teams', 2));
 
@@ -179,7 +179,7 @@ test('a competing team captain cannot complete a tournament match', function () 
 
 test('a competing team captain cannot open the lineup editor for a tournament match', function () {
     $this->actingAs($this->homeCaptain)
-        ->get(route('matches.lineup.edit', $this->match->id))
+        ->get(route('matches.lineup.edit', $this->match))
         ->assertForbidden();
 
     $player = $this->homeTeam->teamMembers()->where('role', 'player')->first();

--- a/tests/Feature/TournamentRegistrationTest.php
+++ b/tests/Feature/TournamentRegistrationTest.php
@@ -422,7 +422,7 @@ test('the show page exposes the is_registration_open flag as a tournament prop',
 
     $this->actingAs($user);
 
-    $this->get("/tournaments/{$tournament->id}")
+    $this->get("/tournaments/{$tournament->public_id}")
         ->assertSuccessful()
         ->assertInertia(fn ($page) => $page
             ->component('tournaments/show')

--- a/tests/Feature/TournamentTest.php
+++ b/tests/Feature/TournamentTest.php
@@ -208,7 +208,7 @@ test('show page renders tournament with correct props', function () {
 
     $this->actingAs($user);
 
-    $response = $this->get("/tournaments/{$tournament->id}");
+    $response = $this->get("/tournaments/{$tournament->public_id}");
 
     $response->assertSuccessful();
     $response->assertInertia(fn ($page) => $page
@@ -228,7 +228,7 @@ test('edit page accessible by organizer', function () {
 
     $this->actingAs($user);
 
-    $response = $this->get("/tournaments/{$tournament->id}/edit");
+    $response = $this->get("/tournaments/{$tournament->public_id}/edit");
 
     $response->assertSuccessful();
     $response->assertInertia(fn ($page) => $page


### PR DESCRIPTION
## Summary

Detail-page URLs no longer expose sequential auto-increment IDs. `/teams/6`, `/matches/16`, `/tournaments/3`, and `/jugadores/6` now use opaque, non-enumerable 12-char base62 tokens (e.g. `/teams/G9QLGugN8GML`).

This addresses two problems:
- **UX** — raw numeric IDs are opaque and unmemorable.
- **Security/privacy** — sequential IDs are *enumerable*: they let anyone walk the ID space to scrape the dataset or infer volume/growth (an IDOR/enumeration surface).

The internal numeric primary key is unchanged — `public_id` is purely a public lookup key, so **all foreign keys are untouched**.

## Approach

A uniform, opaque `public_id` on all four resources (12-char base62, random, ~71 bits — no creation-order leak, unlike ULID; not reversible to the PK, unlike hashids).

### Backend
- **`app/Models/Concerns/HasPublicId.php`** — trait that generates a unique `public_id` on `creating` and sets `getRouteKeyName()` → `public_id`. Applied to `Team`, `Tournament`, `FootballMatch`, `User`.
- **Migration** adds a unique `public_id` column to all four tables and backfills existing rows in chunks.
- Only **address-bar GET routes** were converted to model binding by `public_id`: `teams.show`, `matches.show`/`edit`/`lineup.edit`, `tournaments.show`/`edit`, `users.show`. Their controllers take the bound model.
- **Action/API routes stay numeric** — write routes keep the `{id}` param; routes that were already model-bound are explicitly pinned (`{user:id}`, `{tournament:id}`, `{match:id}`) so their frontend callers don't change.
- All `route('*.show', $model->id)` calls now pass the **model** so Laravel emits the `public_id` key; the one partial-`select()` query that feeds a link now includes `public_id`.

### Frontend
- `public_id` added to the relevant global + local TS interfaces.
- ~25 `.show()`/`.edit()`/`.lineup.edit()` call sites now pass `.public_id` (Wayfinder helpers are binding-aware).

## Testing
- ✅ **All 391 tests pass** (updated the ~20 that hard-coded numeric-id URLs; the suite proves `GET /tournaments/{public_id}` → 200, i.e. binding works end-to-end).
- ✅ `bun run types` clean (only pre-existing, unrelated `.form` errors remain).
- ✅ Pint + Prettier clean.

## Deploy note
Old bookmarked `/teams/6`-style links will 404 after cutover — no redirect shim is included (fine pre-launch). Easy to add backward-compat redirects if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)