### PR TITLE
fix: prevent profile-link crash from missing public_id

### DIFF
--- a/app/Http/Controllers/MatchController.php
+++ b/app/Http/Controllers/MatchController.php
@@ -284,6 +284,7 @@ final class MatchController extends Controller
                 'updated_at' => $availability->updated_at,
                 'user' => $availability->user ? [
                     'id' => $availability->user->id,
+                    'public_id' => $availability->user->public_id,
                     'name' => $availability->user->name,
                     'avatar_url' => $availability->user->avatar_url,
                 ] : null,

--- a/app/Http/Controllers/ProfileCommentController.php
+++ b/app/Http/Controllers/ProfileCommentController.php
@@ -19,7 +19,7 @@ class ProfileCommentController extends Controller
     public function index(User $user): JsonResponse
     {
         $comments = ProfileComment::forProfile($user->id)
-            ->with('author:id,name,avatar_path,google_avatar_url')
+            ->with('author:id,public_id,name,avatar_path,google_avatar_url')
             ->paginate(20);
 
         return response()->json($comments);
@@ -53,7 +53,7 @@ class ProfileCommentController extends Controller
         ]);
 
         // Load author relationship
-        $comment->load('author:id,name,avatar_path,google_avatar_url');
+        $comment->load('author:id,public_id,name,avatar_path,google_avatar_url');
 
         // Send notification to profile owner
         $user->notify(new ProfileCommentNotification($authUser, $comment));

--- a/resources/js/components/user-name-link.tsx
+++ b/resources/js/components/user-name-link.tsx
@@ -9,6 +9,12 @@ interface UserNameLinkProps {
 }
 
 export function UserNameLink({ user, className }: UserNameLinkProps) {
+    // Fall back to plain text if the profile identifier is missing, so a single
+    // under-serialized user can never crash the whole page.
+    if (!user?.public_id) {
+        return <span className={className}>{user?.name}</span>;
+    }
+
     return (
         <Link
             href={users.show(user).url}


### PR DESCRIPTION
## Summary

Follow-up to #159. After profile links were routed through the `users.show()` Wayfinder helper, the page would render for a moment and then crash with:

```
Uncaught TypeError: can't access property "toString", n.user is undefined
```

**Cause:** `users.show(user)` throws when `user.public_id` is `undefined` (it calls `.toString()` on the missing route param). The old `/jugadores/${user.id}` interpolation failed silently; the helper fails hard. Any `UserNameLink` whose user was serialized without `public_id` white-screened the whole app right after render.

Two data sources were still under-serializing the linked user:
- **Comment authors** on the profile page (loaded async → the "half a second, then error") — `ProfileCommentController` eager-loaded `author:id,name,...` without `public_id`.
- **Match availability roster** — the availability user payload omitted `public_id`.

## Fixes
- `ProfileCommentController`: include `public_id` in the author eager load (both index + store).
- `MatchController`: include `public_id` in the availability roster user payload.
- `UserNameLink`: fall back to plain text when `public_id` is missing, so a single under-serialized user can never crash the whole page again (defense in depth).

## Testing
- ✅ `bun run types` clean
- ✅ 60 comment/availability/commendation tests pass
- ✅ Pint + Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)