### PR TITLE
fix: show team matches to all active members, not just leaders

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -23,7 +23,7 @@ final class DashboardController extends Controller
     public function index(Request $request): Response
     {
         $user = Auth::user();
-        $teamIds = $user->teams()->pluck('teams.id')->toArray();
+        $teamIds = $user->activeTeams()->pluck('teams.id')->toArray();
         $hasTeams = count($teamIds) > 0;
 
         // Variants of the user's teams — used to surface relevant open matches.
@@ -32,7 +32,7 @@ final class DashboardController extends Controller
             : [];
 
         // User's teams with member count
-        $myTeams = $user->teams()
+        $myTeams = $user->activeTeams()
             ->withCount('teamMembers')
             ->limit(4)
             ->get(['teams.id', 'teams.name', 'teams.variant', 'teams.logo_url', 'teams.max_members']);

--- a/app/Services/MatchService.php
+++ b/app/Services/MatchService.php
@@ -549,10 +549,10 @@ final class MatchService
      */
     public function getUserMatches(int $userId): Collection
     {
-        // Get teams where user is a leader
+        // Get teams the user is an active member of, regardless of role — every
+        // member (players included) should see their team's matches in history.
         $teamIds = Team::whereHas('teamMembers', function ($query) use ($userId) {
             $query->where('user_id', $userId)
-                ->whereIn('role', ['captain', 'co_captain'])
                 ->where('status', 'active');
         })->pluck('id');
 

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\FootballMatch;
+use App\Models\Team;
+use App\Models\TeamMember;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->captain = User::factory()->create();
+    $this->team = Team::create([
+        'name' => 'Dashboard FC',
+        'variant' => 'football_11',
+        'created_by' => $this->captain->id,
+        'max_members' => 25,
+    ]);
+    TeamMember::create([
+        'user_id' => $this->captain->id,
+        'team_id' => $this->team->id,
+        'role' => 'captain',
+        'status' => 'active',
+    ]);
+});
+
+test('base-role player sees upcoming team matches on dashboard', function () {
+    $player = User::factory()->create();
+    TeamMember::create([
+        'user_id' => $player->id,
+        'team_id' => $this->team->id,
+        'role' => 'player',
+        'status' => 'active',
+    ]);
+
+    $match = FootballMatch::create([
+        'home_team_id' => $this->team->id,
+        'variant' => 'football_11',
+        'scheduled_at' => now()->addDays(3),
+        'location' => 'Test Field',
+        'status' => 'confirmed',
+        'created_by' => $this->captain->id,
+    ]);
+
+    $this->actingAs($player)
+        ->get(route('dashboard'))
+        ->assertInertia(fn ($page) => $page
+            ->component('dashboard')
+            ->where('hasTeams', true)
+            ->has('upcomingMatches', 1)
+            ->where('upcomingMatches.0.id', $match->id)
+        );
+});
+
+test('dashboard ignores non-active memberships', function () {
+    $inactiveTeam = Team::create([
+        'name' => 'Former FC',
+        'variant' => 'football_11',
+        'created_by' => $this->captain->id,
+        'max_members' => 25,
+    ]);
+    $formerPlayer = User::factory()->create();
+    TeamMember::create([
+        'user_id' => $formerPlayer->id,
+        'team_id' => $inactiveTeam->id,
+        'role' => 'player',
+        'status' => 'inactive',
+    ]);
+
+    FootballMatch::create([
+        'home_team_id' => $inactiveTeam->id,
+        'variant' => 'football_11',
+        'scheduled_at' => now()->addDays(3),
+        'location' => 'Test Field',
+        'status' => 'confirmed',
+        'created_by' => $this->captain->id,
+    ]);
+
+    $this->actingAs($formerPlayer)
+        ->get(route('dashboard'))
+        ->assertInertia(fn ($page) => $page
+            ->component('dashboard')
+            ->where('hasTeams', false)
+            ->has('upcomingMatches', 0)
+            ->has('myTeams', 0)
+        );
+});

--- a/tests/Feature/MatchTest.php
+++ b/tests/Feature/MatchTest.php
@@ -118,6 +118,26 @@ test('authenticated user can view matches index', function () {
         ->assertSuccessful();
 });
 
+test('base-role player sees their team matches in history', function () {
+    $player = User::factory()->create();
+    TeamMember::create([
+        'user_id' => $player->id,
+        'team_id' => $this->homeTeam->id,
+        'role' => 'player',
+        'status' => 'active',
+    ]);
+
+    $match = createMatch();
+
+    $this->actingAs($player)
+        ->get(route('matches.index'))
+        ->assertInertia(fn ($page) => $page
+            ->component('matches/index')
+            ->has('myMatches', 1)
+            ->where('myMatches.0.id', $match->id)
+        );
+});
+
 test('team leader can view the create match form', function () {
     $this->actingAs($this->homeCaptain)
         ->get(route('matches.create'))


### PR DESCRIPTION
## Problem

Base-role **players** could not see their team's matches in the matches-history page (`/matches`), while captains and co-captains could.

## Cause

`MatchService::getUserMatches()` built the "My Matches" list from teams where the user was a `captain` or `co_captain` only — the `player` role was filtered out, so those users always got an empty list.

## Fix

- **`MatchService::getUserMatches()`** — scope the team lookup to active membership regardless of role, matching `Team::hasMember()` semantics. Match management (create/edit/score) stays leader-gated by the separate checks in `MatchController`, so this is display-only.
- **`DashboardController::index()`** — derive teams from `activeTeams()` instead of `teams()`, so stale/`inactive` memberships no longer surface matches, tournaments, or team cards on the dashboard. (The upcoming-matches widget was already role-agnostic; this only tightens the active-status filter.)

## Tests

- `MatchTest`: base-role player sees their team's matches in history.
- `DashboardTest` (new): base-role player sees upcoming team matches; inactive memberships are ignored.

All match/dashboard/team suites pass (89 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)