### PR TITLE
fix: route remaining resource links through public_id

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -19,7 +19,7 @@ class UserController extends Controller
     {
         // Load active teams with eager loading
         $user->load(['activeTeams' => function ($query) {
-            $query->select('teams.id', 'teams.name', 'teams.variant', 'teams.logo_url', 'teams.logo_path')
+            $query->select('teams.id', 'teams.public_id', 'teams.name', 'teams.variant', 'teams.logo_url', 'teams.logo_path')
                 ->orderBy('teams.name');
         }]);
 
@@ -51,7 +51,7 @@ class UserController extends Controller
     {
         // Load active teams with eager loading
         $user->load(['activeTeams' => function ($query) {
-            $query->select('teams.id', 'teams.name', 'teams.variant', 'teams.logo_url')
+            $query->select('teams.id', 'teams.public_id', 'teams.name', 'teams.variant', 'teams.logo_url')
                 ->orderBy('teams.name');
         }]);
 

--- a/resources/js/components/match/match-hero.tsx
+++ b/resources/js/components/match/match-hero.tsx
@@ -180,7 +180,7 @@ export function MatchHero({
                         <div className="grid grid-cols-1 items-center gap-5 md:grid-cols-[1fr_auto_1fr] md:gap-6">
                             {/* Home team (local) — name outer, crest inner */}
                             <Link
-                                href={`/teams/${match.home_team.id}`}
+                                href={`/teams/${match.home_team.public_id}`}
                                 className="group flex items-center justify-center gap-3 rounded-xl p-2 transition-colors hover:bg-muted/50 md:justify-end md:gap-4"
                             >
                                 <div className="min-w-0 text-center md:text-right">
@@ -290,7 +290,7 @@ export function MatchHero({
                             {/* Away team (visitante) — crest inner, name outer */}
                             {match.away_team ? (
                                 <Link
-                                    href={`/teams/${match.away_team.id}`}
+                                    href={`/teams/${match.away_team.public_id}`}
                                     className="group flex items-center justify-center gap-3 rounded-xl p-2 transition-colors hover:bg-muted/50 md:justify-start md:gap-4"
                                 >
                                     <TeamAvatar

--- a/resources/js/components/match/types.ts
+++ b/resources/js/components/match/types.ts
@@ -11,6 +11,7 @@ export interface MatchPageUser {
 
 export interface MatchPageTeam {
     id: number;
+    public_id: string;
     name: string;
     variant: string;
     logo_url?: string;

--- a/resources/js/components/tournament/tournament-bracket.tsx
+++ b/resources/js/components/tournament/tournament-bracket.tsx
@@ -19,7 +19,9 @@ const BracketMatch = ({ match }: BracketMatchProps) => {
     const winnerId = isCompleted ? getWinnerId(match) : null;
 
     const MatchWrapper = match.id ? Link : 'div';
-    const wrapperProps = match.id ? { href: `/matches/${match.id}` } : {};
+    const wrapperProps = match.id
+        ? { href: `/matches/${match.public_id}` }
+        : {};
 
     return (
         <MatchWrapper {...wrapperProps} className={cn(match.id && 'block')}>

--- a/resources/js/pages/users/show.tsx
+++ b/resources/js/pages/users/show.tsx
@@ -289,7 +289,7 @@ export default function Show({
                                     {teams.map((team: Team) => (
                                         <Link
                                             key={team.id}
-                                            href={`/teams/${team.id}`}
+                                            href={`/teams/${team.public_id}`}
                                             className="group flex items-center gap-3 rounded-lg border bg-card p-3 transition-all hover:border-primary/50 hover:bg-accent/50 hover:shadow-md"
                                         >
                                             <TeamAvatar


### PR DESCRIPTION
## Summary

Follow-up to #158/#159/#160. A few resource links were still **hardcoded** as `/{resource}/{numeric id}` rather than using `public_id`, so they navigated to the old numeric URLs (which now 404). Notably the **team cards on a user's profile** pointed at `/teams/{id}`.

## Fixes
- **User profile** (`users/show`): team cards now link via `team.public_id`; `UserController` also adds `public_id` to the `activeTeams` eager load (both the page and the modal/API), so the id is actually serialized — otherwise the link would crash the same way the profile-comment links did.
- **Match hero** (`match-hero`): home/away team crests now link via `public_id`.
- **Tournament bracket** (`tournament-bracket`): match cells now link via `public_id`.
- Added `public_id` to the `MatchPageTeam` TS interface.

## Testing
- ✅ `bun run types` clean
- ✅ 261 tournament/match/team/profile tests pass (incl. `UserProfileTest`)
- ✅ Pint + Prettier clean

## Note
I did a full frontend sweep this time — there are now **no remaining** hardcoded `/teams`, `/matches`, `/tournaments`, or `/jugadores` links using `.id`, and no route-helper calls passing `.id`. This should be the last of the whack-a-mole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)