### PR TITLE
fix: route player profile links through public_id

### DIFF
--- a/app/Http/Controllers/MatchController.php
+++ b/app/Http/Controllers/MatchController.php
@@ -174,13 +174,13 @@ final class MatchController extends Controller
         if ($match->isConfirmed() || $match->isInProgress() || $match->isCompleted()) {
             $homeLineup = $match->lineups()
                 ->where('team_id', $match->home_team_id)
-                ->with('user:id,name')
+                ->with('user:id,public_id,name')
                 ->get();
 
             if ($match->away_team_id) {
                 $awayLineup = $match->lineups()
                     ->where('team_id', $match->away_team_id)
-                    ->with('user:id,name')
+                    ->with('user:id,public_id,name')
                     ->get();
             }
 
@@ -245,7 +245,7 @@ final class MatchController extends Controller
 
         return $leaders->map(function ($leader) {
             if (! $leader->relationLoaded('user')) {
-                $leader->load('user:id,name,phone_number');
+                $leader->load('user:id,public_id,name,phone_number');
             }
 
             return [
@@ -254,6 +254,7 @@ final class MatchController extends Controller
                 'role' => $leader->role,
                 'user' => [
                     'id' => $leader->user->id,
+                    'public_id' => $leader->user->public_id,
                     'name' => $leader->user->name,
                     'phone_number' => $leader->user->phone_number ?? null,
                 ],

--- a/resources/js/components/match/match-lineups.tsx
+++ b/resources/js/components/match/match-lineups.tsx
@@ -3,6 +3,7 @@ import { TeamAvatar } from '@/components/team-avatar';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { UserAvatar } from '@/components/user-avatar';
+import users from '@/routes/users';
 import { Link } from '@inertiajs/react';
 
 interface MatchLineupsProps {
@@ -84,7 +85,7 @@ function LineupColumn({
                     {players.map((player, index) => (
                         <li key={player.id}>
                             <Link
-                                href={`/jugadores/${player.user.id}`}
+                                href={users.show(player.user).url}
                                 className="flex items-center gap-3 rounded-lg px-2 py-1.5 transition-colors hover:bg-muted/50"
                             >
                                 <span className="w-5 shrink-0 text-center text-xs font-medium text-muted-foreground tabular-nums">

--- a/resources/js/components/match/types.ts
+++ b/resources/js/components/match/types.ts
@@ -5,6 +5,7 @@
 
 export interface MatchPageUser {
     id: number;
+    public_id: string;
     name: string;
 }
 
@@ -49,6 +50,7 @@ export interface OpposingTeamLeader {
     role: string;
     user: {
         id: number;
+        public_id: string;
         name: string;
         phone_number?: string;
     };

--- a/resources/js/components/user-menu-content.tsx
+++ b/resources/js/components/user-menu-content.tsx
@@ -8,6 +8,7 @@ import { UserInfo } from '@/components/user-info';
 import { useMobileNavigation } from '@/hooks/use-mobile-navigation';
 import { logout } from '@/routes';
 import { edit } from '@/routes/profile';
+import users from '@/routes/users';
 import type { User } from '@/types';
 import { Link, router } from '@inertiajs/react';
 import { LogOut, Settings } from 'lucide-react';
@@ -28,7 +29,7 @@ export function UserMenuContent({ user }: UserMenuContentProps) {
         <>
             <DropdownMenuLabel className="p-0 font-normal">
                 <Link
-                    href={`/jugadores/${user.id}`}
+                    href={users.show(user).url}
                     className="flex items-center gap-2 px-1 py-1.5 text-left text-sm transition-colors hover:bg-muted/50"
                     onClick={cleanup}
                 >

--- a/resources/js/components/user-name-link.tsx
+++ b/resources/js/components/user-name-link.tsx
@@ -1,16 +1,17 @@
 import { cn } from '@/lib/utils';
+import users from '@/routes/users';
 import type { User } from '@/types';
 import { Link } from '@inertiajs/react';
 
 interface UserNameLinkProps {
-    user: User | { id: number; name: string };
+    user: User | { public_id: string; name: string };
     className?: string;
 }
 
 export function UserNameLink({ user, className }: UserNameLinkProps) {
     return (
         <Link
-            href={`/jugadores/${user.id}`}
+            href={users.show(user).url}
             className={cn(
                 'cursor-pointer text-foreground underline decoration-neutral-300 underline-offset-4 transition-colors duration-200 hover:decoration-current dark:decoration-neutral-500',
                 className,

--- a/resources/js/pages/matches/lineup.tsx
+++ b/resources/js/pages/matches/lineup.tsx
@@ -27,6 +27,7 @@ import { toast } from 'sonner';
 
 interface User {
     id: number;
+    public_id: string;
     name: string;
 }
 

--- a/resources/js/pages/users/show.tsx
+++ b/resources/js/pages/users/show.tsx
@@ -71,7 +71,7 @@ export default function Show({
     };
 
     const breadcrumbs: BreadcrumbItem[] = [
-        { title: user.name, href: `/jugadores/${user.id}` },
+        { title: user.name, href: `/jugadores/${user.public_id}` },
     ];
 
     return (


### PR DESCRIPTION
## Summary

Follow-up to #158 (opaque public IDs in URLs). Several player-profile links were still **hardcoded** as `/jugadores/{numeric id}` rather than going through the Wayfinder route helper, so they weren't caught by that PR's route-helper migration. After `users.show` switched to `public_id` binding, those links 404'd — e.g. clicking a member in a team's roster.

## Fixes

**Frontend — links now resolve via `public_id`:**
- `UserNameLink` — the shared component used for the team roster, opposing-leaders card, and lineup rows → `users.show(user).url`
- User menu (`user-menu-content`) → `users.show(user).url`
- Match lineups (`match-lineups`) → `users.show(player.user).url`
- Profile breadcrumb (`users/show`) → `/jugadores/${user.public_id}`

**Backend — serialize `public_id` on the users feeding those links:**
- Match lineup eager loads were column-restricted to `id,name` → now `id,public_id,name`
- Opposing-leaders array now includes `public_id`
- (Team-member users already load full columns, so the roster was fixed just by the `UserNameLink` change.)

**Types:** added `public_id` to `MatchPageUser`, `OpposingTeamLeader.user`, and the local `User` interface in `lineup.tsx`.

## Testing
- ✅ `bun run types` clean
- ✅ 86 match/team feature tests pass
- ✅ Pint + Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)